### PR TITLE
populating the hostnames correctly for the Disk resources.

### DIFF
--- a/cmd/controller/ctrl_main.go
+++ b/cmd/controller/ctrl_main.go
@@ -55,8 +55,8 @@ func Watch(kuberconfig string) {
 		glog.Fatalf("Error building sp-spc clientset: %s", err.Error())
 	}
 
-	host, err := os.Hostname()
-	if err != nil {
+	host, ret := os.LookupEnv("NODE_NAME")
+	if ret != true {
 		glog.Fatalf("Error building sp-spc clientset: %s", err.Error())
 	}
 

--- a/node-disk-manager.yaml
+++ b/node-disk-manager.yaml
@@ -31,6 +31,11 @@ spec:
         - name: mount
           mountPath: /host/mnt
           mountPropagation: Bidirectional
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
       volumes:
       - name: device
         hostPath:


### PR DESCRIPTION
Pods will have hostname as pod name and some hash string
(e.g. node-disk-manager-29qw8) which changes with every pod
restart.

We are using system's hostname for populating the
disk resource in etcd. Disk resource should not use the hostname
of the pod for "kubernetes.io/hostname", it should be node's hostname,
which will tell us where the disk is attached to.

Here, we are passing the hostname as an environment to the Node-Disk-Manager
daemonset, which it will use to populate the disk resource in etcd.