### PR TITLE
adding a dummy ndm controller.

### DIFF
--- a/cmd/app/command/commands.go
+++ b/cmd/app/command/commands.go
@@ -39,6 +39,7 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 	flag.CommandLine.Parse([]string{})
 	cmd.AddCommand(
 		NewCmdBlockDevice(), //Add new command on block device
+		NewCmdStart(), //Add new command to start the ndm controller
 	)
 
 	return cmd, nil

--- a/cmd/app/command/start.go
+++ b/cmd/app/command/start.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+import (
+	goflag "flag"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	"github.com/spf13/cobra"
+)
+
+//NewCmdStart starts the ndm controller
+func NewCmdStart() *cobra.Command {
+	//var target string
+	getCmd := &cobra.Command{
+		Use:   "start",
+		Short: "Node disk controller",
+		Long: ` watches for ndm custom resources via "ndmctl start" command `,
+		Run: func(cmd *cobra.Command, args []string) {
+			controller.Watch()
+		},
+	}
+
+	// Bind & parse flags defined by external projects.
+	// e.g. This imports the golang/glog pkg flags into the cmd flagset
+	getCmd.Flags().AddGoFlagSet(goflag.CommandLine)
+	goflag.CommandLine.Parse([]string{})
+
+	return getCmd
+}

--- a/cmd/controller/ctrl_main.go
+++ b/cmd/controller/ctrl_main.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/golang/glog"
+)
+
+// Run will wait for SIGINT signal and exit if received
+func Run(stopCh <-chan os.Signal) error {
+	glog.Info("Started controller")
+
+	<-stopCh
+
+	glog.Info("Shutting down controller")
+
+	return nil
+}
+
+func Watch() {
+	// set up signals so we handle the first shutdown signal gracefully
+	sigCh := make(chan os.Signal, 1)
+
+	signal.Notify(sigCh, syscall.SIGINT)
+
+	if err := Run(sigCh); err != nil {
+		glog.Fatalf("Error running controller: %s", err.Error())
+	}
+}


### PR DESCRIPTION
This daemon will wait for SIGINT signal and if ctrl + c is pressed, the watcher will exit.

```
$ ndmctl -h
ndmctl controls the Node-Disk-Manager

Usage:
  ndmctl [flags]
  ndmctl [command]

Available Commands:
  device      Operations on block devices
  help        Help about any command
  start       Node disk controller

Flags:
      --alsologtostderr                  log to standard error as well as files
  -h, --help                             help for ndmctl
      --log-flush-frequency duration     Maximum number of seconds between log flushes (default 5s)
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files (default true)
      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "ndmctl [command] --help" for more information about a command.

```


```
$ ndmctl start
I0320 14:43:12.209537   31105 ctrl_main.go:29] Started controller
^CI0320 14:43:14.280312   31105 ctrl_main.go:33] Shutting down controller
```
