### PR TITLE
remove o/p dependency of ndm cli commands from pkg/controller

### DIFF
--- a/cmd/app/command/device-list.go
+++ b/cmd/app/command/device-list.go
@@ -18,10 +18,49 @@ package command
 
 import (
 	goflag "flag"
+	"fmt"
+	"html/template"
+	"os"
 
 	"github.com/openebs/node-disk-manager/cmd/controller"
 	"github.com/spf13/cobra"
 )
+
+/*
+defaultDeviceList template use to print list of device
+This template looks like below -
+
+when disk resources present
+root@instance-1:~#ndm device list
+NAME                                         PATH      CAPACITY       STATUS    SERIAL                   MODEL               VENDOR
+disk-ccc636c88bd9ab09dde9de476309058d        /dev/sda  10737418240    Inactive  instance-1               PersistentDisk      Google
+disk-ce41f8f5fa22acb79ec56292441dc207        /dev/sdb  10737418240    Active    disk-1                   PersistentDisk      Google
+
+when no resource present
+root@instance-1:~#ndm device list
+No disk resource present.
+*/
+const defaultDeviceList = `
+{{- if .Items}}
+	{{- printf "%-45s" "NAME"}}
+	{{- printf "%-10s" "PATH"}}
+	{{- printf "%-15s" "CAPACITY"}}
+	{{- printf "%-10s" "STATUS"}}
+	{{- printf "%-25s" "SERIAL"}}
+	{{- printf "%-20s" "MODEL"}}
+	{{- printf "%-20s" "VENDOR"}}
+{{range .Items}}
+	{{- printf "%-45s" .ObjectMeta.Name}}
+	{{- printf "%-10s" .Spec.Path}}
+	{{- printf "%-15d" .Spec.Capacity.Storage}}
+	{{- printf "%-10s" .Status.State}}
+	{{- printf "%-25s" .Spec.Details.Serial}}
+	{{- printf "%-20s" .Spec.Details.Model}}
+	{{- printf "%-20s" .Spec.Details.Vendor}}
+{{end}}
+{{- else}}
+	{{- printf "%s" "No disk resource present."}}
+{{end}}`
 
 // NewSubCmdListBlockDevice is to list block device is created
 func NewSubCmdListBlockDevice() *cobra.Command {
@@ -32,7 +71,11 @@ func NewSubCmdListBlockDevice() *cobra.Command {
 		Long: `the set of block devices on the node
 		can be listed via 'ndm device list' command`,
 		Run: func(cmd *cobra.Command, args []string) {
-			controller.DeviceList(options.kubeconfig)
+			err := deviceList(options.kubeconfig)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 		},
 	}
 
@@ -45,4 +88,22 @@ func NewSubCmdListBlockDevice() *cobra.Command {
 		`kubeconfig needs to be specified if out of cluster`)
 
 	return getCmd
+}
+
+// deviceList prints list of devices using defaultDeviceList template
+func deviceList(kubeconfig string) error {
+	ctrl, err := controller.NewController(kubeconfig)
+	if err != nil {
+		return err
+	}
+	diskList, err := ctrl.ListDiskResource()
+	if err != nil {
+		return err
+	}
+	diskListTemplate := template.Must(template.New("defaultDeviceList").Parse(defaultDeviceList))
+	err = diskListTemplate.Execute(os.Stdout, diskList)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR removes ndm device list cli command output from pkg/controller. Now it prints using defaultDeviceList template.
* Previous output
```
root@instance-1:~#ndm device list
Path: /dev/sda
Size: 10737418240
Status: Active
Model: PersistentDisk
Serial: instance-1
Vendor: Google

Path: /dev/sdb
Size: 10737418240
Status: Active
Model: PersistentDisk
Serial: disk-1
Vendor: Google
```
* Current output
```
root@instance-1:~#ndm device list
NAME                                         MODEL               VENDOR              SERIAL                   STATUS    PATH      CAPACITY
disk-ccc636c88bd9ab09dde9de476309058d        PersistentDisk      Google              instance-1               Active    /dev/sda  10737418240
disk-ce41f8f5fa22acb79ec56292441dc207        PersistentDisk      Google              disk-1                   Active    /dev/sdb  10737418240
```
```
root@instance-1:~#ndm device list
No disk resource present.
```
This is one improvement mention in #53 