### PR TITLE
Add devlinks(by-id and by-path link) in disk cr 

### DIFF
--- a/cmd/controller/disk_test.go
+++ b/cmd/controller/disk_test.go
@@ -19,19 +19,254 @@ package controller
 import (
 	"testing"
 
+	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs.io/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestToDisk(t *testing.T) {
+/*
+In this unit test case we will create one diskInfo struct with path attribute
+and get path value from getPath() and compare them
+*/
+func TestGetPath(t *testing.T) {
+	diskPath := "sample-disk-path"
 	fakeDiskInfo := NewDiskInfo()
-	fakeDiskInfo.HostName = fakeHostName
-	fakeDiskInfo.Uuid = fakeObjectMeta.Name
-	fakeDiskInfo.Capacity = fakeCapacity.Storage
-	fakeDiskInfo.Model = fakeDetails.Model
-	fakeDiskInfo.Serial = fakeDetails.Serial
-	fakeDiskInfo.Vendor = fakeDetails.Vendor
-	fakeDiskInfo.Path = fakeObj.Path
-	expectedDisk := fakeDr
-	expectedDisk.ObjectMeta.Labels[NDMHostKey] = fakeHostName
-	assert.Equal(t, expectedDisk, fakeDiskInfo.ToDisk())
+	fakeDiskInfo.Path = diskPath
+	tests := map[string]struct {
+		actualPath   string
+		expectedPath string
+	}{
+		"create one diskinfo object and get disk path from it": {actualPath: fakeDiskInfo.getPath(), expectedPath: diskPath},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualPath, test.expectedPath)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock Capacity details
+and get Capacity value from getDiskCapacity() and compare them
+*/
+func TestGetDiskCapacity(t *testing.T) {
+	diskCapacity := uint64(123)
+	// add mock fields in diskInfo struct
+	fakeCapacity := apis.DiskCapacity{}
+	fakeCapacity.Storage = diskCapacity
+
+	// Creating one diskDetails struct using mock value
+	fakeDiskInfo := NewDiskInfo()
+	fakeDiskInfo.Capacity = diskCapacity
+
+	tests := map[string]struct {
+		actualCapacity   apis.DiskCapacity
+		expectedCapacity apis.DiskCapacity
+	}{
+		"create one diskinfo object and get capacity from it": {actualCapacity: fakeDiskInfo.getDiskCapacity(), expectedCapacity: fakeCapacity},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualCapacity, test.expectedCapacity)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get DiskDetails value from getDiskDetails() and compare them
+*/
+func TestGetDiskDetails(t *testing.T) {
+	fakeModel := "disk-model-no"
+	fakeSerial := "disk-serial-no"
+	fakeVendor := "disk-vendor"
+	// add mock fields in diskInfo struct
+	fakeDiskInfo := NewDiskInfo()
+	fakeDiskInfo.Model = fakeModel
+	fakeDiskInfo.Serial = fakeSerial
+	fakeDiskInfo.Vendor = fakeVendor
+
+	// Creating one diskDetails struct using mock value
+	fakeDiskDetails := apis.DiskDetails{}
+	fakeDiskDetails.Model = fakeModel
+	fakeDiskDetails.Serial = fakeSerial
+	fakeDiskDetails.Vendor = fakeVendor
+
+	tests := map[string]struct {
+		actualDetails   apis.DiskDetails
+		expectedDetails apis.DiskDetails
+	}{
+		"create one fakeDiskDetails object and compare it": {actualDetails: fakeDiskInfo.getDiskDetails(), expectedDetails: fakeDiskDetails},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualDetails, test.expectedDetails)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get TypeMeta value from getTypeMeta() and compare them
+*/
+func TestGetTypeMeta(t *testing.T) {
+	fakeDiskInfo := NewDiskInfo()
+	fakeTypeMeta := metav1.TypeMeta{
+		Kind:       NDMKind,
+		APIVersion: NDMVersion,
+	}
+
+	tests := map[string]struct {
+		actualTypeMeta   metav1.TypeMeta
+		expectedTypeMeta metav1.TypeMeta
+	}{
+		"create one mock typeMeta object and comapre it": {actualTypeMeta: fakeDiskInfo.getTypeMeta(), expectedTypeMeta: fakeTypeMeta},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualTypeMeta, test.expectedTypeMeta)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get ObjectMeta value from getObjectMeta() and compare them
+*/
+func TestGetObjectMeta(t *testing.T) {
+	diskUid := "disk-uuid"
+	hostName := "host-name"
+
+	// add mock fields in diskInfo struct
+	fakeDiskInfo := NewDiskInfo()
+	fakeDiskInfo.Uuid = diskUid
+	fakeDiskInfo.HostName = hostName
+
+	//create fakeObjectMeta using mock data
+	fakeObjectMeta := metav1.ObjectMeta{
+		Labels: make(map[string]string),
+		Name:   diskUid,
+	}
+	fakeObjectMeta.Labels[NDMHostKey] = hostName
+
+	tests := map[string]struct {
+		actualObjectMeta   metav1.ObjectMeta
+		expectedObjectMeta metav1.ObjectMeta
+	}{
+		"create one mock objectMeta object and comapre it": {actualObjectMeta: fakeDiskInfo.getObjectMeta(), expectedObjectMeta: fakeObjectMeta},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualObjectMeta, test.expectedObjectMeta)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get ObjectMeta value from getObjectMeta() and compare them
+*/
+func TestGetStatus(t *testing.T) {
+	// add mock fields in diskInfo struct
+	fakeDiskInfo := NewDiskInfo()
+
+	//create fakeObjectMeta using mock data
+	fakeDiskStatus := apis.DiskStatus{
+		State: NDMActive,
+	}
+
+	tests := map[string]struct {
+		actualDiskStatus   apis.DiskStatus
+		expectedDiskStatus apis.DiskStatus
+	}{
+		"create one mock DiskStatus object and comapre it": {actualDiskStatus: fakeDiskInfo.getStatus(), expectedDiskStatus: fakeDiskStatus},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualDiskStatus, test.expectedDiskStatus)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get DiskLinks value from getDiskLinks() and compare them
+*/
+func TestGetDiskLinks(t *testing.T) {
+	fakeByIdLink := "fake-by-Id-link"
+	fakeByPathLink := "fake-by-Path-link"
+	byIdLink := make([]string, 0)
+	byPathLink := make([]string, 0)
+	byIdLink = append(byIdLink, fakeByIdLink)
+	byPathLink = append(byPathLink, fakeByPathLink)
+	// add mock fields in diskInfo struct
+	fakeDiskInfo := NewDiskInfo()
+	fakeDiskInfo.ByIdDevLinks = byIdLink
+	fakeDiskInfo.ByPathDevLinks = byPathLink
+
+	// Creating one DevLink struct using mock value
+	fakeDevLinks := make([]apis.DiskDevLink, 0)
+	fakeByIdLinks := apis.DiskDevLink{
+		Kind:  "by-id",
+		Links: byIdLink,
+	}
+	fakeByPathLinks := apis.DiskDevLink{
+		Kind:  "by-path",
+		Links: byPathLink,
+	}
+	fakeDevLinks = append(fakeDevLinks, fakeByIdLinks)
+	fakeDevLinks = append(fakeDevLinks, fakeByPathLinks)
+
+	tests := map[string]struct {
+		actualDiskLink   []apis.DiskDevLink
+		expectedDiskLink []apis.DiskDevLink
+	}{
+		"create one fakeDevLinks object and compare it": {actualDiskLink: fakeDiskInfo.getDiskLinks(), expectedDiskLink: fakeDevLinks},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.actualDiskLink, test.expectedDiskLink)
+		})
+	}
+}
+
+/*
+In this unit test case we will create one diskInfo struct with mock details
+and get Disk value from ToDisk() and compare them
+*/
+func TestToDisk(t *testing.T) {
+	diskUid := "disk-uuid"
+	hostName := "host-name"
+	fakeDevLinks := make([]apis.DiskDevLink, 0)
+	// add mock fields in diskInfo struct
+	fakeDiskInfo := NewDiskInfo()
+	fakeDiskInfo.Uuid = diskUid
+	fakeDiskInfo.HostName = hostName
+
+	// Creating one Disk struct using mock value
+	expectedDisk := apis.Disk{}
+	fakeTypeMeta := metav1.TypeMeta{
+		Kind:       NDMKind,
+		APIVersion: NDMVersion,
+	}
+	expectedDisk.TypeMeta = fakeTypeMeta
+	fakeObjectMeta := metav1.ObjectMeta{
+		Labels: make(map[string]string),
+		Name:   diskUid,
+	}
+	fakeObjectMeta.Labels[NDMHostKey] = hostName
+	expectedDisk.ObjectMeta = fakeObjectMeta
+	expectedDisk.Spec.DevLinks = fakeDevLinks
+	expectedDisk.Status.State = NDMActive
+
+	tests := map[string]struct {
+		actualDisk   apis.Disk
+		expectedDisk apis.Disk
+	}{
+		"create one diskinfo object and convert it into api.Disk": {actualDisk: fakeDiskInfo.ToDisk(), expectedDisk: expectedDisk}}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedDisk, test.actualDisk)
+		})
+	}
 }

--- a/cmd/controller/mockdata_test.go
+++ b/cmd/controller/mockdata_test.go
@@ -42,6 +42,7 @@ var (
 		Path:     "dev/disk-fake-path",
 		Capacity: fakeCapacity,
 		Details:  fakeDetails,
+		DevLinks: make([]apis.DiskDevLink, 0),
 	}
 	fakeTypeMeta = metav1.TypeMeta{
 		Kind:       NDMKind,
@@ -74,6 +75,7 @@ var (
 		Path:     "dev/disk-fake-path-new",
 		Capacity: newFakeCapacity,
 		Details:  newFakeDetails,
+		DevLinks: make([]apis.DiskDevLink, 0),
 	}
 	newFakeTypeMeta = metav1.TypeMeta{
 		Kind:       NDMKind,

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -47,6 +47,7 @@ func mockEmptyDiskCr() apis.Disk {
 	fakeDr.ObjectMeta = fakeObjectMeta
 	fakeDr.TypeMeta = fakeTypeMeta
 	fakeDr.Status.State = controller.NDMActive
+	fakeDr.Spec.DevLinks = make([]apis.DiskDevLink, 0)
 	return fakeDr
 }
 func TestAddDiskEvent(t *testing.T) {

--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -156,6 +156,8 @@ func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
 	d.Serial = udevDiskDetails.Serial
 	d.Vendor = udevDiskDetails.Vendor
 	d.Capacity = udevDiskDetails.Size
+	d.ByIdDevLinks = udevDiskDetails.ByIdDevLinks
+	d.ByPathDevLinks = udevDiskDetails.ByPathDevLinks
 }
 
 // listen listens for event message over UdevEventMessages channel

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -47,6 +47,24 @@ func mockOsDiskToAPI() (apis.Disk, error) {
 		Capacity: fakeCapacity,
 		Details:  fakeDetails,
 	}
+
+	devLinks := make([]apis.DiskDevLink, 0)
+	if len(mockOsdiskDeails.ByIdDevLinks) != 0 {
+		byIdLinks := apis.DiskDevLink{
+			Kind:  "by-id",
+			Links: mockOsdiskDeails.ByIdDevLinks,
+		}
+		devLinks = append(devLinks, byIdLinks)
+	}
+	if len(mockOsdiskDeails.ByPathDevLinks) != 0 {
+		byPathLinks := apis.DiskDevLink{
+			Kind:  "by-path",
+			Links: mockOsdiskDeails.ByPathDevLinks,
+		}
+		devLinks = append(devLinks, byPathLinks)
+	}
+	fakeObj.DevLinks = devLinks
+
 	fakeTypeMeta := metav1.TypeMeta{
 		Kind:       controller.NDMKind,
 		APIVersion: controller.NDMVersion,
@@ -83,6 +101,8 @@ func TestFillDiskDetails(t *testing.T) {
 	expectedDiskInfo.Serial = mockOsdiskDeails.Serial
 	expectedDiskInfo.Vendor = mockOsdiskDeails.Vendor
 	expectedDiskInfo.Capacity = mockOsdiskDeails.Capacity
+	expectedDiskInfo.ByIdDevLinks = mockOsdiskDeails.ByIdDevLinks
+	expectedDiskInfo.ByPathDevLinks = mockOsdiskDeails.ByPathDevLinks
 	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
 }
 

--- a/pkg/apis/openebs.io/v1alpha1/types.go
+++ b/pkg/apis/openebs.io/v1alpha1/types.go
@@ -21,9 +21,10 @@ type Disk struct {
 
 // DiskSpec is the specification for the disk stored as CRD
 type DiskSpec struct {
-	Path     string       `json:"path"`     //disk path (e.g. /dev/sdb)
-	Capacity DiskCapacity `json:"capacity"` //capacity (e.g. size, used)
-	Details  DiskDetails  `json:"details"`  //disk details (e.g. model, serial)
+	Path     string        `json:"path"`               //Path contain devpath (e.g. /dev/sdb)
+	Capacity DiskCapacity  `json:"capacity"`           //Capacity
+	Details  DiskDetails   `json:"details"`            //Details contains static attributes (model, serial ..)
+	DevLinks []DiskDevLink `json:"devlinks,omitempty"` //DevLinks contains soft links of one disk
 }
 
 type DiskStatus struct {
@@ -34,10 +35,17 @@ type DiskCapacity struct {
 	Storage uint64 `json:"storage"` //disk size in byte
 }
 
+// DiskDetails contains basic and static info of a disk
 type DiskDetails struct {
-	Model  string `json:"model"`  //disk model number
-	Serial string `json:"serial"` //disk serial number
-	Vendor string `json:"vendor"` //disk vendor
+	Model  string `json:"model"`  // Model is model of disk
+	Serial string `json:"serial"` // Serial is serial no of disk
+	Vendor string `json:"vendor"` // Vendor is vendor of disk
+}
+
+// DiskDevlink holds the maping between type and links like by-id type or by-path type link
+type DiskDevLink struct {
+	Kind  string   `json:"kind,omitempty"`  // Kind is the type of link like by-id or by-path.
+	Links []string `json:"links,omitempty"` // Links are the soft links of Type type
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
For each disk by-id and by-path links are created using udev. These links are like -
```
/dev/disk/by-id/scsi-0Google_PersistentDisk_demo-disk
/dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:4:0
```
these are added in Details of Disk cr's spec.
Describe disk -
```
shovan_maity@instance-1:~$ kubectl describe disk disk-ce41f8f5fa22acb79ec56292441dc207
Name:         disk-ce41f8f5fa22acb79ec56292441dc207
Namespace:    
Labels:       kubernetes.io/hostname=instance-1
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-07-11T15:15:18Z
  Generation:          0
  Resource Version:    1076774
  Self Link:           /apis/openebs.io/v1alpha1/disk-ce41f8f5fa22acb79ec56292441dc207
  UID:                 3876eb24-851d-11e8-b1d3-42010a8e0003
Spec:
  Capacity:
    Storage:  10737418240
  Details:
    Model:   PersistentDisk
    Serial:  disk-1
    Vendor:  Google
  Devlinks:
    Kind:  by-id
    Links:
      /dev/disk/by-id/scsi-0Google_PersistentDisk_disk-1
      /dev/disk/by-id/google-disk-1
    Kind:  by-path
    Links:
      /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:2:0
  Path:  /dev/sdb
Status:
  State:  Active
Events:   <none>
```