### PR TITLE
Order by-id links in disk cr

### DIFF
--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -39,6 +39,8 @@ const (
 	UDEV_PATH           = "DEVPATH"         // udev attribute to get device path
 	UDEV_WWN            = "ID_WWN"          // udev attribute to get device WWN number
 	UDEV_SERIAL         = "ID_SERIAL_SHORT" // udev attribute to get device serial number
+	UDEV_SERIAL_FULL    = "ID_SERIAL"       // udev attribute to get - separated vendor, model, serial
+	UDEV_BUS            = "ID_BUS"          // udev attribute to get bus name
 	UDEV_MODEL          = "ID_MODEL"        // udev attribute to get device model number
 	UDEV_VENDOR         = "ID_VENDOR"       // udev attribute to get device vendor details
 	UDEV_TYPE           = "ID_TYPE"         // udev attribute to get device type
@@ -53,9 +55,10 @@ const (
 	UDEV_SOURCE         = "udev"            // udev source constant
 	UDEV_SYSPATH_PREFIX = "/sys/dev/block/" // udev syspath prefix
 	UDEV_DEVNAME        = "DEVNAME"         // udev attrinute contain disk name given by kernel
-	UDEV_DEVLINKS       = "DEVLINKS"        //udev attrinute contain devlinks of a disk
+	UDEV_DEVLINKS       = "DEVLINKS"        // udev attrinute contain devlinks of a disk
 	BY_ID_LINK          = "by-id"           // by-path devlink contains this string
 	BY_PATH_LINK        = "by-path"         // by-path devlink contains this string
+	LINK_ID_INDEX       = 4                 // this is used to get link index from dev link
 )
 
 // UdevDiskDetails struct contain different attribute of disk.
@@ -143,9 +146,23 @@ func (device *UdevDevice) GetDevLinks() map[string][]string {
 	byIdLink := make([]string, 0)
 	byPathLink := make([]string, 0)
 	for _, link := range strings.Split(device.GetPropertyValue(UDEV_DEVLINKS), " ") {
+		/*
+			devlink is like - /dev/disk/by-id/scsi-0Google_PersistentDisk_demo-disk
+			parts = ["", "dev", "disk", "by-id", "scsi-0Google_PersistentDisk_demo-disk"]
+			parts[4] contains link index like model or wwn or sysPath (wwn-0x5000c5009e3a8d2b) (ata-ST500LM021-1KJ152_W6HFGR)
+		*/
 		parts := strings.Split(link, "/")
 		if util.Contains(parts, BY_ID_LINK) {
-			byIdLink = append(byIdLink, link)
+			/*
+				A default by-id link is observed to be created for all types of disks (physical, virtual and cloud).
+				This link has the format - bus, vendor, model, serial - all appended in the same order. Keeping this
+				link as the first element of array for consistency purposes.
+			*/
+			if strings.HasPrefix(parts[LINK_ID_INDEX], device.GetPropertyValue(UDEV_BUS)) && strings.HasSuffix(parts[LINK_ID_INDEX], device.GetPropertyValue(UDEV_SERIAL_FULL)) {
+				byIdLink = append([]string{link}, byIdLink...)
+			} else {
+				byIdLink = append(byIdLink, link)
+			}
 		}
 		if util.Contains(parts, BY_PATH_LINK) {
 			byPathLink = append(byPathLink, link)


### PR DESCRIPTION
by-id links were not in order in disk cr
This PR arrange them below order-
```
1. by-id link which contains serial no and bus
2. others links(if present)
```
DevLinks section of Disk CR
```
  Devlinks:
    Kind:  by-id
    Links:
      /dev/disk/by-id/scsi-0Google_PersistentDisk_ganesh-disk4
      /dev/disk/by-id/google-ganesh-disk4
    Kind:  by-path
    Links:
      /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:6:0
```