### PR TITLE
add integration test framework for node-disk-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,18 @@ header:
 	@echo "----------------------------"
 	@echo
 
+install-e2e-deps:
+	# Assumption: User of this file is a Super user
+	# Assumption: `apt` is present in system
+	# Assumption: `python` is present in system
+	apt install python-pip
+	pip install --upgrade pip
+	pip install pyYAML
+	pip install kubernetes
+
+e2e: install-e2e-deps
+	python test.py
+
 ndm:
 	@echo '--> Building binary...'
 	@CTLNAME=${NODE_DISK_MANAGER} sh -c "'$(PWD)/hack/build.sh'"

--- a/e2e/e2e_test.py
+++ b/e2e/e2e_test.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python
+
+"""This module is written to perform end-to-end test for openebs/node-disk-manager"""
+
+# Initialization
+print 'Initializing...'
+import subprocess
+
+from os.path import isfile
+from os import remove as removefile
+
+from json import loads as load_json_str
+from time import sleep
+from kubernetes.client.rest import ApiException as K8SApiException
+
+import minikube_adm
+
+import ndm_util
+from ndm_util import NDM_TEST_YAML_NAME, NDM_TEST_YAML_PATH
+
+import k8s_util
+from k8s_util import POD_WAIT_STATES, POD_GOOD_STATES, POD_GOOD_PHASES, POD_BAD_PHASES
+
+def start_minikube(max_try=1, wait_for_sec=1):
+    """
+    This method starts the minikube with `--vm-driver=none` and
+    `--feature-gates=MountPropagation=true` options.
+
+    :param int max_try: maximum number of tries to be make in order to start minikube.
+                        (default to 1) (minimum value 1)
+    :param int wait_for_sec: ammount of time in seconds to wait where needed.
+                             (default to 1) (minimum value 0)
+    """
+
+    # Ensuring minimum value for the arguments
+
+    # Making sure that it tries at least once to start minikube
+    max_try = max(1, max_try)
+    wait_for_sec = max(0, wait_for_sec)
+
+    while True:
+        print 'Starting minikube...'
+        print
+        minikube_adm.setup()
+        # Wait for at least 2 sec
+        sleep(max(2, wait_for_sec))
+
+        i = 0
+        while i < max_try:
+            try:
+                status = minikube_adm.check_status()
+                break
+            except Exception as err:
+                print 'Error occured while getting status. Error:', str(err)
+                sleep(wait_for_sec)
+            finally:
+                i += 1
+        else:
+            print '[ERROR] Failed to get minikube status.'
+            exit(2)
+        print 'Minikube status:', status['minikube']
+        print 'Cluster status:', status['cluster']
+        print 'kubectl status:', status['kubectl']
+        if status['minikube'] != 'Running':
+            print 'Deleting minikube...'
+            minikube_adm.teardown()
+        else:
+            break
+
+def apply_ndm_yaml(max_try=1, wait_for_sec=1):
+    """
+    This method applies the yaml prepared to test.
+
+    :param int max_try: maximum number of tries to be make for applying configuration.
+                        (default to 1) (minimum value 1)
+    :param int wait_for_sec: ammount of time in seconds to wait where needed.
+                             (default to 1) (minimum value 0)
+    """
+    # Ensuring minimum value for the arguments
+
+    # Making sure that it tries at least once to apply the YAML
+    max_try = max(1, max_try)
+    wait_for_sec = max(0, wait_for_sec)
+
+    i = 0
+    while i < max_try:
+        try:
+            ndm_util.yaml_apply()
+            break
+        except Exception as err:
+            print 'Error while applying YAML. Error:', str(err)
+            sleep(wait_for_sec)
+        finally:
+            i += 1
+    else:
+        print '[ERROR] Error getting log.'
+        exit(3)
+
+def wait_till_ndm_is_up(max_try=0, wait_for_sec=1):
+    """
+    This method busy waits until the pod is up or number of try exceeds max_try.
+    Each try is make after waiting for wait_for_sec number of seconds.
+
+    :param int max_try: maximum number of tries to be make to check if NDM-Pod is up.
+                        (default to 1) (minimum value 1)
+    :param int wait_for_sec: ammount of time in seconds to wait after each try.
+                             (default to 1) (minimum value 0)
+    """
+
+    # Ensuring minimum value for the arguments
+
+    # Making sure that it tries at least once to apply the YAML
+    max_try = max(1, max_try)
+    wait_for_sec = max(0, wait_for_sec)
+
+    i = 0
+    while i < max_try:
+        try:
+            ndm_pod = k8s_util.get_ndm_pod()
+            ndm_pod_state = k8s_util.get_container_state_in_ndm_pod()
+            if ndm_pod_state.terminated is not None:
+                print 'Pod terminated unexpectedly.'
+                exit(4)
+            elif ndm_pod_state.waiting is not None:
+                if ndm_pod_state.waiting.reason in POD_WAIT_STATES:
+                    print 'Waiting as pod-state:', ndm_pod_state.waiting.reason
+                    sleep(wait_for_sec)
+                elif ndm_pod_state.waiting.reason not in POD_GOOD_STATES:
+                    print 'Pod is in bad state:', ndm_pod_state.waiting.reason,\
+                        'message:', ndm_pod_state.waiting.message
+                    exit(4)
+            elif ndm_pod_state.running is None:
+                # At this point all states are None,
+                # so just showing phase is enough
+                print 'Waiting as pod-phase:', k8s_util.get_pod_phase(ndm_pod)
+                sleep(wait_for_sec)
+            else:
+                break
+        except K8SApiException as err:
+            if err.status == 404:
+                print 'Status code: 404 while connecting to REST API.'
+                sleep(wait_for_sec)
+            else:
+                print 'K8SApiException occured',\
+                    'while checking if Pod is up. Error:', str(err)
+                raise err
+        except Exception as err:
+            print 'Error occured while checking if Pod is up. Error:', str(err)
+            raise err
+        finally:
+            i += 1
+    print 'Pod is up.'
+
+def validate_log(max_try=0, wait_for_sec=1):
+    """
+    This method validates node-disk-manager log.
+
+    :param int max_try: maximum number of tries to extract log of node-disk-manager.
+                        (default to 1) (minimum value 1)
+    :param int wait_for_sec: ammount of time in seconds to wait after each try.
+                             (default to 1) (minimum value 0)
+    """
+
+    # Ensuring minimum value for the arguments
+
+    # Making sure that it tries at least once to apply the YAML
+    max_try = max(1, max_try)
+    wait_for_sec = max(0, wait_for_sec)
+
+    ndm_pod = k8s_util.get_ndm_pod()
+    if ndm_pod.status.phase in POD_GOOD_PHASES:
+        # Try to get logs for max_try times
+        i = 0
+        while i < max_try:
+            try:
+                ndm_log = k8s_util.get_log(ndm_pod.metadata.name, 'default')
+                break
+            except K8SApiException as err:
+                print 'Error occured while connecting to REST API. Error:',\
+                    str(err)
+                sleep(wait_for_sec)
+            finally:
+                i += 1
+        else:
+            print '[ERROR] Error getting log.'
+            exit(5)
+
+        print
+        print 'Validating log...'
+        if ndm_util.validate_ndm_log(ndm_log) is True:
+            print 'Log is OK.'
+    elif ndm_pod.status.phase in POD_BAD_PHASES:
+        print 'Pod is in bad phase:', ndm_pod.status.phase
+        exit(5)
+    else:
+        print "I am uncertain about pod's this phase:", ndm_pod.status.phase
+        exit(5)
+
+def validate_lsblk_output():
+    """This method validates lsblk output (inside and outside the pod)."""
+
+    ndm_pod = k8s_util.get_ndm_pod()
+    try:
+        # exec_to_pod handles the scenario
+        # where we pass V1Pod object instead of str, so we handle V1Pod here
+        lsblk_in_pod = k8s_util.exec_to_pod(['lsblk', '-J'], ndm_pod)
+        # string returned from above is not a valid json.
+        # Some values converted to python equivalent like 'null' become 'None'
+
+        # So, need to revert those changes before parsing through library
+        lsblk_in_pod = load_json_str(lsblk_in_pod.replace("u'", '"')\
+                                  .replace("'", '"').replace('None', 'null'))
+
+        try:
+            lsblk_in_host = subprocess.check_output(['lsblk', '-J'])
+            lsblk_in_host = load_json_str(lsblk_in_host.replace("u'", '"')\
+                                       .replace("'", '"')\
+                                       .replace('None', 'null'))
+
+            if ndm_util.match_lsblk_output(lsblk_in_host, lsblk_in_pod):
+                print 'lsblk output OK.'
+            else:
+                print 'lsblk output mismatch.'
+                exit(6)
+        except Exception as err:
+            print 'Error executing `lsblk` in host. Error:', str(err)
+            exit(6)
+    except Exception as err:
+        print 'Error executing `lsblk` inside pod. Error:', str(err)
+        exit(6)
+
+def validate_ndm_output():
+    """This method validates lsblk output (inside and outside the pod)."""
+    ndm_pod = k8s_util.get_ndm_pod()
+    try:
+        ndm_in_pod = k8s_util.exec_to_pod(['ndm', 'device', 'list'], ndm_pod)
+
+        try:
+            ndm_in_host = subprocess.check_output(['../bin/amd64/ndm',
+                                                   'device', 'list'])
+
+            print 'In Pod:', ndm_in_pod
+            print 'In Host:', ndm_in_host
+
+            if ndm_util.match_ndm_output(ndm_in_host, ndm_in_pod):
+                print 'ndm output OK.'
+            else:
+                print 'ndm output mismatch.'
+                exit(7)
+
+        except Exception as err:
+            print 'Error executing `ndm` in host. Error:', str(err)
+            exit(7)
+    except Exception as err:
+        print 'Error executing `ndm` inside pod. Error:', str(err)
+        exit(7)
+
+def clean():
+    """
+    This method is intended to clean the residue of the testing.
+    It should be run at the very end of the test.
+    CAUTION: it calls `minikube_adm.clear_containers`
+    which removes all Docker Containers in your machine.
+    """
+
+    # Check minikube status and delete if minikube is running
+    print 'Checking minikube status...'
+    try:
+        status = minikube_adm.check_status()
+        if status['minikube'] == "Running" or status['minikube'] == "Stopped":
+            print 'Deleting minikube...'
+            try:
+                minikube_adm.teardown()
+            except Exception as err:
+                print str(err)
+        else:
+            print 'Machine not present.'
+    except Exception as err:
+        print str(err)
+
+    # Remove all docker containers
+    print
+    print 'Removing docker containers...'
+    try:
+        minikube_adm.clear_containers()
+    except Exception as err:
+        print str(err)
+
+    print
+    print 'Removing', NDM_TEST_YAML_NAME, '...'
+    if isfile(NDM_TEST_YAML_PATH+NDM_TEST_YAML_NAME):
+        removefile(NDM_TEST_YAML_PATH+NDM_TEST_YAML_NAME)
+        print 'Removed.'
+    else:
+        print 'Not present.'
+
+if __name__ == '__main__':
+    # Step: 1 (Commenting it out for now)
+    # print 'Making Project...'
+    # print
+    # make()
+
+    # Step: 2
+    print
+    print 'Preparing', NDM_TEST_YAML_NAME, '...'
+    ndm_util.yaml_prepare()
+
+    # Step: 3
+    print
+    start_minikube(max_try=5, wait_for_sec=1)
+
+    # Step: 4
+    print
+    print 'Applying the prepared YAML...'
+    print
+    apply_ndm_yaml(max_try=5, wait_for_sec=1)
+
+    # Step: 4.5
+    print
+    print 'Checking if NDM Pod is up...'
+    wait_till_ndm_is_up(max_try=120, wait_for_sec=1)
+
+    # Step: 5
+    validate_log()
+
+    # Step: 6-1
+    print
+    print 'Validating lsblk output...'
+    validate_lsblk_output()
+
+    # Step: 6-2
+    print
+    print 'Validating ndm output...'
+    validate_ndm_output()
+
+    print 'Success.'
+
+    # print
+    # print 'Cleaning...'
+    # clean()
+    # print 'Done Cleaning.'

--- a/e2e/k8s_util.py
+++ b/e2e/k8s_util.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+
+"""This module provides methods to administrate k8s tailered for our use-cases."""
+
+import subprocess
+
+from time import sleep
+from os import popen as os_popen
+
+# Assumption: kubernetes python client is installed
+from kubernetes import client, config
+from kubernetes.client import Configuration
+from kubernetes.client.apis import core_v1_api
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream
+from kubernetes.client.models.v1_pod import V1Pod
+
+import ndm_util
+
+# Different phases of Pod
+POD_WAIT_PHASES = ['Pending']
+POD_GOOD_PHASES = ['Running']
+POD_BAD_PHASES = ['Error']
+
+# Different states of Pod
+POD_WAIT_STATES = ['ContainerCreating', 'Pending']
+POD_GOOD_STATES = ['Running']
+POD_BAD_STATES = ['CrashLoopBackOff', 'ImagePullBackOff']
+
+def get_ndm_pod():
+    """
+    This method returns Pod object of node-disk-manager.
+
+    :return: kubernetes.client.models.v1_pod.V1Pod: node-disk-manager Pod object.
+    """
+    config.load_kube_config()
+    api_client = client.CoreV1Api()
+
+    # Try to get node-disk-manager for 5 times as sometime code reaches
+    # when pod is not even in ContainerCreating state
+    i = 0
+    ndm_pod = None
+    while ndm_pod is None and i < 5:
+        sleep(1)
+
+        # List pods
+        # Assumption: NDM pod runs under 'dafault' namespace.
+        pods = api_client.list_namespaced_pod('default')
+
+        # Find NDM Pod
+        for pod in pods.items:
+            #Assumption: Pod name starts with string 'node-disk-manager'.
+            if pod.metadata.name.startswith('node-disk-manager'):
+                ndm_pod = pod
+                break
+        i += 1
+    if ndm_pod is None:
+        print 'Failed getting NDM-Pod.'
+        exit(1)
+
+    return ndm_pod
+
+def get_pod_phase(pod):
+    """
+    This method returns phase of the pod passed.
+
+    :param kubernetes.client.models.v1_pod.V1Pod pod: pod object for which
+                                                      you want to get phase. (required)
+    :return: str: phase of the pod.
+    """
+    return pod.status.phase
+
+def get_container_state_in_ndm_pod(container_index=0, wait_for_sec=10):
+    """
+    This method returns the state of the container of supplied index.
+
+    :param container_index: index of the container for which you want state. (default is 0)
+    :param wait_for_sec: maximum time to get the container's state in seconds.
+                         This method does not very strictly obey this param. (default to 10)
+    :return: str: state of the container.
+    """
+    waited = 0
+    pod = get_ndm_pod()
+    while pod.status.container_statuses is None and waited < wait_for_sec:
+        sleep(1)
+        waited += 1
+        pod = get_ndm_pod()
+    if not waited < wait_for_sec:
+        raise ndm_util.NDMTestException('Pod had no container till '\
+                               + str(wait_for_sec) + ' seconds.')
+
+    while len(pod.status.container_statuses) <= container_index\
+            and waited < wait_for_sec:
+        sleep(1)
+        waited += 1
+        pod = get_ndm_pod()
+    if not waited < wait_for_sec:
+        raise ndm_util.NDMTestException('Pod did not had ' + str(container_index+1)\
+                               + ' containers till ' + str(wait_for_sec)\
+                               + ' seconds.')
+
+    return pod.status.container_statuses[container_index].state
+
+def get_node_names():
+    """
+    This method returns a list of the name of all the nodes.
+
+    :return: list: list of node names (list of str).
+    """
+    config.load_kube_config()
+    api_client = client.CoreV1Api()
+
+    # Assumption: Cluster has only one node. (which is true for minikube).
+    return [node.metadata.name for node in api_client.list_node().items]
+
+def label_node(node_name, key, value):
+    """
+    This method label the node with the given key and value.
+
+    :param srt node_name: Name of the node. (required)
+    :param str key: Key of the label. (required)
+    :param str value: Value of the label. (required)
+    :return: kubernetes.client.models.v1_node.V1Node: Node which is labeled.
+    """
+    config.load_kube_config()
+    api_client = client.CoreV1Api()
+    body = {
+        "metadata": {
+            "labels": {
+                key: value
+            }
+        }
+    }
+    return api_client.patch_node(node_name, body)
+
+def exec_to_pod(command, pod_name, namespace='default'):
+    """
+    This method uninterractively exec to the pod with the command specified.
+
+    :param list command: list of the str which specify the command. (required)
+    :param str/kubernetes.client.models.v1_pod.V1Pod pod_name: Pod name
+                                           or V1Pod obj of the pod. (required)
+    :param str namespace: namespace of the Pod. (default to 'default')
+    :return: str: Output of the command.
+    """
+    config.load_kube_config()
+
+    # If someone send kubernetes.client.models.v1_pod.V1Pod object in pod_name
+    if isinstance(pod_name, V1Pod):
+        pod_name = pod_name.metadata.name
+
+    # config.load_kube_config()
+    conf = Configuration()
+    assert_hostname = conf.assert_hostname
+    conf.assert_hostname = False
+    Configuration.set_default(conf)
+    api = core_v1_api.CoreV1Api()
+
+    try:
+        result = stream(api.connect_get_namespaced_pod_exec, pod_name,\
+                        namespace, command=command,\
+                        stderr=True, stdin=False, stdout=True, tty=False)
+    except ApiException as err:
+        print 'Execing to NDM-Pod using kubernetes API failed:', str(err)
+        try:
+            result = subprocess.check_output(['kubectl', 'exec',
+                                              '-n', namespace, pod_name]
+                                             + ['--'] + command)
+        except subprocess.CalledProcessError as err:
+            print 'Subprocess error occured',\
+                    'while executing command on pod:', err.returncode
+        except Exception as err:
+            print 'An error occured while executing command on pod:',\
+                    str(err)
+
+            try:
+                result = os_popen('kubectl exec -n ' + namespace\
+                                  + ' ' + pod_name + ' -- '\
+                                  + ' '.join(command)).read()
+            except Exception as err:
+                raise err
+    finally:
+        # Undoing the previous changes to configuration
+        conf.assert_hostname = assert_hostname
+        Configuration.set_default(conf)
+
+    return result
+
+def get_log(pod_name, namespace):
+    """
+    This method returns the log of the pod.
+
+    :param str pod_name: Name of the pod. (required)
+    :param str namespace: Namespace of the pod. (required)
+    :return: str: Log of the pod specified.
+    """
+    config.load_kube_config()
+    api_client = client.CoreV1Api()
+    return api_client.read_namespaced_pod_log(pod_name, namespace)

--- a/e2e/minikube_adm.py
+++ b/e2e/minikube_adm.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+"""This module provides methods used for minikube administration."""
+
+import subprocess
+
+def setup():
+    """
+    This method starts minikube with `--vm-driver=none` and
+    `--feature-gates=MountPropagation=true` options.
+    """
+    # Start minikube
+    # Assumption: This function's caller should be a Super user.
+    try:
+        subprocess.check_call(["minikube", "start", "--vm-driver=none",
+                               "--feature-gates=MountPropagation=true"])
+    except subprocess.CalledProcessError as err:
+        print 'Subprocess error occured while starting minikube:',\
+            err.returncode
+        raise err
+    except Exception as err:
+        print 'Unknown error occured while starting minikube.'
+        raise err
+
+    # Run the commands required when run minikube as --vm-driver=none
+    # Assumption: Environment variables `USER` and `HOME` is well defined.
+    commands = [
+        "mv /root/.kube $HOME/.kube",
+        "chown -R $USER $HOME/.kube",
+        "chgrp -R $USER $HOME/.kube",
+        "mv /root/.minikube $HOME/.minikube",
+        "chown -R $USER $HOME/.minikube",
+        "chgrp -R $USER $HOME/.minikube"
+    ]
+
+    for command in commands:
+        print 'Running', command
+        returncode = subprocess.call(command.split())
+        print 'Return code:', returncode
+        print
+
+def check_status():
+    """
+    This method checks minikube status and parse it to a dict.
+
+    :return: dict: minikube status parsed into dict.
+    """
+    # Caller of this function should have proper rights
+    # to check minikube status
+    try:
+        status_str = subprocess.check_output(["minikube", "status"]).strip()
+    except subprocess.CalledProcessError as err:
+        print 'Subprocess error occured while checking minikube status:',\
+            err.returncode
+        raise err
+    except Exception as err:
+        print 'Unknown error occured while checking minikube status.'
+        raise err
+
+    status = {}
+    for line in status_str.split('\n'):
+        key, val = line.split(':', 1)
+        status[key.strip()] = val.strip()
+    return status
+
+def teardown():
+    """This method deletes minikube."""
+    # Caller of this function should have proper rights to delete minikube
+    try:
+        subprocess.check_output(["minikube", "delete"])
+    except subprocess.CalledProcessError as err:
+        print 'Subprocess error occured while deleting minikube:',\
+            err.returncode
+        raise err
+    except Exception as err:
+        print 'Unknown error occured while deleting minikube.'
+        raise err
+
+def clear_containers():
+    """This method removes all the docker containers present on the machine."""
+    # CAUTION: This function call deletes all docker containers
+    try:
+        containers = subprocess.check_output(['docker', 'ps', '-aq'])
+        if containers != '':
+            containers = containers.split()
+            for container in containers:
+                try:
+                    subprocess.check_call(['docker', 'rm', '-f', container])
+                except subprocess.CalledProcessError as err:
+                    print 'Subprocess error occured',\
+                        'while deleting docker containers:', err.returncode
+                    raise err
+                except Exception as err:
+                    print 'Unknown error occured',\
+                        'while deleting docker containers.'
+                    raise err
+    except Exception as err:
+        raise err

--- a/e2e/ndm_util.py
+++ b/e2e/ndm_util.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+
+"""This module provides node-disk-manager specific general tools."""
+
+import subprocess
+
+from re import compile as regex_compile
+
+import yaml # Assumption: PyYAML is installed
+
+NDM_YAML_PATH = '../'
+NDM_YAML = 'node-disk-manager.yaml'
+NDM_TEST_YAML_PATH = '/tmp/'
+NDM_TEST_YAML_NAME = 'NDM_Test_'+NDM_YAML
+DOCKER_IMAGE_NAME = 'openebs/node-disk-manager'
+try:
+    DOCKER_IMAGE_TAG = subprocess.check_output(["git",
+                                                "rev-parse",
+                                                "--abbrev-ref",
+                                                "HEAD"]).strip()
+except subprocess.CalledProcessError as err:
+    print 'Subprocess error occured while getting HEAD name:', err.returncode
+    raise err
+except Exception as err:
+    print 'Unknown error occured while getting HEAD name.'
+    raise err
+
+class NDMTestException(Exception):
+    """This is NDM test specific Exception"""
+    pass
+
+# TODO: Check the pod current status like we do in `kubectl describe`
+# Example: Check if all volumes are mounted correctly
+# def validateNDMPod(ndm_pod):
+
+def validate_ndm_log(log):
+    """
+    This method checks the supplied log and checks for any error in the log.
+
+    :param str log: log of node-disk-manager-xxx Pod (required)
+    :return: bool: True if log contains no error otherwise return False.
+    """
+
+    # Definition of this function should grow as program grows
+    if 'Started controller' in log:
+        return True
+    return False
+
+def yaml_prepare():
+    """
+    This method reads and parse the configuration file and changes some fields
+    so that it can be applied to create node-disk-manager daemonset from recently built image.
+    Then it saves that configuration to temp directory which will be cleaned by calling clean()
+    """
+
+    # Prepare the yaml
+    with open(NDM_YAML_PATH+NDM_YAML) as f_ndm_yaml:
+        ndm_yaml = yaml.load(f_ndm_yaml)
+
+    # Assumption: In following two statements it is assumed that
+    # this pod has only one container
+
+    # Set image name
+    ndm_yaml['spec']['template']['spec']['containers'][0]['image']\
+        = DOCKER_IMAGE_NAME + ":" + DOCKER_IMAGE_TAG
+
+    # set imagePullPolicy
+    ndm_yaml['spec']['template']['spec']['containers'][0]['imagePullPolicy']\
+        = "IfNotPresent"
+
+    with open(NDM_TEST_YAML_PATH + NDM_TEST_YAML_NAME, 'w') as f_ndm_test_yaml:
+        yaml.dump(ndm_yaml, f_ndm_test_yaml)
+
+def yaml_apply():
+    """
+    This method apply the yaml prepared for NDM with yaml_prepare()
+    """
+    try:
+        subprocess.check_call(["kubectl", "apply", "-f",
+                               NDM_TEST_YAML_PATH + NDM_TEST_YAML_NAME])
+    except subprocess.CalledProcessError as err:
+        print 'Subprocess error occured while applying the prepared YAML:',\
+            err.returncode
+        raise err
+    except Exception as err:
+        print 'Unknown error occured while applying the prepared YAML.'
+        raise err
+
+def match_lsblk_output(host_op, pod_op):
+    """
+    This method takes `lsblk` command's output on host as well as inside pod,
+    then matches them.
+
+    :param dict host_op: output of `lsblk -J` on host parsed into a dictionary (required)
+    :param dict pod_op: output of `lsblk -J` inside node-disk-manager-xxx Pod
+                        parsed into a dictionary (required)
+    :return: bool: True if outputs are equivalent otherwise return False.
+    """
+
+    if set(host_op.keys()) != set(pod_op.keys()):
+        return False
+
+    for k in host_op.keys():
+        # Special Case for mountpoint
+        if k == 'mountpoint':
+            if host_op['mountpoint'] != pod_op['mountpoint']\
+                    and pod_op['mountpoint']\
+                    .replace('/etc/hosts/', '/')\
+                    .replace('/etc/hosts', '/')\
+                    != host_op['mountpoint']:
+                return False
+
+        # and if value is a list
+        elif isinstance(host_op[k], list)\
+            and isinstance(pod_op[k], list):
+            for i in xrange(len(host_op[k])):
+                # if element of this list will again be a JSON
+                if isinstance(host_op[k][i], dict)\
+                        and isinstance(pod_op[k][i], dict):
+                    if not match_lsblk_output(host_op[k][i],\
+                                          pod_op[k][i]):
+                        return False
+                # Or if it is other then JSON then just direct match
+                else:
+                    if host_op[k][i] != pod_op[k][i]:
+                        return False
+
+        # and for normal cases
+        else:
+            if host_op[k] != pod_op[k]:
+                return False
+
+    # If no negative cases matches then it is OK
+    return True
+
+def match_ndm_output(host_op, pod_op):
+    """
+    This method takes `ndm` binary's output on host as well as inside pod,
+    then matches them.
+
+    :param dict host_op: output of `ndm` on host parsed into a dictionary (required)
+    :param dict pod_op: output of `ndm` inside node-disk-manager-xxx Pod
+                        parsed into a dictionary (required)
+    :return: bool: True if outputs are equivalent otherwise return False.
+    """
+    # Before comparing it removes all characters (which are mostly spaces)
+    # except alphanumeric characters, . (Dot), / (Forward Slash),
+    # [ (Square bracket open) and ] (Square bracket close), then compares
+    # (where mountpoints is an exception as we mount '/' on '/etc/hosts')
+    pattern = regex_compile('[^a-zA-Z0-9./\[\]]')
+    return pattern.sub('', pod_op).replace('/etc/hosts/', '/')\
+        .replace('/etc/hosts', '/') == pattern.sub('', host_op)


### PR DESCRIPTION
NOT YET CHECKED WITH TRAVIS
PYTEST-BDD COMPATIBILITY IS NOT THERE YET

Fixes https://github.com/openebs/node-disk-manager/issues/30

**Actions:**
- Runs minikube with this command: `sudo minikube start --vm-driver=none --feature-gates=MountPropagation=true`.
- In YAML changes value of `image` to match with newly built image and `imagePullPolicy` to `IfNotPresent`.
- Apply the YAML.
- Check pod description and log.
- Runs `lsblk` and `ndm` in both inside and outside the pod and match the results.

Assumptions:
- User of this file is a Super user.
- `apt` is present in system.
- `python` is present in system.
- `e2e_test.py`, `k8s_util.py`, `minikube_adm.py` and `ndm_util.py` should be kept together.
- Yaml for NDM daemonset: 'node-disk-manager.yaml' in same directory where test files are.
- Docker image name: 'openebs/node-disk-manager'.
- Docker image tag is output of `git rev-parse --abbrev-ref HEAD`.
- If 'Started controller' is in log, log is considered OK.
- Runs under 'dafault' namespace.
- Pod name starts with string 'node-disk-manager'.
- This pod has only one container
- Environment variables `USER` and `HOME` is well defined.
- Cluster has only one node. (which is true for minikube).

Note:
- Calling `clear_containers` from `minikube_adm` or `clean` from `e2e_test` removes all the Docker Containers from the machine.

**`pylint` status:**

File | pylint rating | pylint exit code
--- | :---: | :---:
minikube_adm.py | 10.00/10 | 0
k8s_util.py | 9.89/10 | 4
e2e_test.py | 9.49/10 | 12
ndm_util.py | 9.48/10 | 4

<!-- To know what exit code means: Read [pylint doc](https://pylint.readthedocs.io/en/latest/user_guide/run.html#exit-codes). -->