### PR TITLE
creating a single yaml for the deployment of NDM

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -1,0 +1,105 @@
+# Define the Service Account
+# Define the RBAC rules for the Service Account
+# Launch the node-disk-manager ( daemeon set )
+
+# Create NDM Service Account
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openebs-ndm-operator
+  namespace: default
+---
+# Define Role that allows operations on K8s pods/deployments
+#  in "default" namespace
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: openebs-ndm-operator
+rules:
+- apiGroups: ["disks.openebs.io"]
+  resources: ["disks"]
+  verbs: ["*"]
+---
+# Bind the Service Account with the Role Privileges.
+# TODO: Check if default account also needs to be there
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-ndm-operator
+  namespace: default
+subjects:
+- kind: ServiceAccount
+  name: openebs-ndm-operator
+  namespace: default
+- kind: User
+  name: system:serviceaccount:default:default
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: openebs-ndm-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  # name must match the spec fields below, and be in the form: <plural>.<group>
+  name: disks.openebs.io
+spec:
+  # group name to use for REST API: /apis/<group>/<version>
+  group: openebs.io
+  # version name to use for REST API: /apis/<group>/<version>
+  version: v1alpha1
+  scope: Cluster
+  names:
+    # plural name to be used in the URL: /apis/<group>/<version>/<plural>
+    plural: disks
+    # singular name to be used as an alias on the CLI and for display
+    singular: disk
+    # kind is normally the CamelCased singular type. Your resource manifests use this.
+    kind: Disk
+    # shortNames allow shorter string to match your resource on the CLI
+    shortNames:
+    - disk
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-disk-manager
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-disk-manager
+    spec:
+      # By default the node-disk-manager will be run on all kubernetes nodes
+      # If you would like to limit this to only some nodes, say the nodes
+      # that have storage attached, you could label those node and use nodeSelector.
+      # Example: Label the storage nodes with - "openebs.io/nodegroup"="storage-node"
+      # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
+      #nodeSelector:
+      #  "openebs.io/nodegroup": "storage-node"
+      containers:
+      - name: node-disk-manager
+        command:
+        - /usr/sbin/ndm
+        - start
+        image: openebs/node-disk-manager-amd64:ci
+        imagePullPolicy: Always
+        securityContext:
+          privileged: true
+        # make udev database available inside container
+        volumeMounts:
+        - name: udev
+          mountPath: /run/udev
+        env:
+        # pass hostname as env variable using downward API to the NDM container
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+      volumes:
+      - name: udev
+        hostPath:
+          path: /run/udev
+          type: Directory

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -9,7 +9,7 @@ spec:
         app: node-disk-manager
     spec:
       # By default the node-disk-manager will be run on all kubernetes nodes
-      # If you would like to limit this to only some nodes, say the nodes 
+      # If you would like to limit this to only some nodes, say the nodes
       # that have storage attached, you could label those node and use nodeSelector.
       # Example: Label the storage nodes with - "openebs.io/nodegroup"="storage-node"
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"


### PR DESCRIPTION
It is cumbersome to apply more than one yamls to deploy a solution.
For NDM, we are applying crd yaml and deployment yaml for deployment.
Writing a complete yaml, which will do everyting like apply the
CRD yaml, create a service account, apply the deployment yaml would
be useful for users.

Signed-off-by: Pawan <pawanprakash101@gmail.com>