### PR TITLE
unify disk resource name.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 cscope*
 tags
 *.swp
+*.swo
+Dockerfile

--- a/cmd/controller/ctrl.go
+++ b/cmd/controller/ctrl.go
@@ -59,13 +59,7 @@ func NewController(
 
 // getUid will return unique id for the disk block device
 func getUid(blk v1.Blockdevice) string {
-	uuid := NDMPrefix
-	if blk.Wwn != "" {
-		uuid += blk.Wwn
-	} else {
-		uuid += util.Hash(blk.Serial)
-	}
-	return uuid
+	return NDMPrefix + util.Hash(blk.Wwn+blk.Model+blk.Serial+blk.Vendor)
 }
 
 // Run will discover the local disks and push them to the etcd


### PR DESCRIPTION
NDM is having separate logic to create UUID for the disk resources
which does not have the Wwn number. This patch will unify them
and have same kind of name for all kinds of disk resources.

```
$  kubectl get disks
NAME                                    AGE
disk-60118c2e5b9fe3c33884765ea95db585   7m
disk-dd038c382a92a22f75910b4198d18db2   3s
```

Earlier it was
```
$ kubectl get disk
NAME                                    AGE
disk-0x500003949d304e06                 45s
disk-b3f828db7cd829ac237e90ccf433bd17   5s
```