### PR TITLE
Udev-event module integration with node-disk-manager to automatically update disk cr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ EXTERNAL_TOOLS=\
 	gopkg.in/alecthomas/gometalinter.v1
 
 vet:
+# composite flag ignores struct literals that do not use the field-keyed syntax.
+Flag: -composites
 	go list ./... | grep -v "./vendor/*" | xargs go vet
 
 fmt:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/openebs/node-disk-manager.svg?branch=master)](https://travis-ci.org/openebs/node-disk-manager)
 [![Go Report](https://goreportcard.com/badge/github.com/openebs/node-disk-manager)](https://goreportcard.com/report/github.com/openebs/node-disk-manager)
 [![codecov](https://codecov.io/gh/openebs/node-disk-manager/branch/master/graph/badge.svg)](https://codecov.io/gh/openebs/node-disk-manager)
+[![BCH compliance](https://bettercodehub.com/edge/badge/openebs/node-disk-manager?branch=master)](https://bettercodehub.com/results/openebs/node-disk-manager)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/openebs/node-disk-manager/blob/master/LICENSE)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fopenebs%2Fnode-disk-manager.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fopenebs%2Fnode-disk-manager?ref=badge_shield)
 

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -146,7 +146,7 @@ func DeviceList(kubeconfig string) {
 // If disk resource is present in etcd then it updates that resource else it
 // creates one new reource.
 func (c *Controller) PushDiskResource(uuid string, dr apis.Disk) {
-	cdr := c.getExistingResource(uuid)
+	cdr := c.GetExistingResource(uuid)
 	if cdr != nil {
 		c.UpdateDisk(dr, cdr)
 		return

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/golang/glog"
-	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs.io/v1alpha1"
 	clientset "github.com/openebs/node-disk-manager/pkg/client/clientset/versioned"
 	"github.com/openebs/node-disk-manager/pkg/signals"
 	"github.com/openebs/node-disk-manager/pkg/util"
@@ -131,7 +130,7 @@ func DeviceList(kubeconfig string) {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	diskList, err := controller.listDiskResource()
+	diskList, err := controller.ListDiskResource()
 	if err != nil {
 		glog.Fatalf("error listing device: %s", err.Error())
 	}
@@ -142,24 +141,12 @@ func DeviceList(kubeconfig string) {
 	}
 }
 
-// PushDiskResource push disk resource to etcd it will use create/update disk.
-// If disk resource is present in etcd then it updates that resource else it
-// creates one new reource.
-func (c *Controller) PushDiskResource(uuid string, dr apis.Disk) {
-	cdr := c.GetExistingResource(uuid)
-	if cdr != nil {
-		c.UpdateDisk(dr, cdr)
-		return
-	}
-	c.CreateDisk(dr)
-}
-
 // DeactivateStaleDiskResource deactivates the stale entry from etcd.
 // It gets list of resources which are present in system and queries etcd to get
 // list of active resources. One active resource which is present in etcd not in
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleDiskResource(devices []string) {
-	listDR, err := c.listDiskResource()
+	listDR, err := c.ListDiskResource()
 	if err != nil {
 		glog.Error(err)
 		return

--- a/cmd/controller/controller_test.go
+++ b/cmd/controller/controller_test.go
@@ -26,38 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestPushDiskResource(t *testing.T) {
-	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
-	fakeKubeClient := fake.NewSimpleClientset()
-	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
-	}
-	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
-	fakeController.PushDiskResource(fakeDiskUid, dr)
-	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
-	fakeController.PushDiskResource(fakeDiskUid, dr)
-	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
-
-	tests := map[string]struct {
-		actualDisk    apis.Disk
-		actualError   error
-		expectedDisk  apis.Disk
-		expectedError error
-	}{
-		"push disk resource creates resource": {actualDisk: *cdr1, actualError: err1, expectedDisk: dr, expectedError: nil},
-		"push disk resource updates resource": {actualDisk: *cdr2, actualError: err2, expectedDisk: dr, expectedError: nil},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expectedDisk, test.actualDisk)
-			assert.Equal(t, test.expectedError, test.actualError)
-		})
-	}
-}
-
 func TestDeactivateStaleDiskResource(t *testing.T) {
 	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
 	fakeKubeClient := fake.NewSimpleClientset()

--- a/cmd/controller/diskstore.go
+++ b/cmd/controller/diskstore.go
@@ -100,7 +100,7 @@ func (c *Controller) DeleteDisk(name string) {
 
 // ListDiskResource queries the etcd for the devices for the host/node
 // and returns list of disk resources.
-func (c *Controller) listDiskResource() (*apis.DiskList, error) {
+func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 	label := NDMHostKey + "=" + c.HostName
 	filter := metav1.ListOptions{LabelSelector: label}
 	listDR, err := c.Clientset.OpenebsV1alpha1().Disks().List(filter)
@@ -109,13 +109,8 @@ func (c *Controller) listDiskResource() (*apis.DiskList, error) {
 
 // GetExistingResource returns the existing disk resource if it is
 // present in etcd if not it returns nil pointer.
-func (c *Controller) GetExistingResource(uuid string) *apis.Disk {
-	listDR, err := c.listDiskResource()
-	if err != nil {
-		glog.Error(err)
-		return nil
-	}
-	for _, item := range listDR.Items {
+func (c *Controller) GetExistingResource(listDr *apis.DiskList, uuid string) *apis.Disk {
+	for _, item := range listDr.Items {
 		if uuid == item.ObjectMeta.Name {
 			return &item
 		}

--- a/cmd/controller/diskstore.go
+++ b/cmd/controller/diskstore.go
@@ -107,9 +107,9 @@ func (c *Controller) listDiskResource() (*apis.DiskList, error) {
 	return listDR, err
 }
 
-// getExistingResource returns the existing disk resource if it is
+// GetExistingResource returns the existing disk resource if it is
 // present in etcd if not it returns nil pointer.
-func (c *Controller) getExistingResource(uuid string) *apis.Disk {
+func (c *Controller) GetExistingResource(uuid string) *apis.Disk {
 	listDR, err := c.listDiskResource()
 	if err != nil {
 		glog.Error(err)

--- a/cmd/controller/diskstore_test.go
+++ b/cmd/controller/diskstore_test.go
@@ -229,7 +229,7 @@ func TestListDiskResource(t *testing.T) {
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeController.CreateDisk(newDr)
-	listDevice, err := fakeController.listDiskResource()
+	listDevice, err := fakeController.ListDiskResource()
 	typeMeta := metav1.TypeMeta{}
 	listMeta := metav1.ListMeta{}
 	diskList := make([]apis.Disk, 0)
@@ -274,9 +274,13 @@ func TestGetExistingResource(t *testing.T) {
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeController.CreateDisk(newDr)
 
-	cdr1 := fakeController.GetExistingResource(fakeDiskUid)
-	cdr2 := fakeController.GetExistingResource(newFakeDiskUid)
-	cdr3 := fakeController.GetExistingResource("newFakeDiskUid")
+	listDr, err := fakeController.ListDiskResource()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cdr1 := fakeController.GetExistingResource(listDr, fakeDiskUid)
+	cdr2 := fakeController.GetExistingResource(listDr, newFakeDiskUid)
+	cdr3 := fakeController.GetExistingResource(listDr, "newFakeDiskUid")
 	tests := map[string]struct {
 		actualDisk   *apis.Disk
 		expectedDisk *apis.Disk

--- a/cmd/controller/diskstore_test.go
+++ b/cmd/controller/diskstore_test.go
@@ -274,9 +274,9 @@ func TestGetExistingResource(t *testing.T) {
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeController.CreateDisk(newDr)
 
-	cdr1 := fakeController.getExistingResource(fakeDiskUid)
-	cdr2 := fakeController.getExistingResource(newFakeDiskUid)
-	cdr3 := fakeController.getExistingResource("newFakeDiskUid")
+	cdr1 := fakeController.GetExistingResource(fakeDiskUid)
+	cdr2 := fakeController.GetExistingResource(newFakeDiskUid)
+	cdr3 := fakeController.GetExistingResource("newFakeDiskUid")
 	tests := map[string]struct {
 		actualDisk   *apis.Disk
 		expectedDisk *apis.Disk

--- a/cmd/probe/eventhandler.go
+++ b/cmd/probe/eventhandler.go
@@ -36,35 +36,50 @@ type ProbeEvent struct {
 
 // addDiskEvent fill disk details from different probes and push it to etcd
 func (pe *ProbeEvent) addDiskEvent(msg controller.EventMessage) {
+	diskList, err := pe.Controller.ListDiskResource()
+	if err != nil {
+		glog.Error(err)
+		pe.initOrErrorEvent()
+		return
+	}
 	for _, diskDetails := range msg.Devices {
-		func() {
-			glog.Info("processing data for ", diskDetails.ProbeIdentifiers.Uuid)
-			diskDetails.HostName = pe.Controller.HostName
-			diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
-			probes := pe.Controller.ListProbe()
-			for _, probe := range probes {
-				glog.Info("disk details filled by ", probe.ProbeName)
-				probe.FillDiskDetails(diskDetails)
-			}
-			diskApi := diskDetails.ToDisk()
-			pe.Controller.PushDiskResource(diskApi.ObjectMeta.Name, diskApi)
-		}()
+		glog.Info("processing data for ", diskDetails.ProbeIdentifiers.Uuid)
+		diskDetails.HostName = pe.Controller.HostName
+		diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
+		probes := pe.Controller.ListProbe()
+		for _, probe := range probes {
+			glog.Info("disk details filled by ", probe.ProbeName)
+			probe.FillDiskDetails(diskDetails)
+		}
+		diskApi := diskDetails.ToDisk()
+		oldDr := pe.Controller.GetExistingResource(diskList, diskDetails.ProbeIdentifiers.Uuid)
+		if oldDr != nil {
+			pe.Controller.UpdateDisk(diskApi, oldDr)
+			continue
+		}
+		pe.Controller.CreateDisk(diskApi)
 	}
 }
 
 // deleteDiskEvent deactivate disk resource using uuid from etcd
 func (pe *ProbeEvent) deleteDiskEvent(msg controller.EventMessage) {
+	diskList, err := pe.Controller.ListDiskResource()
+	if err != nil {
+		glog.Error(err)
+		pe.initOrErrorEvent()
+		return
+	}
 	mismatch := false
 	// set mismatch = true when one disk is removed from node and
 	// entry related that disk not present in etcd in that case it
 	// again rescan full system and update etcd accordingly.
 	for _, diskDetails := range msg.Devices {
-		edr := pe.Controller.GetExistingResource(diskDetails.ProbeIdentifiers.Uuid)
-		if edr == nil {
+		oldDr := pe.Controller.GetExistingResource(diskList, diskDetails.ProbeIdentifiers.Uuid)
+		if oldDr == nil {
 			mismatch = true
 			continue
 		}
-		pe.Controller.DeactivateDisk(*edr)
+		pe.Controller.DeactivateDisk(*oldDr)
 	}
 	if mismatch {
 		pe.initOrErrorEvent()

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -29,12 +29,27 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestAddDiskEvent(t *testing.T) {
-	mockOsdiskDeails, err := libudevwrapper.MockDiskDetails()
-	if err != nil {
-		t.Fatal(err)
+var (
+	mockuid      = "fake-disk-uid"
+	fakeHostName = "node-name"
+)
+
+func mockEmptyDiskCr() apis.Disk {
+	fakeDr := apis.Disk{}
+	fakeObjectMeta := metav1.ObjectMeta{
+		Labels: make(map[string]string),
+		Name:   mockuid,
 	}
-	fakeHostName := "node-name"
+	fakeTypeMeta := metav1.TypeMeta{
+		Kind:       controller.NDMKind,
+		APIVersion: controller.NDMVersion,
+	}
+	fakeDr.ObjectMeta = fakeObjectMeta
+	fakeDr.TypeMeta = fakeTypeMeta
+	fakeDr.Status.State = controller.NDMActive
+	return fakeDr
+}
+func TestAddDiskEvent(t *testing.T) {
 	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
 	fakeKubeClient := fake.NewSimpleClientset()
 	probes := make([]*controller.Probe, 0)
@@ -46,71 +61,78 @@ func TestAddDiskEvent(t *testing.T) {
 		Probes:        probes,
 		Mutex:         mutex,
 	}
-	udevprobe := newUdevProbe(fakeController)
-	var pi controller.ProbeInterface = udevprobe
-	newPrgisterProbe := &registerProbe{
-		priority:       1,
-		probeName:      "udev probe",
-		probeState:     true,
-		probeInterface: pi,
-		controller:     fakeController,
-	}
-	newPrgisterProbe.register()
-
 	probeEvent := &ProbeEvent{
 		Controller: fakeController,
 	}
+	// Creating one event message
 	eventmsg := make([]*controller.DiskInfo, 0)
 	deviceDetails := &controller.DiskInfo{}
-	deviceDetails.ProbeIdentifiers.Uuid = mockOsdiskDeails.Uid
-	deviceDetails.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
+	deviceDetails.ProbeIdentifiers.Uuid = mockuid
 	eventmsg = append(eventmsg, deviceDetails)
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: eventmsg,
 	}
 	probeEvent.addDiskEvent(eventDetails)
-	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockOsdiskDeails.Uid, metav1.GetOptions{})
-
-	// creating mock api.Disk to compare
-	fakeCapacity := apis.DiskCapacity{
-		Storage: mockOsdiskDeails.Capacity,
-	}
-	fakeDetails := apis.DiskDetails{
-		Model:  mockOsdiskDeails.Model,
-		Serial: mockOsdiskDeails.Serial,
-		Vendor: mockOsdiskDeails.Vendor,
-	}
-	fakeObj := apis.DiskSpec{
-		Path:     mockOsdiskDeails.DevNode,
-		Capacity: fakeCapacity,
-		Details:  fakeDetails,
-	}
-	fakeTypeMeta := metav1.TypeMeta{
-		Kind:       controller.NDMKind,
-		APIVersion: controller.NDMVersion,
-	}
-	fakeObjectMeta := metav1.ObjectMeta{
-		Labels: make(map[string]string),
-		Name:   mockOsdiskDeails.Uid,
-	}
-	fakeDiskStatus := apis.DiskStatus{
-		State: controller.NDMActive,
-	}
-	fakeDr := apis.Disk{
-		TypeMeta:   fakeTypeMeta,
-		ObjectMeta: fakeObjectMeta,
-		Spec:       fakeObj,
-		Status:     fakeDiskStatus,
-	}
+	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockuid, metav1.GetOptions{})
+	// Create one fake disk resource
+	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+
 	tests := map[string]struct {
 		actualDisk    apis.Disk
 		expectedDisk  apis.Disk
 		actualError   error
 		expectedError error
 	}{
-		"resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
+		"add event for resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedDisk, test.actualDisk)
+			assert.Equal(t, test.expectedError, test.actualError)
+		})
+	}
+}
+
+func TestDeleteDiskEvent(t *testing.T) {
+	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
+	fakeKubeClient := fake.NewSimpleClientset()
+	probes := make([]*controller.Probe, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &controller.Controller{
+		HostName:      fakeHostName,
+		KubeClientset: fakeKubeClient,
+		Clientset:     fakeNdmClient,
+		Probes:        probes,
+		Mutex:         mutex,
+	}
+	// Create one fake disk resource
+	fakeDr := mockEmptyDiskCr()
+	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+	fakeController.CreateDisk(fakeDr)
+
+	probeEvent := &ProbeEvent{
+		Controller: fakeController,
+	}
+	eventmsg := make([]*controller.DiskInfo, 0)
+	deviceDetails := &controller.DiskInfo{}
+	deviceDetails.ProbeIdentifiers.Uuid = mockuid
+	eventmsg = append(eventmsg, deviceDetails)
+	eventDetails := controller.EventMessage{
+		Action:  libudevwrapper.UDEV_ACTION_REMOVE,
+		Devices: eventmsg,
+	}
+	probeEvent.deleteDiskEvent(eventDetails)
+	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockuid, metav1.GetOptions{})
+	fakeDr.Status.State = controller.NDMInactive
+	tests := map[string]struct {
+		actualDisk    apis.Disk
+		expectedDisk  apis.Disk
+		actualError   error
+		expectedError error
+	}{
+		"remove resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -75,6 +75,8 @@ func TestAddDiskEvent(t *testing.T) {
 	}
 	probeEvent.addDiskEvent(eventDetails)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockuid, metav1.GetOptions{})
+	probeEvent.addDiskEvent(eventDetails)
+	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockuid, metav1.GetOptions{})
 	// Create one fake disk resource
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
@@ -85,7 +87,8 @@ func TestAddDiskEvent(t *testing.T) {
 		actualError   error
 		expectedError error
 	}{
-		"add event for resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
+		"add event for resouce with 'fake-disk-uid' uuid for create resource": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
+		"add event for resouce with 'fake-disk-uid' uuid for update resource": {actualDisk: *cdr2, expectedDisk: fakeDr, actualError: err2, expectedError: nil},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -65,7 +65,6 @@ func mockOsDiskToAPI() (apis.Disk, error) {
 		Status:     fakeDiskStatus,
 	}
 	return fakeDr, nil
-	//fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 }
 
 func TestFillDiskDetails(t *testing.T) {
@@ -128,10 +127,12 @@ func TestUdevProbe(t *testing.T) {
 	}
 	probeEvent.addDiskEvent(eventDetails)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockOsdiskDeails.Uid, metav1.GetOptions{})
-
+	if err1 != nil {
+		t.Fatal(err1)
+	}
 	fakeDr, err := mockOsDiskToAPI()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	tests := map[string]struct {

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -29,67 +29,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestFillDiskDetails(t *testing.T) {
+func mockOsDiskToAPI() (apis.Disk, error) {
 	mockOsdiskDeails, err := libudevwrapper.MockDiskDetails()
 	if err != nil {
-		t.Fatal(err)
-	}
-	uProbe := udevProbe{}
-	actualDiskInfo := controller.NewDiskInfo()
-	actualDiskInfo.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
-	uProbe.FillDiskDetails(actualDiskInfo)
-	expectedDiskInfo := &controller.DiskInfo{}
-	expectedDiskInfo.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
-	expectedDiskInfo.Model = mockOsdiskDeails.Model
-	expectedDiskInfo.Path = mockOsdiskDeails.DevNode
-	expectedDiskInfo.Serial = mockOsdiskDeails.Serial
-	expectedDiskInfo.Vendor = mockOsdiskDeails.Vendor
-	expectedDiskInfo.Capacity = mockOsdiskDeails.Capacity
-	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
-}
-
-func TestListen(t *testing.T) {
-	mockOsdiskDeails, err := libudevwrapper.MockDiskDetails()
-	if err != nil {
-		t.Fatal(err)
-	}
-	fakeHostName := "node-name"
-	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
-	fakeKubeClient := fake.NewSimpleClientset()
-	probes := make([]*controller.Probe, 0)
-	mutex := &sync.Mutex{}
-	fakeController := &controller.Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
-		Probes:        probes,
-		Mutex:         mutex,
-	}
-	udevprobe := newUdevProbe(fakeController)
-	go udevprobe.listen()
-
-	var pi controller.ProbeInterface = udevprobe
-	newPrgisterProbe := &registerProbe{
-		priority:       1,
-		probeName:      "udev probe",
-		probeState:     true,
-		probeInterface: pi,
-		controller:     fakeController,
-	}
-	newPrgisterProbe.register()
-	eventmsg := make([]*controller.DiskInfo, 0)
-	deviceDetails := &controller.DiskInfo{}
-	deviceDetails.ProbeIdentifiers.Uuid = mockOsdiskDeails.Uid
-	deviceDetails.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
-	eventmsg = append(eventmsg, deviceDetails)
-	eventDetails := controller.EventMessage{
-		Action:  libudevwrapper.UDEV_ACTION_ADD,
-		Devices: eventmsg,
-	}
-	UdevEventMessageChannel <- eventDetails
-	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockOsdiskDeails.Uid, metav1.GetOptions{})
-	for cdr1 == nil {
-		cdr1, err1 = fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockOsdiskDeails.Uid, metav1.GetOptions{})
+		return apis.Disk{}, err
 	}
 	fakeCapacity := apis.DiskCapacity{
 		Storage: mockOsdiskDeails.Capacity,
@@ -121,6 +64,75 @@ func TestListen(t *testing.T) {
 		Spec:       fakeObj,
 		Status:     fakeDiskStatus,
 	}
+	return fakeDr, nil
+	//fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+}
+
+func TestFillDiskDetails(t *testing.T) {
+	mockOsdiskDeails, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uProbe := udevProbe{}
+	actualDiskInfo := controller.NewDiskInfo()
+	actualDiskInfo.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
+	uProbe.FillDiskDetails(actualDiskInfo)
+	expectedDiskInfo := &controller.DiskInfo{}
+	expectedDiskInfo.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
+	expectedDiskInfo.Model = mockOsdiskDeails.Model
+	expectedDiskInfo.Path = mockOsdiskDeails.DevNode
+	expectedDiskInfo.Serial = mockOsdiskDeails.Serial
+	expectedDiskInfo.Vendor = mockOsdiskDeails.Vendor
+	expectedDiskInfo.Capacity = mockOsdiskDeails.Capacity
+	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
+}
+
+func TestUdevProbe(t *testing.T) {
+	mockOsdiskDeails, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeHostName := "node-name"
+	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
+	fakeKubeClient := fake.NewSimpleClientset()
+	probes := make([]*controller.Probe, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &controller.Controller{
+		HostName:      fakeHostName,
+		KubeClientset: fakeKubeClient,
+		Clientset:     fakeNdmClient,
+		Probes:        probes,
+		Mutex:         mutex,
+	}
+	udevprobe := newUdevProbe(fakeController)
+	var pi controller.ProbeInterface = udevprobe
+	newPrgisterProbe := &registerProbe{
+		priority:       1,
+		probeName:      "udev probe",
+		probeState:     true,
+		probeInterface: pi,
+		controller:     fakeController,
+	}
+	newPrgisterProbe.register()
+	probeEvent := &ProbeEvent{
+		Controller: fakeController,
+	}
+	eventmsg := make([]*controller.DiskInfo, 0)
+	deviceDetails := &controller.DiskInfo{}
+	deviceDetails.ProbeIdentifiers.Uuid = mockOsdiskDeails.Uid
+	deviceDetails.ProbeIdentifiers.UdevIdentifier = mockOsdiskDeails.SysPath
+	eventmsg = append(eventmsg, deviceDetails)
+	eventDetails := controller.EventMessage{
+		Action:  libudevwrapper.UDEV_ACTION_ADD,
+		Devices: eventmsg,
+	}
+	probeEvent.addDiskEvent(eventDetails)
+	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(mockOsdiskDeails.Uid, metav1.GetOptions{})
+
+	fakeDr, err := mockOsDiskToAPI()
+	if err != nil {
+		t.Error(err)
+	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	tests := map[string]struct {
 		actualDisk    apis.Disk
@@ -128,7 +140,7 @@ func TestListen(t *testing.T) {
 		actualError   error
 		expectedError error
 	}{
-		"resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
+		"add event for resouce with 'fake-disk-uid' uuid": {actualDisk: *cdr1, expectedDisk: fakeDr, actualError: err1, expectedError: nil},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -79,6 +79,9 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       # nodeSelector:
       #   "openebs.io/nodegroup": "storage-node"
+      # Use host network as container network to monitor udev source using netlink
+      # to detect disk attach and detach events using fd.
+      hostNetwork: true
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -74,10 +74,10 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 	if err != nil {
 	}
 	diskDetails := UdevDiskDetails{
-		Model:  device.UdevDeviceGetPropertyValue(UDEV_MODEL),
-		Serial: device.UdevDeviceGetPropertyValue(UDEV_SERIAL),
-		Vendor: device.UdevDeviceGetPropertyValue(UDEV_VENDOR),
-		Path:   device.UdevDeviceGetPropertyValue(UDEV_DEVNAME),
+		Model:  device.GetPropertyValue(UDEV_MODEL),
+		Serial: device.GetPropertyValue(UDEV_SERIAL),
+		Vendor: device.GetPropertyValue(UDEV_VENDOR),
+		Path:   device.GetPropertyValue(UDEV_DEVNAME),
 		Size:   size,
 	}
 	return diskDetails
@@ -86,22 +86,22 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 // GetUid returns unique id for the disk block device
 func (device *UdevDevice) GetUid() string {
 	return NDMPrefix +
-		util.Hash(device.UdevDeviceGetPropertyValue(UDEV_WWN)+
-			device.UdevDeviceGetPropertyValue(UDEV_MODEL)+
-			device.UdevDeviceGetPropertyValue(UDEV_SERIAL)+
-			device.UdevDeviceGetPropertyValue(UDEV_VENDOR))
+		util.Hash(device.GetPropertyValue(UDEV_WWN)+
+			device.GetPropertyValue(UDEV_MODEL)+
+			device.GetPropertyValue(UDEV_SERIAL)+
+			device.GetPropertyValue(UDEV_VENDOR))
 }
 
 // IsDisk returns true if device is a disk
 func (device *UdevDevice) IsDisk() bool {
-	return device.UdevDeviceGetDevtype() == UDEV_SYSTEM && device.UdevDeviceGetPropertyValue(UDEV_TYPE) == UDEV_SYSTEM
+	return device.GetDevtype() == UDEV_SYSTEM && device.GetPropertyValue(UDEV_TYPE) == UDEV_SYSTEM
 }
 
 // GetSyspath returns syspath of a disk using syspath we can fell details
 // in diskInfo struct using udev probe
 func (device *UdevDevice) GetSyspath() string {
-	major := device.UdevDeviceGetPropertyValue(UDEV_MAJOR)
-	minor := device.UdevDeviceGetPropertyValue(UDEV_MINOR)
+	major := device.GetPropertyValue(UDEV_MAJOR)
+	minor := device.GetPropertyValue(UDEV_MINOR)
 	syspath := UDEV_SYSPATH_PREFIX + major + ":" + minor
 	return syspath
 }
@@ -110,12 +110,12 @@ func (device *UdevDevice) GetSyspath() string {
 func (device *UdevDevice) getSize() (uint64, error) {
 	var sector []byte
 	var sec int64
-	n, err := strconv.ParseInt(device.UdevDeviceGetSysattrValue("size"), 10, 64)
+	n, err := strconv.ParseInt(device.GetSysattrValue("size"), 10, 64)
 	if err != nil {
 		return 0, err
 	}
 	// should we use disk smart queries to get the sector size?
-	fname := "/sys" + device.UdevDeviceGetPropertyValue(UDEV_PATH) + "/queue/hw_sector_size"
+	fname := "/sys" + device.GetPropertyValue(UDEV_PATH) + "/queue/hw_sector_size"
 	sector, err = ioutil.ReadFile(fname)
 	if err != nil {
 		return 0, err

--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -100,21 +100,21 @@ func TestIsDisk(t *testing.T) {
 	}
 	defer udevEnumerate.UnrefUdevEnumerate()
 
-	err = udevEnumerate.UdevEnumerateAddMatchSubsystem(UDEV_SUBSYSTEM)
+	err = udevEnumerate.AddSubsystemFilter(UDEV_SUBSYSTEM)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = udevEnumerate.UdevEnumerateScanDevices()
+	err = udevEnumerate.ScanDevices()
 	if err != nil {
 		t.Fatal(err)
 	}
-	for l := udevEnumerate.UdevEnumerateGetListEntry(); l != nil; l = l.UdevListEntryGetNext() {
-		s := l.UdevListEntryGetName()
+	for l := udevEnumerate.ListEntry(); l != nil; l = l.GetNextEntry() {
+		s := l.GetName()
 		newUdevice, err := udev.NewDeviceFromSysPath(s)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if newUdevice.UdevDeviceGetDevtype() == UDEV_SYSTEM && newUdevice.UdevDeviceGetPropertyValue(UDEV_TYPE) == UDEV_SYSTEM {
+		if newUdevice.GetDevtype() == UDEV_SYSTEM && newUdevice.GetPropertyValue(UDEV_TYPE) == UDEV_SYSTEM {
 			assert.Equal(t, true, newUdevice.IsDisk())
 		} else {
 			assert.Equal(t, false, newUdevice.IsDisk())

--- a/pkg/udev/device.go
+++ b/pkg/udev/device.go
@@ -42,32 +42,38 @@ func newUdevDevice(ptr *C.struct_udev_device) (*UdevDevice, error) {
 	return ud, nil
 }
 
-// UdevDeviceGetPropertyValue retrieves the value of a device property
-func (ud *UdevDevice) UdevDeviceGetPropertyValue(key string) string {
+// GetPropertyValue retrieves the value of a device property
+func (ud *UdevDevice) GetPropertyValue(key string) string {
 	k := C.CString(key)
 	defer freeCharPtr(k)
 	return C.GoString(C.udev_device_get_property_value(ud.udptr, k))
 }
 
-// UdevDeviceGetSysattrValue retrieves the content of a sys attribute file
+// GetSysattrValue retrieves the content of a sys attribute file
 // returns an empty string if there is no sys attribute value.
-// The retrieved value is cached in the device.
-// Repeated calls will return the same value and not open the attribute again.
-func (ud *UdevDevice) UdevDeviceGetSysattrValue(sysattr string) string {
+// The retrieved value is cached in the device. Repeated calls
+// will return the same value and not open the attribute again.
+func (ud *UdevDevice) GetSysattrValue(sysattr string) string {
 	k := C.CString(sysattr)
 	defer freeCharPtr(k)
 	return C.GoString(C.udev_device_get_sysattr_value(ud.udptr, k))
 }
 
-// UdevDeviceGetDevtype returns the devtype string of the udev device.
-func (ud *UdevDevice) UdevDeviceGetDevtype() string {
+// GetDevtype returns the devtype string of the udev device.
+func (ud *UdevDevice) GetDevtype() string {
 	return C.GoString(C.udev_device_get_devtype(ud.udptr))
 }
 
-// UdevDeviceGetDevnode returns the device node file name belonging to the udev device.
+// GetDevnode returns the device node file name belonging to the udev device.
 // The path is an absolute path, and starts with the device directory.
-func (ud *UdevDevice) UdevDeviceGetDevnode() string {
+func (ud *UdevDevice) GetDevnode() string {
 	return C.GoString(C.udev_device_get_devnode(ud.udptr))
+}
+
+// GetAction returns device action when it is monitored.
+// It can be add,remove,online,offline,change
+func (ud *UdevDevice) GetAction() string {
+	return C.GoString(C.udev_device_get_action(ud.udptr))
 }
 
 // UdevDeviceUnref frees udev_device structure.

--- a/pkg/udev/device_test.go
+++ b/pkg/udev/device_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUdevDeviceGetPropertyValue(t *testing.T) {
+func TestGetPropertyValue(t *testing.T) {
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)
@@ -37,11 +37,11 @@ func TestUdevDeviceGetPropertyValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer device.UdevDeviceUnref()
-	deviceType := device.UdevDeviceGetPropertyValue(UDEV_TYPE)
+	deviceType := device.GetPropertyValue(UDEV_TYPE)
 	assert.Equal(t, diskDetails.DevType, deviceType)
 }
 
-func TestUdevDeviceGetSysattrValue(t *testing.T) {
+func TestGetSysattrValue(t *testing.T) {
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)
@@ -56,11 +56,11 @@ func TestUdevDeviceGetSysattrValue(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer device.UdevDeviceUnref()
-	expectedSize := device.UdevDeviceGetSysattrValue("size")
+	expectedSize := device.GetSysattrValue("size")
 	assert.Equal(t, expectedSize, diskDetails.Size)
 }
 
-func TestUdevDeviceGetDevtype(t *testing.T) {
+func TestGetDevtype(t *testing.T) {
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)
@@ -75,10 +75,10 @@ func TestUdevDeviceGetDevtype(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer device.UdevDeviceUnref()
-	assert.Equal(t, diskDetails.DevType, device.UdevDeviceGetDevtype())
+	assert.Equal(t, diskDetails.DevType, device.GetDevtype())
 }
 
-func TestUdevDeviceGetDevnode(t *testing.T) {
+func TestGetDevnode(t *testing.T) {
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)
@@ -93,5 +93,23 @@ func TestUdevDeviceGetDevnode(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer device.UdevDeviceUnref()
-	assert.Equal(t, diskDetails.DevNode, device.UdevDeviceGetDevnode())
+	assert.Equal(t, diskDetails.DevNode, device.GetDevnode())
+}
+
+func TestGetAction(t *testing.T) {
+	diskDetails, err := MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	newUdev, err := NewUdev()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer newUdev.UnrefUdev()
+	device, err := newUdev.NewDeviceFromSysPath(diskDetails.SysPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer device.UdevDeviceUnref()
+	assert.Equal(t, "", device.GetAction())
 }

--- a/pkg/udev/enumerate.go
+++ b/pkg/udev/enumerate.go
@@ -30,10 +30,10 @@ type UdevEnumerate struct {
 	ueptr *C.struct_udev_enumerate
 }
 
-// UdevEnumerateAddMatchSubsystem adds filter in UdeviceMon struct.
+// AddSubsystemFilter adds filter in UdeviceMon struct.
 // This filter is efficiently executed inside kernel, and libudev
 // subscribers will usually not be woken up for devices which do not match.
-func (ue *UdevEnumerate) UdevEnumerateAddMatchSubsystem(subSystem string) error {
+func (ue *UdevEnumerate) AddSubsystemFilter(subSystem string) error {
 	subsystem := C.CString(subSystem)
 	defer freeCharPtr(subsystem)
 	ret := C.udev_enumerate_add_match_subsystem(ue.ueptr, subsystem)
@@ -43,8 +43,9 @@ func (ue *UdevEnumerate) UdevEnumerateAddMatchSubsystem(subSystem string) error 
 	return nil
 }
 
-// UdevEnumerateScanDevices scan devices in system
-func (ue *UdevEnumerate) UdevEnumerateScanDevices() error {
+// ScanDevices scan devices in system and returns list
+// of devices present in system
+func (ue *UdevEnumerate) ScanDevices() error {
 	ret := C.udev_enumerate_scan_devices(ue.ueptr)
 	if ret < 0 {
 		return errors.New("unable to scan device list")
@@ -52,8 +53,8 @@ func (ue *UdevEnumerate) UdevEnumerateScanDevices() error {
 	return nil
 }
 
-// UdevEnumerateGetListEntry returns UdevListEntry struct from which wecan get device.
-func (ue *UdevEnumerate) UdevEnumerateGetListEntry() *UdevListEntry {
+// ListEntry returns UdevListEntry struct from which wecan get device.
+func (ue *UdevEnumerate) ListEntry() *UdevListEntry {
 	return newUdevListEntry(C.udev_enumerate_get_list_entry(ue.ueptr))
 }
 

--- a/pkg/udev/enumerate_test.go
+++ b/pkg/udev/enumerate_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 )
 
-func TestUdevEnumerateAddMatchSubsystem(t *testing.T) {
+func TestAddSubsystemFilter(t *testing.T) {
 	newUdev, err := NewUdev()
 	if err != nil {
 		t.Fatal(err)
@@ -33,13 +33,13 @@ func TestUdevEnumerateAddMatchSubsystem(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer newUdevEnumerate.UnrefUdevEnumerate()
-	err = newUdevEnumerate.UdevEnumerateAddMatchSubsystem("block")
+	err = newUdevEnumerate.AddSubsystemFilter("block")
 	if err != nil {
 		t.Error("error should be nil for successfull subsystem filter")
 	}
 }
 
-func TestUdevEnumerateScanDevices(t *testing.T) {
+func TestScanDevices(t *testing.T) {
 	newUdev, err := NewUdev()
 	if err != nil {
 		t.Fatal(err)
@@ -50,11 +50,11 @@ func TestUdevEnumerateScanDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer newUdevEnumerate.UnrefUdevEnumerate()
-	err = newUdevEnumerate.UdevEnumerateAddMatchSubsystem("block")
+	err = newUdevEnumerate.AddSubsystemFilter("block")
 	if err != nil {
 		t.Error("error should be nil for successfull subsystem filter")
 	}
-	err = newUdevEnumerate.UdevEnumerateScanDevices()
+	err = newUdevEnumerate.ScanDevices()
 	if err != nil {
 		t.Error("error should be nil for successfull scan device")
 	}

--- a/pkg/udev/listentry.go
+++ b/pkg/udev/listentry.go
@@ -40,13 +40,13 @@ func newUdevListEntry(ptr *C.struct_udev_list_entry) (le *UdevListEntry) {
 	return
 }
 
-// UdevListEntryGetNext return UdevListEntry struct if next device present.
-// else it returns nil
-func (le *UdevListEntry) UdevListEntryGetNext() *UdevListEntry {
+// GetNext return UdevListEntry struct if next device present
+// else it returns nil pointer.
+func (le *UdevListEntry) GetNextEntry() *UdevListEntry {
 	return newUdevListEntry(C.udev_list_entry_get_next(le.listEntry))
 }
 
-//UdevListEntryGetName return Udevice syspath.
-func (le *UdevListEntry) UdevListEntryGetName() string {
+// GetName return Udevice syspath.
+func (le *UdevListEntry) GetName() string {
 	return C.GoString(C.udev_list_entry_get_name(le.listEntry))
 }

--- a/pkg/udev/mockdata.go
+++ b/pkg/udev/mockdata.go
@@ -86,10 +86,10 @@ func MockDiskDetails() (MockOsDiskDetails, error) {
 	diskDetails.DevNode = "/dev/" + osDiskName
 	diskDetails.Size = sizeString
 	diskDetails.SysPath = sysPath
-	diskDetails.Model = device.UdevDeviceGetPropertyValue(UDEV_MODEL)
-	diskDetails.Serial = device.UdevDeviceGetPropertyValue(UDEV_SERIAL)
-	diskDetails.Vendor = device.UdevDeviceGetPropertyValue(UDEV_VENDOR)
-	diskDetails.Wwn = device.UdevDeviceGetPropertyValue(UDEV_WWN)
+	diskDetails.Model = device.GetPropertyValue(UDEV_MODEL)
+	diskDetails.Serial = device.GetPropertyValue(UDEV_SERIAL)
+	diskDetails.Vendor = device.GetPropertyValue(UDEV_VENDOR)
+	diskDetails.Wwn = device.GetPropertyValue(UDEV_WWN)
 	diskDetails.Capacity = size
 	diskDetails.Uid = device.GetUid()
 	return diskDetails, nil

--- a/pkg/udev/monitor.go
+++ b/pkg/udev/monitor.go
@@ -1,0 +1,92 @@
+// +build linux,cgo
+
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+/*
+  #cgo LDFLAGS: -ludev
+  #include <libudev.h>
+*/
+import "C"
+
+import (
+	"errors"
+)
+
+// UdevMonitor wraps a libudev monitor device object
+type UdevMonitor struct {
+	umptr *C.struct_udev_monitor
+}
+
+// newUdevMonitor is a helper function and returns a pointer to a new monitor device.
+// The agrument ptr is a pointer to the underlying C udev_device_monitor structure.
+// The function returns nil if the pointer passed is NULL.
+func newUdeviceMonitor(ptr *C.struct_udev_monitor) (*UdevMonitor, error) {
+	// If passed a NULL pointer, return nil
+	if ptr == nil {
+		return nil, errors.New("unable to create Udevenumerate object for for null struct struct_udev_monitor")
+	}
+	// Create a new monitor device object
+	um := &UdevMonitor{
+		umptr: ptr,
+	}
+	// Return the monitor device object
+	return um, nil
+}
+
+// AddSubsystemFilter adds subsystem filter in UdevMonitor struct.
+// This filter is efficiently executed inside kernel, and libudev
+// subscribers will usually not be woken up for devices which do not match.
+func (um *UdevMonitor) AddSubsystemFilter(key string) error {
+	subsystem := C.CString(key)
+	defer freeCharPtr(subsystem)
+	ret := C.udev_monitor_filter_add_match_subsystem_devtype(um.umptr, subsystem, nil)
+	if ret < 0 {
+		return errors.New("unable to apply filter")
+	}
+	return nil
+}
+
+// EnableReceiving binds udev_monitor socket to event source.
+func (um *UdevMonitor) EnableReceiving() error {
+	ret := C.udev_monitor_enable_receiving(um.umptr)
+	if ret < 0 {
+		return errors.New("unable to enable receving udev")
+	}
+	return nil
+}
+
+// GetFd retrieves socket file descriptor associated with monitor.
+func (um *UdevMonitor) GetFd() (int, error) {
+	ret := int(C.udev_monitor_get_fd(um.umptr))
+	if ret < 0 {
+		return ret, errors.New("unable to get fd from monitor")
+	}
+	return ret, nil
+}
+
+// ReceiveDevice receives data from udev monitor socket, allocate a
+// new udev device, fill in received data, and return Udevice struct.
+func (um *UdevMonitor) ReceiveDevice() (*UdevDevice, error) {
+	return newUdevDevice(C.udev_monitor_receive_device(um.umptr))
+}
+
+// UdevMonitorUnref frees udev monitor structure.
+func (um *UdevMonitor) UdevMonitorUnref() {
+	C.udev_monitor_unref(um.umptr)
+}

--- a/pkg/udev/monitor_test.go
+++ b/pkg/udev/monitor_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udev
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDeviceFromNetlink(t *testing.T) {
+	udev, err := NewUdev()
+	if err != nil {
+		t.Error(err)
+	}
+	defer udev.UnrefUdev()
+	// For valid monitor source NewUdeviceMon() should return monitor device pointer and nil error.
+	udevMonitor, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udevMonitor.UdevMonitorUnref()
+	// For invalid monitor source NewUdeviceMon() should return nil monitor device pointer and error.
+	_, err = udev.NewDeviceFromNetlink("block")
+	if err != nil {
+		assert.Equal(t, errors.New("unable to create Udevenumerate object for for null struct struct_udev_monitor"), err)
+	}
+}
+
+func TestAddFilterSubsystem(t *testing.T) {
+	// for successfull AddFilterSubsystem() it should return nil error.
+	udev, err := NewUdev()
+	if err != nil {
+		t.Error(err)
+	}
+	defer udev.UnrefUdev()
+	udevMonitor, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udevMonitor.UdevMonitorUnref()
+	assert.Equal(t, nil, udevMonitor.AddSubsystemFilter("block"))
+}
+
+func TestEnableMonitorReceiving(t *testing.T) {
+	// for successfull EnableMonitorReceiving() it should return nil error.
+	// if we free udevMonitor pointer then it should return an error.
+	udev, err := NewUdev()
+	if err != nil {
+		t.Error(err)
+	}
+	defer udev.UnrefUdev()
+	udevMonitor, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udevMonitor.UdevMonitorUnref()
+	err = udevMonitor.EnableReceiving()
+	if err != nil {
+		t.Error("expected nil error")
+	}
+	udevMonitor1, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	udevMonitor1.UdevMonitorUnref()
+	err = udevMonitor1.EnableReceiving()
+	assert.Equal(t, errors.New("unable to enable receving udev"), err)
+
+}
+
+func TestGetFd(t *testing.T) {
+	// for successfull TestGetFd() it should return nil error
+	// and fd value should be greater than 0.
+	udev, err := NewUdev()
+	if err != nil {
+		t.Error(err)
+	}
+	defer udev.UnrefUdev()
+	udevMonitor, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udevMonitor.UdevMonitorUnref()
+	fd, err := udevMonitor.GetFd()
+	if fd <= 0 {
+		t.Error("fd value should be greater than 0")
+	}
+	assert.Equal(t, nil, err)
+}
+
+func TestUdevMonitorNewDevice(t *testing.T) {
+	udev, err := NewUdev()
+	if err != nil {
+		t.Error(err)
+	}
+	defer udev.UnrefUdev()
+	udevMonitor, err := udev.NewDeviceFromNetlink("udev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer udevMonitor.UdevMonitorUnref()
+	_, err = udevMonitor.ReceiveDevice()
+	if err != nil {
+		assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+	}
+}

--- a/pkg/udev/udev.go
+++ b/pkg/udev/udev.go
@@ -77,3 +77,11 @@ func (u *Udev) NewDeviceFromSysPath(sysPath string) (*UdevDevice, error) {
 	defer freeCharPtr(syspath)
 	return newUdevDevice(C.udev_device_new_from_syspath(u.uptr, syspath))
 }
+
+// NewDeviceFromNetlink use newUdeviceMonitor() and use returns UdevMonitor pointer in success
+// The function returns nil on failure it can monitor udev or kernel as source.
+func (u *Udev) NewDeviceFromNetlink(source string) (*UdevMonitor, error) {
+	monitorSources := C.CString(source)
+	defer freeCharPtr(monitorSources)
+	return newUdeviceMonitor(C.udev_monitor_new_from_netlink(u.uptr, monitorSources))
+}

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udevevent
+
+import (
+	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
+)
+
+// event contains EventMessage struct
+type event struct {
+	eventDetails controller.EventMessage
+}
+
+//newEvent returns a copy of event struct
+func newEvent() *event {
+	event := &event{
+		eventDetails: controller.EventMessage{},
+	}
+	return event
+}
+
+// process takes udevdevice as input and generate event message
+func (e *event) process(device *libudevwrapper.UdevDevice) {
+	defer device.UdevDeviceUnref()
+	diskInfo := make([]*controller.DiskInfo, 0)
+	uuid := device.GetUid()
+	action := device.GetAction()
+	glog.Info("processing new event for ", uuid, " action type ", action)
+	deviceDetails := &controller.DiskInfo{}
+	deviceDetails.ProbeIdentifiers.Uuid = uuid
+	deviceDetails.ProbeIdentifiers.UdevIdentifier = device.GetSyspath()
+	diskInfo = append(diskInfo, deviceDetails)
+	e.eventDetails.Action = action
+	e.eventDetails.Devices = diskInfo
+}
+
+// send sends event message to udev probe via channel
+func (e *event) send() {
+	UdevEventMessageChannel <- e.eventDetails
+}

--- a/pkg/udevevent/event_test.go
+++ b/pkg/udevevent/event_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udevevent
+
+import (
+	"testing"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewEvent(t *testing.T) {
+	event := newEvent()
+	if event == nil {
+		t.Error("event pointer should not be nil")
+	}
+}
+
+func TestProcess(t *testing.T) {
+	actualEvent := newEvent()
+	osDiskDetails, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	udev, err := libudevwrapper.NewUdev()
+	if err != nil {
+		t.Fatal(err)
+	}
+	device, err := udev.NewDeviceFromSysPath(osDiskDetails.SysPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualEvent.process(device)
+
+	// creating mock event
+	expectedEvent := newEvent()
+	diskInfo := make([]*controller.DiskInfo, 0)
+	deviceDetails := &controller.DiskInfo{}
+	deviceDetails.ProbeIdentifiers.Uuid = osDiskDetails.Uid
+	deviceDetails.ProbeIdentifiers.UdevIdentifier = osDiskDetails.SysPath
+	diskInfo = append(diskInfo, deviceDetails)
+	expectedEvent.eventDetails.Action = ""
+	expectedEvent.eventDetails.Devices = diskInfo
+	assert.Equal(t, expectedEvent, actualEvent)
+
+	tests := map[string]struct {
+		actualEvent   *event
+		expextedEvent *event
+	}{
+		"match content of one event after process": {actualEvent: actualEvent, expextedEvent: expectedEvent},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expextedEvent, test.actualEvent)
+		})
+	}
+}
+
+func TestSend(t *testing.T) {
+	event := newEvent()
+	if event == nil {
+		t.Error("event pointer should not be nil")
+	}
+	go event.send()
+	msg := <-UdevEventMessageChannel
+
+	tests := map[string]struct {
+		actualEventMessage   controller.EventMessage
+		expextedEventMessage controller.EventMessage
+	}{
+		"match content of one event after process": {actualEventMessage: msg, expextedEventMessage: event.eventDetails},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expextedEventMessage, test.actualEventMessage)
+		})
+	}
+}

--- a/pkg/udevevent/monitor.go
+++ b/pkg/udevevent/monitor.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udevevent
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
+	"github.com/openebs/node-disk-manager/pkg/util"
+)
+
+// UdevEventMessageChannel used to send event message
+var UdevEventMessageChannel = make(chan controller.EventMessage)
+
+// monitor contains udev and udevmonitor struct
+type monitor struct {
+	udev        *libudevwrapper.Udev
+	udevMonitor *libudevwrapper.UdevMonitor
+}
+
+// newMonitor returns monitor struct in success
+// we can get fd and monitor using this struct
+func newMonitor() (*monitor, error) {
+	udev, err := libudevwrapper.NewUdev()
+	if err != nil {
+		return nil, err
+	}
+	udevMonitor, err := udev.NewDeviceFromNetlink(libudevwrapper.UDEV_SOURCE)
+	if err != nil {
+		return nil, err
+	}
+	err = udevMonitor.AddSubsystemFilter(libudevwrapper.UDEV_SUBSYSTEM)
+	if err != nil {
+		return nil, err
+	}
+	err = udevMonitor.EnableReceiving()
+	if err != nil {
+		return nil, err
+	}
+	monitor := &monitor{
+		udev:        udev,
+		udevMonitor: udevMonitor,
+	}
+	return monitor, nil
+}
+
+// setup returns file descriptor value to monitor system
+func (m *monitor) setup() (int, error) {
+	return m.udevMonitor.GetFd()
+}
+
+// free frees udev and udevMonitor pointer
+func (m *monitor) free() {
+	if m.udev != nil {
+		m.udev.UnrefUdev()
+	}
+	if m.udevMonitor != nil {
+		m.udevMonitor.UdevMonitorUnref()
+	}
+}
+
+// process get device info which is attached or detached
+// generate one new event and sent it to udev probe
+func (m *monitor) process(fd int) error {
+	fds := &syscall.FdSet{}
+	util.FD_ZERO(fds)
+	util.FD_SET(fds, int(fd))
+	ret, _ := syscall.Select(int(fd)+1, fds, nil, nil, nil)
+	if ret <= 0 {
+		return errors.New("unable to apply select call")
+	}
+	if !util.FD_ISSET(fds, int(fd)) {
+		return errors.New("unable to set fd")
+	}
+	device, err := m.udevMonitor.ReceiveDevice()
+	if err != nil {
+		return err
+	}
+	if !device.IsDisk() {
+		device.UdevDeviceUnref()
+		return nil
+	}
+	event := newEvent()
+	event.process(device)
+	event.send()
+	return nil
+}
+
+//Monitor start monitoring on udev source
+func Monitor() {
+	monitor, err := newMonitor()
+	if err != nil {
+		glog.Error(err)
+	}
+	defer monitor.free()
+	fd, err := monitor.setup()
+	if err != nil {
+		glog.Error(err)
+	}
+	for {
+		err := monitor.process(fd)
+		if err != nil {
+			glog.Error(err)
+		}
+	}
+}

--- a/pkg/udevevent/monitor_test.go
+++ b/pkg/udevevent/monitor_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package udevevent
+
+import (
+	"testing"
+)
+
+func TestNewMonitor(t *testing.T) {
+	monitor, err := newMonitor()
+	if err != nil {
+		t.Error(err)
+	}
+	defer monitor.free()
+	if monitor.udev == nil {
+		t.Errorf("udev should not be nil")
+	}
+	if monitor.udevMonitor == nil {
+		t.Errorf("udevMonitor should not be nil")
+	}
+}
+
+func TestSetup(t *testing.T) {
+	monitor, err := newMonitor()
+	if err != nil {
+		t.Error(err)
+	}
+	defer monitor.free()
+	fd, err := monitor.setup()
+	if err != nil {
+		t.Error(err)
+	}
+	if fd < 3 {
+		t.Errorf("fd value should be greater than 2")
+	}
+}

--- a/pkg/util/fdutil.go
+++ b/pkg/util/fdutil.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "syscall"
+
+//FD_SET add a given file descriptor from  a  set
+//it perform bit shift operations and set fdset.
+//ie if value of i is 2 then it will set fdset's value as {[16]int64{4}}
+func FD_SET(p *syscall.FdSet, i int) {
+	p.Bits[i/64] |= 1 << (uint(i) % 64)
+}
+
+//FD_ISSET tests to see if a file descriptor is part of the set
+func FD_ISSET(p *syscall.FdSet, i int) bool {
+	return (p.Bits[i/64] & (1 << (uint(i) % 64))) != 0
+}
+
+//FD_ZERO clears a set
+//it perform bit shift operations and clear fdset.
+func FD_ZERO(p *syscall.FdSet) {
+	for i := range p.Bits {
+		p.Bits[i] = 0
+	}
+}

--- a/pkg/util/fdutil_test.go
+++ b/pkg/util/fdutil_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFD_SET(t *testing.T) {
+	tests := map[string]struct {
+		x        int
+		expected syscall.FdSet
+	}{
+		"fd set test for fd value 0": {x: 0, expected: syscall.FdSet{[16]int64{1}}},
+		"fd set test for fd value 1": {x: 1, expected: syscall.FdSet{[16]int64{2}}},
+		"fd set test for fd value 7": {x: 7, expected: syscall.FdSet{[16]int64{128}}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := &syscall.FdSet{}
+			FD_SET(result, test.x)
+			assert.Equal(t, test.expected, *result)
+		})
+	}
+}
+
+func TestFD_ISSET(t *testing.T) {
+	tests := map[string]struct {
+		x        int
+		fdset    syscall.FdSet
+		expected bool
+	}{
+		"set 0 and check with 2^0": {x: 0, fdset: syscall.FdSet{[16]int64{1}}, expected: true},
+		"set 1 and check with 2^1": {x: 1, fdset: syscall.FdSet{[16]int64{2}}, expected: true},
+		"set 7 and check with 2^7": {x: 7, fdset: syscall.FdSet{[16]int64{128}}, expected: true},
+		"set 4 and check with 6":   {x: 4, fdset: syscall.FdSet{[16]int64{6}}, expected: false},
+		"set 2 and check with 2":   {x: 2, fdset: syscall.FdSet{[16]int64{2}}, expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := FD_ISSET(&test.fdset, test.x)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestFD_ZERO(t *testing.T) {
+	tests := map[string]struct {
+		x        int
+		expected syscall.FdSet
+	}{
+		"fd zero test for fdset value {[16]int64{1}}":   {x: 0, expected: syscall.FdSet{[16]int64{1}}},
+		"fd zero test for fdset value {[16]int64{2}}":   {x: 1, expected: syscall.FdSet{[16]int64{2}}},
+		"fd zero test for fdset value {[16]int64{128}}": {x: 7, expected: syscall.FdSet{[16]int64{128}}},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := &syscall.FdSet{}
+			FD_ZERO(&test.expected)
+			assert.Equal(t, test.expected, *result)
+		})
+	}
+}

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -15,6 +15,9 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       # nodeSelector:
       #   "openebs.io/nodegroup": "storage-node"
+      # Use host network as container network to monitor udev source using netlink
+      # to detect disk attach and detach events using fd.
+      hostNetwork: true
       containers:
       - name: node-disk-manager
         command:


### PR DESCRIPTION
Node-disk-manager will automate the management of the disk attached to the node. To automate management of disks node-disk-manager should be notified by udev-event module for two basic event disk attach and disk detach. Node-disk-manager will detect new disks attached to its node and create a Disk CR corresponding to the newly detected disk. In case this disk was moved from another node in the same cluster to this node, it should update the host-name associated with the disk.
libudev API calls will help to detect attach and detach event and get details info about attached or detached disk.


![image](https://user-images.githubusercontent.com/14263515/40598578-2181f19a-6266-11e8-91df-5aa3a50102fd.png)
`Fig - flow of libudev API calls to monitor device.`

![image](https://user-images.githubusercontent.com/14263515/42447792-acad00f4-8398-11e8-9f86-25249173407b.png)

`Fig - udev-event module integration with node-disk manager.`


visual logs:
1. Pod log
```
shovan_maity@instance-1:~$ kubectl get pod
NAME                                   READY     STATUS    RESTARTS   AGE
node-disk-manager-l4759                1/1       Running   0          21s
shovan_maity@instance-1:~$ kubectl logs -f node-disk-manager-l4759
I0528 05:37:42.851717       1 ctrl.go:79] Started the controller
I0528 05:37:42.855474       1 server.go:39] Starting HTTP server at http://localhost:9090/metrics for metrics.
I0528 05:37:42.890649       1 ctrl.go:124] Created disk object in etcd : disk-0c296ae11848ba414852bc1070321c21
I0528 05:38:50.845132       1 event.go:69] Disk add event disk-ce41f8f5fa22acb79ec56292441dc207
I0528 05:38:50.854621       1 ctrl.go:124] Created disk object in etcd : disk-ce41f8f5fa22acb79ec56292441dc207
```


2. Describe disk
```
shovan_maity@instance-1:~$ kubectl describe disk disk-ce41f8f5fa22acb79ec56292441dc207
Name:         disk-ce41f8f5fa22acb79ec56292441dc207
Namespace:    
Labels:       kubernetes.io/hostname=instance-1
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-05-28T05:38:50Z
  Resource Version:    48984
  Self Link:           /apis/openebs.io/v1alpha1/disk-ce41f8f5fa22acb79ec56292441dc207
  UID:                 6695393c-6239-11e8-9f65-42010a8e0003
Spec:
  Capacity:
    Storage:  10737418240
  Details:
    Model:   PersistentDisk
    Serial:  disk-1
    Vendor:  Google
  Path:      /dev/sdb
Status:
  State:  Active
Events:   <none>
```


~`pkg/udev/udev.go` is temporarily checked in once pr #48 got merged I will remove it.
TODO use common constant string~
For detail implementation details please follow [Design doc.](https://docs.google.com/document/d/100No7LwD6VIK4HhvE3fU75xN2Qih3lbOPsqUb3w0wmk) 
Signed-off-by: Shovan <shovan.cse91@gmail.com>