### PR TITLE
Sample YAML for running node-disk-manager as k8s DaemonSet.

### DIFF
--- a/node-disk-manager.yaml
+++ b/node-disk-manager.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-disk-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-disk-manager
+    spec:
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes 
+      # that have storage attached, you could label those node and use nodeSelector.
+      # Example: Label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+      containers:
+      - name: node-disk-manager
+        command:
+        - /usr/sbin/ndm
+        - start
+        image: openebs/node-disk-manager:latest
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: device
+          mountPath: /host/dev
+          mountPropagation: Bidirectional
+        - name: mount
+          mountPath: /host/mnt
+          mountPropagation: Bidirectional
+      volumes:
+      - name: device
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: mount
+        hostPath:
+          path: /mnt
+          type: Directory
+


### PR DESCRIPTION
Fixes #7 

Made the following assumptions:
- A docker image will be available with latest tag at openebs/node-disk-manager:latest
- The ndm binary will be included in the docker image at /usr/sbin. 
- `ndm start` will start the node-disk-manager service. 
- Kubernetes Clusters will have the MountPropagation feature enabled

Tested in minikube using the following steps:
- Made docker image with `make`.
- Ran minikube with this command: `sudo minikube start --vm-driver=none --feature-gates=MountPropagation=true`
- In YAML changed value of `image` to match with newly built image and `imagePullPolicy` to `IfNotPresent`.
- Applied the YAML
- Checked pod description and log.
- Ran `lsblk` and `ndm` in both inside and outside the pod and match the results.
- Attached Pen Drive, then see if it is visible on the host and inside the pod
- Did mount and unmount operation from within pod and check that it is reflected on the host. 


Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>