### PR TITLE
Filter os disk while creating/updating disk cr.

### DIFF
--- a/cmd/controller/filter.go
+++ b/cmd/controller/filter.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/golang/glog"
+)
+
+// Filter contains name, state and filterInterface
+type Filter struct {
+	Name      string          // Name is the name of the filter
+	State     bool            // State is the State of the filter
+	Interface FilterInterface // Interface contains registerd filter
+}
+
+/*
+	ApplyFilter returns true if both any of include() or exclude() returns true.
+	We are having two types of filter function one is inclusion and exclusion type
+	if any of them returns true then filter doesn't want further process of that event.
+*/
+func (f *Filter) ApplyFilter(diskInfo *DiskInfo) bool {
+	return f.Interface.Include(diskInfo) || f.Interface.Exclude(diskInfo)
+
+}
+
+// Start implements FilterInterface's Start()
+func (f *Filter) Start() {
+	f.Interface.Start()
+}
+
+// FilterInterface contains Filters interface and Start()
+type FilterInterface interface {
+	Start()
+	Filters
+}
+
+/*
+	Filters contains Include() and Exclude() filter method. There
+	will be some preset value of include and exclude if passing DiskInfo
+	matches with include value then it returns true if passing DiskINfo
+	does not match with exclude value then it returns false
+*/
+type Filters interface {
+	Include(*DiskInfo) bool // Include returns True if passing DiskInfo matches with include value
+	Exclude(*DiskInfo) bool // exclude returns True if passing DiskInfo does not matche with exclude value
+}
+
+// AddNewFilter adds new filter to controller object
+func (c *Controller) AddNewFilter(filter *Filter) {
+	c.Lock()
+	defer c.Unlock()
+	filters := c.Filters
+	filters = append(filters, filter)
+	c.Filters = filters
+	glog.Info(filter.Name, " applied")
+}
+
+// ListFilter returns list of active filters associated with controller object
+func (c *Controller) ListFilter() []*Filter {
+	c.Lock()
+	defer c.Unlock()
+	listFilter := make([]*Filter, 0)
+	for _, filter := range c.Filters {
+		if filter.State {
+			listFilter = append(listFilter, filter)
+		}
+	}
+	return listFilter
+}
+
+// ApplyFilter checks status for every registered filters if any of the filters
+// wants to stop further process of the event it returns true else it returns false
+func (c *Controller) ApplyFilter(diskDetails *DiskInfo) bool {
+	for _, filter := range c.ListFilter() {
+		if filter.ApplyFilter(diskDetails) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/controller/filter_test.go
+++ b/cmd/controller/filter_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var matchDiskUuid = "fake-match-uuid"
+
+type fakeFilter struct{}
+
+func (f *fakeFilter) Start() {
+	messageChannel <- message
+}
+
+func (f *fakeFilter) Include(fakeDiskInfo *DiskInfo) bool {
+	return fakeDiskInfo.Uuid == matchDiskUuid
+}
+
+func (f *fakeFilter) Exclude(fakeDiskInfo *DiskInfo) bool {
+	return false
+}
+
+//Add one new filter and get the list of the filters and match them
+func TestAddNewFilter(t *testing.T) {
+	filters := make([]*Filter, 0)
+	expectedFilterList := make([]*Filter, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &Controller{
+		Filters: filters,
+		Mutex:   mutex,
+	}
+	filter := &fakeFilter{}
+	filter1 := &Filter{
+		Name:      "filter1",
+		State:     true,
+		Interface: filter,
+	}
+	fakeController.AddNewFilter(filter1)
+	expectedFilterList = append(expectedFilterList, filter1)
+	tests := map[string]struct {
+		actualFilterList   []*Filter
+		expectedFilterList []*Filter
+	}{
+		"add one filter and check if it is present or not": {actualFilterList: fakeController.Filters, expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}
+
+//Add some new filters and get the list of the filters and match them
+func TestListFilter(t *testing.T) {
+	filters := make([]*Filter, 0)
+	expectedFilterList := make([]*Filter, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &Controller{
+		Filters: filters,
+		Mutex:   mutex,
+	}
+	filter := &fakeFilter{}
+	filter1 := &Filter{
+		Name:      "probe1",
+		State:     true,
+		Interface: filter,
+	}
+	filter2 := &Filter{
+		Name:      "filter2",
+		State:     true,
+		Interface: filter,
+	}
+	fakeController.AddNewFilter(filter1)
+	fakeController.AddNewFilter(filter2)
+	expectedFilterList = append(expectedFilterList, filter1)
+	expectedFilterList = append(expectedFilterList, filter2)
+	tests := map[string]struct {
+		actualFilterList   []*Filter
+		expectedFilterList []*Filter
+	}{
+		"add some filters and check if they are present or not": {actualFilterList: fakeController.ListFilter(), expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}
+
+func TestSrartFilter(t *testing.T) {
+	var msg1 string
+	filter := &fakeFilter{}
+	filter1 := &Filter{
+		Name:      "filter1",
+		State:     true,
+		Interface: filter,
+	}
+	go filter1.Start()
+	select {
+	case res := <-messageChannel:
+		msg1 = res
+	case <-time.After(1 * time.Second):
+		msg1 = ""
+	}
+
+	tests := map[string]struct {
+		actualMessage   string
+		expectedMessage string
+	}{
+		"comparing message from start method of filter": {actualMessage: msg1, expectedMessage: message},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedMessage, test.actualMessage)
+		})
+	}
+}
+
+func TestShouldIgnore(t *testing.T) {
+	fakeFilter := &fakeFilter{}
+	filter := &Filter{
+		Name:      "filter1",
+		State:     true,
+		Interface: fakeFilter,
+	}
+	disk := &DiskInfo{}
+	tests := map[string]struct {
+		actual   bool
+		expected bool
+	}{
+		"comparing return of ApplyFilter": {actual: filter.ApplyFilter(disk), expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.actual)
+		})
+	}
+}
+
+func TestShouldProcess(t *testing.T) {
+	filters := make([]*Filter, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &Controller{
+		Filters: filters,
+		Mutex:   mutex,
+	}
+	fakeFilter := &fakeFilter{}
+	filter := &Filter{
+		Name:      "probe1",
+		State:     true,
+		Interface: fakeFilter,
+	}
+	fakeController.AddNewFilter(filter)
+	disk1 := &DiskInfo{}
+	disk2 := &DiskInfo{}
+	disk2.Uuid = matchDiskUuid
+	tests := map[string]struct {
+		disk     *DiskInfo
+		actual   bool
+		expected bool
+	}{
+		"comparing return of ApplyFilter for disk1": {actual: fakeController.ApplyFilter(disk1), expected: false},
+		"comparing return of ApplyFilter for disk2": {actual: fakeController.ApplyFilter(disk2), expected: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.actual)
+		})
+	}
+}

--- a/cmd/controller/probe.go
+++ b/cmd/controller/probe.go
@@ -30,10 +30,10 @@ type EventMessage struct {
 
 // Probe contains name, state and probeinterface
 type Probe struct {
-	Priority   int
-	ProbeName  string
-	ProbeState bool
-	Interface  ProbeInterface
+	Priority  int
+	Name      string
+	State     bool
+	Interface ProbeInterface
 }
 
 // Start implements ProbeInterface's Start()
@@ -79,7 +79,7 @@ func (c *Controller) AddNewProbe(probe *Probe) {
 	probes = append(probes, probe)
 	sort.Sort(sortableProbes(probes))
 	c.Probes = probes
-	glog.Info("configured ", probe.ProbeName)
+	glog.Info("configured ", probe.Name)
 }
 
 // ListProbe returns list of active probe associated with controller object
@@ -88,9 +88,19 @@ func (c *Controller) ListProbe() []*Probe {
 	defer c.Unlock()
 	listProbe := make([]*Probe, 0)
 	for _, probe := range c.Probes {
-		if probe.ProbeState {
+		if probe.State {
 			listProbe = append(listProbe, probe)
 		}
 	}
 	return listProbe
+}
+
+// FillDiskDetails lists registered probes and fills details from each probe
+func (c *Controller) FillDiskDetails(diskDetails *DiskInfo) {
+	diskDetails.HostName = c.HostName
+	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
+	probes := c.ListProbe()
+	for _, probe := range probes {
+		probe.FillDiskDetails(diskDetails)
+	}
 }

--- a/cmd/filter/filter.go
+++ b/cmd/filter/filter.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/cmd/controller"
+)
+
+const (
+	defaultEnabled  = true  // use in each filter to make it enable.
+	defaultDisabled = false // use in each filter to make it disable.
+)
+
+// RegisterdFilters contains register function of filters which we want to register
+var RegisterdFilters = []func(){oSDiskExludeFilterRegister}
+
+type registerFilter struct {
+	name       string
+	state      bool
+	fi         controller.FilterInterface
+	controller *controller.Controller
+}
+
+// register called by register function of each filter it will check for filter
+// status if it is enabled then it will call Start() of that filter.
+func (rf *registerFilter) register() {
+	newFilter := &controller.Filter{
+		Name:      rf.name,
+		State:     rf.state,
+		Interface: rf.fi,
+	}
+	rf.controller.AddNewFilter(newFilter)
+	if rf.state {
+		rf.fi.Start()
+	}
+}
+
+// Start() starts registration of filters present in RegisteredFilters
+func Start(registerdFilters []func()) {
+	glog.Info("registering filters")
+	for _, filter := range registerdFilters {
+		filter()
+	}
+}

--- a/cmd/filter/filter_test.go
+++ b/cmd/filter/filter_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeFilter struct {
+	ctrl *controller.Controller
+}
+
+func (f *fakeFilter) Start() {}
+
+func (f *fakeFilter) Include(*controller.DiskInfo) bool {
+	return false
+}
+func (f *fakeFilter) Exclude(*controller.DiskInfo) bool {
+	return true
+}
+
+//Add one new filter and get the list of the filters and match them
+func TestRegisterFilter(t *testing.T) {
+	expectedFilterList := make([]*controller.Filter, 0)
+	filters := make([]*controller.Filter, 0)
+	mutex := &sync.Mutex{}
+	fakeController := &controller.Controller{
+		Filters: filters,
+		Mutex:   mutex,
+	}
+	var i controller.FilterInterface = &fakeFilter{}
+	newPrgisterFilter := &registerFilter{
+		name:       "filter-1",
+		state:      true,
+		fi:         i,
+		controller: fakeController,
+	}
+	newPrgisterFilter.register()
+	filter := &controller.Filter{
+		Name:      newPrgisterFilter.name,
+		State:     newPrgisterFilter.state,
+		Interface: newPrgisterFilter.fi,
+	}
+	expectedFilterList = append(expectedFilterList, filter)
+	tests := map[string]struct {
+		actualFilterList   []*controller.Filter
+		expectedFilterList []*controller.Filter
+	}{
+		"add one filter and check if it is present or not": {actualFilterList: fakeController.Filters, expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}
+
+func TestStart(t *testing.T) {
+	expectedFilterList := make([]*controller.Filter, 0)
+	fakeController := &controller.Controller{
+		Filters: make([]*controller.Filter, 0),
+		Mutex:   &sync.Mutex{},
+	}
+	go func() {
+		controller.ControllerBroadcastChannel <- fakeController
+	}()
+	var fakeFilterRegister = func() {
+		ctrl := <-controller.ControllerBroadcastChannel
+		if ctrl == nil {
+			t.Fatal("controller struct should not be nil")
+		}
+		var fi controller.FilterInterface = &fakeFilter{ctrl: ctrl}
+		newPrgisterFilter := &registerFilter{
+			name:       "fake-filter",
+			state:      defaultEnabled,
+			fi:         fi,
+			controller: ctrl,
+		}
+		newPrgisterFilter.register()
+	}
+	var registerdFilters = []func(){fakeFilterRegister}
+	Start(registerdFilters)
+	var fi controller.FilterInterface = &fakeFilter{ctrl: fakeController}
+	filter := &controller.Filter{
+		Name:      "fake-filter",
+		State:     defaultEnabled,
+		Interface: fi,
+	}
+	expectedFilterList = append(expectedFilterList, filter)
+	tests := map[string]struct {
+		actualFilterList   []*controller.Filter
+		expectedFilterList []*controller.Filter
+	}{
+		"register one filter and check if it is present or not": {actualFilterList: fakeController.Filters, expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}

--- a/cmd/filter/osdiskexludefilter.go
+++ b/cmd/filter/osdiskexludefilter.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	"github.com/openebs/node-disk-manager/pkg/util"
+)
+
+const (
+	oSDiskExludeFilterName  = "os disk exlude filter" // filter name
+	oSDiskExludeFilterState = defaultEnabled          // filter state
+)
+
+var (
+	defaultMountFilePath = "/proc/self/mounts"
+	mountPoints          = []string{"/", "/etc/hosts"}
+	hostMountFilePath    = "/host/mounts" // hostMountFilePath is the file path mounted inside container
+)
+
+// oSDiskExludeFilterRegister contains registration process of oSDiskExludeFilter
+var oSDiskExludeFilterRegister = func() {
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		return
+	}
+	var fi controller.FilterInterface = newNonOsDiskFilter(ctrl)
+	newPrgisterFilter := &registerFilter{
+		name:       oSDiskExludeFilterName,
+		state:      oSDiskExludeFilterState,
+		fi:         fi,
+		controller: ctrl,
+	}
+	newPrgisterFilter.register()
+}
+
+// oSDiskExludeFilter controller and path of os disk
+type oSDiskExludeFilter struct {
+	controller     *controller.Controller
+	excludeDevPath string
+}
+
+// newOsDiskFilter returns new pointer osDiskFilter
+func newNonOsDiskFilter(ctrl *controller.Controller) *oSDiskExludeFilter {
+	return &oSDiskExludeFilter{
+		controller: ctrl,
+	}
+}
+
+// Start set os disk devPath in nonOsDiskFilter pointer
+func (odf *oSDiskExludeFilter) Start() {
+	/*
+		process1 check for mentioned mountpoint in host's /proc/1/mounts file
+		host's /proc/1/mounts file mounted inside container it checks for
+		every mentioned mountpoints if it is able to get parent disk's devpath
+		it adds it in Controller struct and make isOsDiskFilterSet true
+	*/
+	for _, mountPoint := range mountPoints {
+		mountPointUtil := util.NewMountUtil(hostMountFilePath, mountPoint)
+		if devPath, err := mountPointUtil.GetDiskPath(); err == nil {
+			odf.excludeDevPath = devPath
+			return
+		}
+	}
+	/*
+		process2 check for mountpoints in /proc/self/mounts file if it is able to get
+		disk's path of it adds it in Controller struct and make isOsDiskFilterSet true
+	*/
+	for _, mountPoint := range mountPoints {
+		mountPointUtil := util.NewMountUtil(defaultMountFilePath, mountPoint)
+		if devPath, err := mountPointUtil.GetDiskPath(); err == nil {
+			odf.excludeDevPath = devPath
+			return
+		}
+	}
+	glog.Error("unable to apply os disk filter")
+}
+
+// Include contains nothing by default it returns false
+func (odf *oSDiskExludeFilter) Include(d *controller.DiskInfo) bool {
+	return false
+}
+
+// Exclude returns true if disk devpath matches with excludeDevPath
+func (odf *oSDiskExludeFilter) Exclude(d *controller.DiskInfo) bool {
+	return odf.excludeDevPath != d.Path
+}

--- a/cmd/filter/osdiskexludefilter_test.go
+++ b/cmd/filter/osdiskexludefilter_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOsDiskFilterRegister(t *testing.T) {
+	diskDetails, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedFilterList := make([]*controller.Filter, 0)
+	fakeController := &controller.Controller{
+		Filters: make([]*controller.Filter, 0),
+		Mutex:   &sync.Mutex{},
+	}
+	go func() {
+		controller.ControllerBroadcastChannel <- fakeController
+	}()
+	oSDiskExludeFilterRegister()
+	var fi controller.FilterInterface = &oSDiskExludeFilter{
+		controller:     fakeController,
+		excludeDevPath: diskDetails.DevNode,
+	}
+	filter := &controller.Filter{
+		Name:      oSDiskExludeFilterName,
+		State:     oSDiskExludeFilterState,
+		Interface: fi,
+	}
+	expectedFilterList = append(expectedFilterList, filter)
+	tests := map[string]struct {
+		actualFilterList   []*controller.Filter
+		expectedFilterList []*controller.Filter
+	}{
+		"add one filter and check if it is present or not": {actualFilterList: fakeController.Filters, expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}
+
+func TestExclude(t *testing.T) {
+	fakeDiskUuid := "fake-disk-path"
+	fakeOsDiskFilter := oSDiskExludeFilter{excludeDevPath: fakeDiskUuid}
+	disk1 := &controller.DiskInfo{}
+	disk2 := &controller.DiskInfo{}
+	disk1.Path = fakeDiskUuid
+	tests := map[string]struct {
+		disk     *controller.DiskInfo
+		actual   bool
+		expected bool
+	}{
+		"comparing return of Exclude for disk1": {actual: fakeOsDiskFilter.Exclude(disk1), expected: false},
+		"comparing return of Exclude for disk2": {actual: fakeOsDiskFilter.Exclude(disk2), expected: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.actual)
+		})
+	}
+}
+
+func TestInclude(t *testing.T) {
+	fakeDiskUuid := "fake-disk-path"
+	fakeOsDiskFilter := oSDiskExludeFilter{excludeDevPath: fakeDiskUuid}
+	disk1 := &controller.DiskInfo{}
+	disk2 := &controller.DiskInfo{}
+	disk1.Path = fakeDiskUuid
+	tests := map[string]struct {
+		disk     *controller.DiskInfo
+		actual   bool
+		expected bool
+	}{
+		"comparing return of Include for disk1": {actual: fakeOsDiskFilter.Include(disk1), expected: false},
+		"comparing return of Include for disk2": {actual: fakeOsDiskFilter.Include(disk2), expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.actual)
+		})
+	}
+}

--- a/cmd/probe/probe.go
+++ b/cmd/probe/probe.go
@@ -26,30 +26,36 @@ const (
 	defaultDisabled = false // use in each probe to make it disable.
 )
 
+// RegisterdProbes contains register function of probes which we want to register
+var RegisterdProbes = []func(){udevProbeRegister, smartProbeRegister}
+
 type registerProbe struct {
-	priority       int
-	probeName      string
-	probeState     bool
-	probeInterface controller.ProbeInterface
-	controller     *controller.Controller
+	priority   int
+	name       string
+	state      bool
+	pi         controller.ProbeInterface
+	controller *controller.Controller
 }
 
-// registerProbe called by init() of each probe it will check for probe status
-// if it is enabled then it will call Start() of that probe.
+// register called by register function of each probe it will check for probe
+// status if it is enabled then it will call Start() of that probe.
 func (rp *registerProbe) register() {
 	newProbe := &controller.Probe{
-		Priority:   rp.priority,
-		ProbeName:  rp.probeName,
-		ProbeState: rp.probeState,
-		Interface:  rp.probeInterface,
+		Priority:  rp.priority,
+		Name:      rp.name,
+		State:     rp.state,
+		Interface: rp.pi,
 	}
 	rp.controller.AddNewProbe(newProbe)
-	if rp.probeState {
-		rp.probeInterface.Start()
+	if rp.state {
+		rp.pi.Start()
 	}
 }
 
-// Start() is called to invoke all init functions of each specific probe.
-func Start() {
-	glog.Info("starting probe")
+// Start() starts registration of probes present in RegisteredProbes
+func Start(registerdProbes []func()) {
+	glog.Info("registering probes")
+	for _, probe := range registerdProbes {
+		probe()
+	}
 }

--- a/cmd/probe/smartprobe.go
+++ b/cmd/probe/smartprobe.go
@@ -38,25 +38,23 @@ const (
 )
 
 // init is used to get a controller object and then register itself
-func init() {
-	go func() {
-		// Get a controller object
-		ctrl := <-controller.ControllerBroadcastChannel
-		if ctrl == nil {
-			glog.Error("unable to configure", smartProbeName)
-			return
-		}
-		var pi controller.ProbeInterface = &smartProbe{Controller: ctrl}
-		newPrgisterProbe := &registerProbe{
-			priority:       smartProbePriority,
-			probeName:      smartProbeName,
-			probeState:     smartProbeState,
-			probeInterface: pi,
-			controller:     ctrl,
-		}
-		// Here we register the probe (smart probe in this case)
-		newPrgisterProbe.register()
-	}()
+var smartProbeRegister = func() {
+	// Get a controller object
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		glog.Error("unable to configure", smartProbeName)
+		return
+	}
+	var pi controller.ProbeInterface = &smartProbe{Controller: ctrl}
+	newPrgisterProbe := &registerProbe{
+		priority:   smartProbePriority,
+		name:       smartProbeName,
+		state:      smartProbeState,
+		pi:         pi,
+		controller: ctrl,
+	}
+	// Here we register the probe (smart probe in this case)
+	newPrgisterProbe.register()
 }
 
 // newSmartProbe returns smartProbe struct which helps populate diskInfo struct

--- a/cmd/probe/smartprobe_test.go
+++ b/cmd/probe/smartprobe_test.go
@@ -116,26 +116,36 @@ func TestSmartProbe(t *testing.T) {
 	fakeNdmClient := ndmFakeClientset.NewSimpleClientset()
 	fakeKubeClient := fake.NewSimpleClientset()
 	probes := make([]*controller.Probe, 0)
+	filters := make([]*controller.Filter, 0)
 	mutex := &sync.Mutex{}
 	fakeController := &controller.Controller{
 		HostName:      fakeHostName,
 		KubeClientset: fakeKubeClient,
 		Clientset:     fakeNdmClient,
-		Probes:        probes,
 		Mutex:         mutex,
+		Probes:        probes,
+		Filters:       filters,
 	}
 
 	smartProbe := newSmartProbe("fakeController")
 	var pi controller.ProbeInterface = smartProbe
 
 	newPrgisterProbe := &registerProbe{
-		priority:       1,
-		probeName:      "smart probe",
-		probeState:     true,
-		probeInterface: pi,
-		controller:     fakeController,
+		priority:   1,
+		name:       "smart probe",
+		state:      true,
+		pi:         pi,
+		controller: fakeController,
 	}
 	newPrgisterProbe.register()
+	//add one filter
+	filter := &alwaysTrueFilter{}
+	filter1 := &controller.Filter{
+		Name:      "filter1",
+		State:     true,
+		Interface: filter,
+	}
+	fakeController.AddNewFilter(filter1)
 
 	probeEvent := &ProbeEvent{
 		Controller: fakeController,

--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -31,23 +31,22 @@ const (
 	udevProbePriority = 1
 )
 
-func init() {
-	go func() {
-		ctrl := <-controller.ControllerBroadcastChannel
-		if ctrl == nil {
-			glog.Error("unable to configure", udevProbeName)
-			return
-		}
-		var pi controller.ProbeInterface = newUdevProbe(ctrl)
-		newPrgisterProbe := &registerProbe{
-			priority:       udevProbePriority,
-			probeName:      udevProbeName,
-			probeState:     udevProbeState,
-			probeInterface: pi,
-			controller:     ctrl,
-		}
-		newPrgisterProbe.register()
-	}()
+// udevProbeRegister contains registration process of udev probe
+var udevProbeRegister = func() {
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		glog.Error("unable to configure", udevProbeName)
+		return
+	}
+	var pi controller.ProbeInterface = newUdevProbe(ctrl)
+	newPrgisterProbe := &registerProbe{
+		priority:   udevProbePriority,
+		name:       udevProbeName,
+		state:      udevProbeState,
+		pi:         pi,
+		controller: ctrl,
+	}
+	newPrgisterProbe.register()
 }
 
 // udevProbe contains require variables for scan , populate diskInfo and push

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -96,6 +96,8 @@ spec:
         volumeMounts:
         - name: udev
           mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/mounts
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -107,3 +109,8 @@ spec:
         hostPath:
           path: /run/udev
           type: Directory
+      - name: procmount
+      # mount /proc/1/mounts (mount file of process 1 of host) inside container
+      # to read which partition is mounted on / path
+        hostPath:
+          path: /proc/1/mounts

--- a/pkg/util/mountutil.go
+++ b/pkg/util/mountutil.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// MountUtil contains mount point and mount file attributes
+// It helps to find which partition is mounted on given mount point
+type MountUtil struct {
+	FilePath   string // FilePath is the path of mounts file like -/proc/self/mounts
+	MountPoint string // MountPoint is mount points like - / /var ...
+}
+
+// NewMountUtil returns MountUtil struct for given mounts file path and mount point
+func NewMountUtil(filePath, mountPoint string) MountUtil {
+	MountUtil := MountUtil{
+		FilePath:   filePath,
+		MountPoint: mountPoint,
+	}
+	return MountUtil
+}
+
+// GetDiskPath returns os disk devpath
+func (m MountUtil) GetDiskPath() (string, error) {
+	partition, err := m.getPartitionName()
+	if err != nil {
+		return "", err
+	}
+	devPath, err := getDiskDevPath(partition)
+	if err != nil {
+		return "", err
+	}
+	_, err = filepath.EvalSymlinks(devPath)
+	if err != nil {
+		return "", err
+	}
+	return devPath, err
+}
+
+// getPartitionName read mounts file and returns partition name which is mounted on mount point
+func (m MountUtil) getPartitionName() (string, error) {
+	// Read file from filepath and get which partition is mounted on given mount point
+	file, err := os.Open(m.FilePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		/*
+			read each line of given file in below format -
+			/dev/sda4 / ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
+			/dev/sda4 /var/lib/docker/aufs ext4 rw,relatime,errors=remount-ro,data=ordered 0 0
+			1st entry is partition or file system 2nd is mount point
+		*/
+		if parts := strings.Split(line, " "); parts[1] == m.MountPoint {
+			// /dev/ by default added with partition name we wnat to get only sda1 / sdc2 ..
+			return strings.Replace(parts[0], "/dev/", "", 1), nil
+		}
+	}
+	return "", errors.New("error while geting os partition name")
+}
+
+/*
+	getDiskSysPath takes disk/partition name as input (sda, sda1, sdb, sdb2 ...) and
+	returns syspath of that disk from which we can generate ndm given uuid of that disk.
+*/
+func getDiskDevPath(partition string) (string, error) {
+	// dev path be like /dev/sda4 we need to remove /dev/ from this string to get sys block path.
+	var diskName string
+	softlink := "/sys/class/block/" + partition
+	link, err := filepath.EvalSymlinks(softlink)
+	if err != nil {
+		return "", err
+	}
+	/*
+		link looks - /sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda4
+		parent disk is present after block then partition of that disk
+	*/
+	parts := strings.Split(link, "/")
+	for i, part := range parts {
+		if part == "block" {
+			diskName = parts[i+1]
+			break
+		}
+	}
+	return "/dev/" + diskName, nil
+}

--- a/pkg/util/mountutil_test.go
+++ b/pkg/util/mountutil_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOsDiskPath(t *testing.T) {
+	filePath := "/proc/self/mounts"
+	mountPointUtil := NewMountUtil(filePath, "/")
+	path, err := mountPointUtil.GetDiskPath()
+	tests := map[string]struct {
+		actualPath    string
+		actualError   error
+		expectedError error
+	}{
+		"test case for os disk path": {actualPath: path, actualError: err, expectedError: nil},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := filepath.EvalSymlinks(test.actualPath)
+			if err != nil {
+				t.Error(err)
+			}
+			assert.Equal(t, test.expectedError, test.actualError)
+		})
+	}
+}
+
+func TestGetOsPartitionName(t *testing.T) {
+	filePath := "/tmp/data"
+	mountPoint := "/"
+	fileContent1 := []byte("/dev/sda4 / ext4 rw,relatime,errors=remount-ro,data=ordered 0 0")
+	fileContent2 := []byte("/dev/sda4 /newpath ext4 rw,relatime,errors=remount-ro,data=ordered 0 0")
+	expectedErr2 := errors.New("error while geting os partition name")
+
+	tests := map[string]struct {
+		fileContent   []byte
+		osPartition   string
+		expectedError error
+	}{
+		"/ path present":     {fileContent: fileContent1, osPartition: "sda4", expectedError: nil},
+		"/ path not present": {fileContent: fileContent2, osPartition: "", expectedError: expectedErr2},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ioutil.WriteFile(filePath, test.fileContent, 0644)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mountPointUtil := MountUtil{
+				FilePath:   filePath,
+				MountPoint: mountPoint,
+			}
+			partName, err := mountPointUtil.getPartitionName()
+			assert.Equal(t, test.osPartition, partName)
+			assert.Equal(t, test.expectedError, err)
+			os.Remove(filePath)
+		})
+	}
+	// Test case for invalid file path
+	mountPointUtil := MountUtil{
+		FilePath:   filePath,
+		MountPoint: mountPoint,
+	}
+	_, err := mountPointUtil.getPartitionName()
+	if err == nil {
+		t.Fatal("error should not be nil for invalid path")
+	}
+}

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -23,13 +23,15 @@ spec:
         command:
         - /usr/sbin/ndm
         - start
-        image: openebs/node-disk-manager-amd64:latest
+        image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: Always
         securityContext:
           privileged: true
         volumeMounts:
         - name: udev
           mountPath: /run/udev
+        - name: procmount
+          mountPath: /host/mounts
         env:
         - name: NODE_NAME
           valueFrom:
@@ -40,4 +42,8 @@ spec:
         hostPath:
           path: /run/udev
           type: Directory
-
+      - name: procmount
+      # mount /proc/1/mounts (mount file of process 1 of host) inside container
+      # to read which partition is mounted on / path
+        hostPath:
+          path: /proc/1/mounts


### PR DESCRIPTION
This PR contains plugable filter concept and os disk filter.
Filter interface is implemented in this PR.
In `Start()` of each filter we set range of check variables for that filter.
In `Include(*DiskInfo) bool` if property of disk matches with include value it returns true.
In `Exclude(*DiskInfo) bool` if property of disk does not match with exclude value it returns true.
If any of `Include()` or `Exclude()` returns true filter returns true.

**special notes for reviewer** -
I removed package level init for registering probes and filters. If I do like that then we will lost control of registering order as all of them are as go routine. And we want to register all filters then all probes so I have made separate register method of each probe and filters.

**Implementation steps** -
1. read `/proc/self/mounts` and find which partition is mounted on `/` path `ie - sda2`
2. read link `/sys/class/block/[partition-name]` ie - ```/sys/class/block/sda2```
this link looks like - 
```/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2```
read `/` separated entry after ```block``` that is os disk name
3. we need to mount `/proc/self/mounts` inside container if we use self it points to currently running process so content of that file getting changed for that. We need to `mount /proc/1/mounts` this is the proc file of process 1 of host/node.
4. If process 3 is not able to get OS Disk uuid then it search for ```/etc/hosts``` mount point of containers ```/proc/self/mounts``` file. suppose ```/dev/sdc1``` on host is ```/var```, which is where ```/var/lib/docker``` resides and where Docker keeps certain data, such as the hosts file allocated to container. The hosts file is exposed as a bind mount inside the container at ```/etc/hosts``` mount point:
5. one new attribute IgnoreDiskUuid added in Controller struct at the time of event processing if the uuid of the disk is present in IgnoreDiskUuid then that event will not processed by event handler.
6. as a part of creating controller struct all ignored disk's uuid added in IgnoreDiskUuid field of Controller struct and cr creation of these disk is ignored.


For details - [Design doc](https://docs.google.com/document/d/1uyul5Sb6LL5PfXBE7tOUa4jSVLk-aPutZuP8kGRjGX0)