### PR TITLE
Include support for creating sparse file

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -31,12 +31,17 @@ import (
 )
 
 const (
-	NDMKind     = "Disk"                   // NDMKind is the CR kind.
-	NDMVersion  = "openebs.io/v1alpha1"    // NDMVersion is the CR version.
-	NDMHostKey  = "kubernetes.io/hostname" // NDMHostKey is host name label prefix.
-	NDMActive   = "Active"                 // NDMActive is constant for active resource status.
-	NDMInactive = "Inactive"               // NDMInactive is constant for inactive resource status.
-	NDMUnknown  = "Unknown"                // NDMUnknown is constant for resource unknown satus.
+	NDMKind        = "Disk"                   // NDMKind is the CR kind.
+	NDMVersion     = "openebs.io/v1alpha1"    // NDMVersion is the CR version.
+	NDMHostKey     = "kubernetes.io/hostname" // NDMHostKey is host name label prefix.
+	NDMActive      = "Active"                 // NDMActive is constant for active resource status.
+	NDMInactive    = "Inactive"               // NDMInactive is constant for inactive resource status.
+	NDMUnknown     = "Unknown"                // NDMUnknown is constant for resource unknown satus.
+	NDMDiskTypeKey = "ndm.io/disk-type"       // NDMDiskTypeKey specifies the type of disk
+)
+
+const (
+	NDMDefaultDiskType = "disk" // NDMDefaultDiskType will be used to initialize the disk type
 )
 
 // ControllerBroadcastChannel is used to send a copy of controller object to each probe.
@@ -130,6 +135,7 @@ func (c *Controller) setNodeName() error {
 
 // Start is called when we execute cli command ndm start.
 func (c *Controller) Start() {
+	c.InitializeSparseFiles()
 	// set up signals so we handle the first shutdown signal gracefully
 	stopCh := signals.SetupSignalHandler()
 	if err := c.run(2, stopCh); err != nil {

--- a/cmd/controller/disk.go
+++ b/cmd/controller/disk.go
@@ -41,6 +41,7 @@ type DiskInfo struct {
 	FirmwareRevision  string          // FirmwareRevision is the firmware revision for a disk
 	LogicalSectorSize uint32          // LogicalSectorSize is the Logical size of a disk in bytes
 	SPCVersion        string          // SPCVersion is implemented specifications version i.e. SPC-1, SPC-2, etc
+	DiskType          string          // DiskType represents the type of disk like Disk, Sparse etc.,
 }
 
 // ProbeIdentifier contains some keys to enable probes to uniquely identify each disk.
@@ -63,6 +64,7 @@ type ProbeIdentifier struct {
 // populate some specific fields of DiskInfo struct.
 func NewDiskInfo() *DiskInfo {
 	diskInfo := &DiskInfo{}
+	diskInfo.DiskType = NDMDefaultDiskType
 	return diskInfo
 }
 
@@ -84,6 +86,7 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 		Name:   di.Uuid,
 	}
 	objectMeta.Labels[NDMHostKey] = di.HostName
+	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
 	return objectMeta
 }
 

--- a/cmd/controller/disk_test.go
+++ b/cmd/controller/disk_test.go
@@ -148,6 +148,7 @@ func TestGetObjectMeta(t *testing.T) {
 		Name:   diskUid,
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
+	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 
 	tests := map[string]struct {
 		actualObjectMeta   metav1.ObjectMeta
@@ -255,6 +256,7 @@ func TestToDisk(t *testing.T) {
 		Name:   diskUid,
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
+	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	expectedDisk.ObjectMeta = fakeObjectMeta
 	expectedDisk.Spec.DevLinks = fakeDevLinks
 	expectedDisk.Status.State = NDMActive

--- a/cmd/controller/diskstore_test.go
+++ b/cmd/controller/diskstore_test.go
@@ -56,18 +56,21 @@ func TestCreateDisk(t *testing.T) {
 	// create resource1
 	dr1 := fakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr1)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
 	// create resource which is already present it should update
 	dr2 := fakeDr
 	dr2.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr2.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr2)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
 	// create resource2
 	dr3 := newFakeDr
 	dr3.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr3.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr3)
 	cdr3, err3 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
 
@@ -100,6 +103,7 @@ func TestUpdateDisk(t *testing.T) {
 	// update a resource which is not present
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	err := fakeController.UpdateDisk(dr, nil)
 	if err == nil {
 		t.Error("error should not be nil as the resource is not present")
@@ -158,16 +162,19 @@ func TestDeactivateDisk(t *testing.T) {
 	// create one resource and deactivate it.
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 	fakeController.DeactivateDisk(dr)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 	// deactivate one resource which is not present it should return error
 	dr1 := newFakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.DeactivateDisk(dr1)
 	// create another resource and deactivate it.
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(newDr)
 	fakeController.DeactivateDisk(newDr)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -201,6 +208,7 @@ func TestDeleteDisk(t *testing.T) {
 	// create one resource and delete it
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 	fakeController.DeleteDisk(fakeDiskUid)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
@@ -209,6 +217,7 @@ func TestDeleteDisk(t *testing.T) {
 	// create another resource and delete it
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(newDr)
 	fakeController.DeleteDisk(newFakeDiskUid)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -242,10 +251,12 @@ func TestListDiskResource(t *testing.T) {
 	// create resource1
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(newDr)
 	listDevice, err := fakeController.ListDiskResource()
 	typeMeta := metav1.TypeMeta{}
@@ -286,10 +297,12 @@ func TestGetExistingResource(t *testing.T) {
 	// create resource1
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(newDr)
 
 	listDr, err := fakeController.ListDiskResource()
@@ -331,10 +344,12 @@ func TestPushResource(t *testing.T) {
 	// create one DiskInfo struct with mock uuid
 	deviceDetails := &DiskInfo{}
 	deviceDetails.ProbeIdentifiers.Uuid = fakeDiskUid
+	deviceDetails.DiskType = NDMDefaultDiskType
 
 	// create one fake Disk struct
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 
 	// pass 1st argument as nil then it creates one disk resource
 	fakeController.PushDiskResource(nil, deviceDetails)
@@ -372,10 +387,12 @@ func TestDeactivateStaleDiskResource(t *testing.T) {
 	// create resource1
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(newDr)
 	//add one resource's uuid so state of the other resource should be inactive.
 	diskList := make([]string, 0)
@@ -411,6 +428,7 @@ func TestMarkDiskStatusToUnknown(t *testing.T) {
 	}
 	dr := mockEmptyDiskCr()
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeController.CreateDisk(dr)
 
 	fakeController.MarkDiskStatusToUnknown()

--- a/cmd/controller/probe.go
+++ b/cmd/controller/probe.go
@@ -99,6 +99,7 @@ func (c *Controller) ListProbe() []*Probe {
 // FillDiskDetails lists registered probes and fills details from each probe
 func (c *Controller) FillDiskDetails(diskDetails *DiskInfo) {
 	diskDetails.HostName = c.HostName
+	diskDetails.DiskType = NDMDefaultDiskType
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
 	probes := c.ListProbe()
 	for _, probe := range probes {

--- a/cmd/controller/probe_test.go
+++ b/cmd/controller/probe_test.go
@@ -189,6 +189,7 @@ func TestFillDetails(t *testing.T) {
 	expectedDr.Model = fakeModel
 	expectedDr.Serial = fakeSerial
 	expectedDr.Vendor = fakeVendor
+	expectedDr.DiskType = NDMDefaultDiskType
 
 	// create one fake Disk struct
 	actualDr := &DiskInfo{}
@@ -198,7 +199,7 @@ func TestFillDetails(t *testing.T) {
 		actualDisk   *DiskInfo
 		expectedDisk *DiskInfo
 	}{
-		"push resouce with 'fake-disk-uid' uuid for create resource": {actualDisk: expectedDr, expectedDisk: actualDr},
+		"push resouce with 'fake-disk-uid' uuid for create resource": {actualDisk: actualDr, expectedDisk: expectedDr},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/controller/sparsefilegenerator.go
+++ b/cmd/controller/sparsefilegenerator.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/pkg/util"
+
+	"fmt"
+	"os"
+	"path"
+	"strconv"
+)
+
+/*
+Sparse File help simulate disk objects that can be used for testing and
+proto typing solutions built using node-disk-manager(NDM).  Sparse files
+will be created if NDM is provided with the location where sparse files
+should be located.
+
+On Startup, if a sparse directory (SPARSE_FILE_DIR) is specified as a
+environment variable, a Sparse file with specified size (SPARSE_FILE_SIZE) will
+be created and an associated Disk CR will be added to Kubernetes. By default
+only one sparse file will be created which can be changed by passing the desired
+number of sparse files required via the environment variable SPARSE_FILE_COUNT.
+
+On Shutdown, the status of the sparse file Disk CR will be marked as Unknown.
+*/
+
+const (
+	ENV_SPARSE_FILE_DIR   = "SPARSE_FILE_DIR"
+	ENV_SPARSE_FILE_SIZE  = "SPARSE_FILE_SIZE"
+	ENV_SPARSE_FILE_COUNT = "SPARSE_FILE_COUNT"
+
+	SPARSE_FILE_NAME          = "ndm-sparse.img"
+	SPARSE_FILE_DEFAULT_SIZE  = "1073741824"
+	SPARSE_FILE_DEFAULT_COUNT = "1"
+
+	SPARSE_DISKTYPE    = "sparse"
+	SPARSE_DISK_PREFIX = "sparse-"
+)
+
+// GetSparseFileDir returns the full path to the sparse
+//  file directory on the node.
+func GetSparseFileDir() string {
+
+	sparseFileDir := os.Getenv(ENV_SPARSE_FILE_DIR)
+
+	if len(sparseFileDir) < 1 {
+		return ""
+	}
+
+	info, err := os.Stat(sparseFileDir)
+	if os.IsNotExist(err) || !info.Mode().IsDir() {
+		glog.Info("Specified directory doesnt exist:  ", sparseFileDir)
+		return ""
+	}
+
+	return sparseFileDir
+}
+
+// GetSparseFileCount returns the number of sparse files to be
+//  created by NDM. Returns 0, if invalid count is specified.
+func GetSparseFileCount() int {
+
+	sparseFileCountStr := os.Getenv(ENV_SPARSE_FILE_COUNT)
+
+	if len(sparseFileCountStr) < 1 {
+		sparseFileCountStr = SPARSE_FILE_DEFAULT_COUNT
+	}
+
+	sparseFileCount, econv := strconv.Atoi(sparseFileCountStr)
+	if econv != nil {
+		glog.Info("Error converting sparse file count:  ", sparseFileCountStr)
+		return 0
+	}
+
+	return sparseFileCount
+}
+
+// GetSparseFileSize returns the size of the sparse file to be
+//  created by NDM. Returns 0, if invalid size is specified.
+func GetSparseFileSize() int64 {
+
+	sparseFileSizeStr := os.Getenv(ENV_SPARSE_FILE_SIZE)
+	if len(sparseFileSizeStr) < 1 {
+		sparseFileSizeStr = SPARSE_FILE_DEFAULT_SIZE
+	}
+
+	sparseFileSize, econv := strconv.ParseInt(sparseFileSizeStr, 10, 64)
+	if econv != nil {
+		glog.Info("Error converting sparse file size:  ", sparseFileSizeStr)
+		return 0
+	}
+
+	return sparseFileSize
+}
+
+// InitializeSparseFiles will check if the sparse file exist or have to be
+//  created and will update or create the associated Disk CR accordingly
+func (c *Controller) InitializeSparseFiles() {
+	sparseFileDir := GetSparseFileDir()
+	sparseFileSize := GetSparseFileSize()
+	sparseFileCount := GetSparseFileCount()
+
+	if len(sparseFileDir) < 1 || sparseFileSize < 1 || sparseFileCount < 1 {
+		glog.Info("No sparse file path/size provided. Skip creating sparse files.")
+		return
+	}
+
+	for i := 0; i < sparseFileCount; i++ {
+		sparseFile := path.Join(sparseFileDir, fmt.Sprint(i)+"-"+SPARSE_FILE_NAME)
+		err := CheckAndCreateSparseFile(sparseFile, sparseFileSize)
+		if err != nil {
+			glog.Info("Error creating sparse file: ", sparseFile, "Error: ", err)
+			continue
+		}
+		c.MarkSparseDiskStateActive(sparseFile, sparseFileSize)
+	}
+}
+
+// CheckAndCreateSparseFile will reuse the existing sparse file if it already exists,
+//   for handling cases where NDM is upgraded or restarted. If the file doesn't exist
+//   a new file will be created.
+func CheckAndCreateSparseFile(sparseFile string, sparseFileSize int64) error {
+	sparseFileInfo, err := util.SparseFileInfo(sparseFile)
+	if err != nil {
+		err = util.SparseFileCreate(sparseFile, sparseFileSize)
+	} else {
+		glog.Info("Sparse file already exists: ", sparseFileInfo.Name())
+	}
+	return err
+}
+
+// GetSparseDiskUuid returns a fixed UUID for the sparse
+//  disk on a given node.
+func GetSparseDiskUuid(hostname string, sparseFile string) string {
+	return SPARSE_DISK_PREFIX + util.Hash(hostname+sparseFile)
+}
+
+// MarkSparseDiskStateActive will either create a Disk CR if it doesn't exist, or it will
+//   update the state of the existing CR as Active.  Note that, when the NDM is going being
+//   gracefully shutdown, all its Disk CRs are marked with State as Unknown.
+func (c *Controller) MarkSparseDiskStateActive(sparseFile string, sparseFileSize int64) {
+	// Fill in the details of the sparse disk
+	diskDetails := NewDiskInfo()
+	diskDetails.Uuid = GetSparseDiskUuid(c.HostName, sparseFile)
+	diskDetails.HostName = c.HostName
+
+	diskDetails.DiskType = SPARSE_DISKTYPE
+	diskDetails.Path = sparseFile
+
+	sparseFileInfo, err := util.SparseFileInfo(sparseFile)
+	if err != nil {
+		glog.Info("Error fetching the size of sparse file: ", err)
+		glog.Error("Failed to create a disk CR for sparse file: ", sparseFile)
+		return
+	}
+
+	diskDetails.Capacity = uint64(sparseFileInfo.Size())
+
+	//If a Disk CR already exits, update it. If not create a new one.
+	c.CreateDisk(diskDetails.ToDisk())
+
+	glog.Info("Created Disk CR for Sprase Disk: ", diskDetails.Uuid)
+}

--- a/cmd/controller/sparsefilegenerator.go
+++ b/cmd/controller/sparsefilegenerator.go
@@ -139,6 +139,8 @@ func (c *Controller) InitializeSparseFiles() {
 func CheckAndCreateSparseFile(sparseFile string, sparseFileSize int64) error {
 	sparseFileInfo, err := util.SparseFileInfo(sparseFile)
 	if err != nil {
+		glog.Info("Check for existing file returned error: ", err)
+		glog.Info("Creating a new Sparse file: ", sparseFile)
 		err = util.SparseFileCreate(sparseFile, sparseFileSize)
 	} else {
 		glog.Info("Sparse file already exists: ", sparseFileInfo.Name())
@@ -176,5 +178,5 @@ func (c *Controller) MarkSparseDiskStateActive(sparseFile string, sparseFileSize
 	//If a Disk CR already exits, update it. If not create a new one.
 	c.CreateDisk(diskDetails.ToDisk())
 
-	glog.Info("Created Disk CR for Sprase Disk: ", diskDetails.Uuid)
+	glog.Info("Created Disk CR for Sparse Disk: ", diskDetails.Uuid)
 }

--- a/cmd/controller/sparsefilegenerator_test.go
+++ b/cmd/controller/sparsefilegenerator_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/openebs/node-disk-manager/pkg/util"
 )
 
 // TestGetSparseFileDir verifies that a valid sparse file directory
@@ -98,4 +99,45 @@ func TestGetSparseFileSize(t *testing.T) {
 		})
 	}
 
+}
+
+// TestCheckAndCreateSparseFile verifies that a sparse file is created
+//  only when it doesn't already exist.
+func TestCheckAndCreateSparseFile(t *testing.T) {
+
+	testFile := "/tmp/test.img"
+	testFileSize := int64(1000)
+	testFileSize1 := int64(2000)
+
+	tests := map[string]struct {
+		fileName	string
+		fileSize	int64
+		expectedSize	int64
+	}{
+		"Create New File"	: {
+				fileName: testFile, 
+				fileSize: testFileSize,
+				expectedSize: testFileSize,
+					},
+		"Reuse Existing File"	: {
+				fileName: testFile, 
+				fileSize: testFileSize1,
+				expectedSize: testFileSize,
+					},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := CheckAndCreateSparseFile( test.fileName, test.fileSize )
+			assert.Equal(t, nil, err)
+			if  err != nil  {
+				aFileInfo, errF := util.SparseFileInfo(test.fileName)
+				assert.Equal(t, nil, errF)
+				if errF != nil {
+					assert.Equal(t, test.expectedSize, aFileInfo.Size())
+				}
+			}
+		})
+	}
+
+	util.SparseFileDelete( testFile )
 }

--- a/cmd/controller/sparsefilegenerator_test.go
+++ b/cmd/controller/sparsefilegenerator_test.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/openebs/node-disk-manager/pkg/util"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestGetSparseFileDir verifies that a valid sparse file directory
@@ -79,18 +79,17 @@ func TestGetSparseFileCount(t *testing.T) {
 //  If no value is set, default size is returned.
 func TestGetSparseFileSize(t *testing.T) {
 
-	defaultSize, econv := strconv.ParseInt(SPARSE_FILE_DEFAULT_SIZE, 10, 64)
-	if econv != nil {
-		defaultSize = int64(0)
-	}
+	defaultSize := SPARSE_FILE_DEFAULT_SIZE
+	minSize := SPARSE_FILE_MIN_SIZE
 
 	tests := map[string]struct {
 		envFileSize  string
 		expectedSize int64
 	}{
-		"When size is not set":     {envFileSize: "", expectedSize: defaultSize},
-		"When valid size is set":   {envFileSize: "1000", expectedSize: int64(1000)},
-		"When invalid size is set": {envFileSize: "z", expectedSize: 0},
+		"When size is not set":           {envFileSize: "", expectedSize: defaultSize},
+		"When valid size is set":         {envFileSize: "2000000000", expectedSize: int64(2000000000)},
+		"When less than min size is set": {envFileSize: "100", expectedSize: minSize},
+		"When invalid size is set":       {envFileSize: "z", expectedSize: 0},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -110,26 +109,26 @@ func TestCheckAndCreateSparseFile(t *testing.T) {
 	testFileSize1 := int64(2000)
 
 	tests := map[string]struct {
-		fileName	string
-		fileSize	int64
-		expectedSize	int64
+		fileName     string
+		fileSize     int64
+		expectedSize int64
 	}{
-		"Create New File"	: {
-				fileName: testFile, 
-				fileSize: testFileSize,
-				expectedSize: testFileSize,
-					},
-		"Reuse Existing File"	: {
-				fileName: testFile, 
-				fileSize: testFileSize1,
-				expectedSize: testFileSize,
-					},
+		"Create New File": {
+			fileName:     testFile,
+			fileSize:     testFileSize,
+			expectedSize: testFileSize,
+		},
+		"Reuse Existing File": {
+			fileName:     testFile,
+			fileSize:     testFileSize1,
+			expectedSize: testFileSize,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := CheckAndCreateSparseFile( test.fileName, test.fileSize )
+			err := CheckAndCreateSparseFile(test.fileName, test.fileSize)
 			assert.Equal(t, nil, err)
-			if  err != nil  {
+			if err != nil {
 				aFileInfo, errF := util.SparseFileInfo(test.fileName)
 				assert.Equal(t, nil, errF)
 				if errF != nil {
@@ -139,5 +138,5 @@ func TestCheckAndCreateSparseFile(t *testing.T) {
 		})
 	}
 
-	util.SparseFileDelete( testFile )
+	util.SparseFileDelete(testFile)
 }

--- a/cmd/controller/sparsefilegenerator_test.go
+++ b/cmd/controller/sparsefilegenerator_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	//	"errors"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetSparseFileDir verifies that a valid sparse file directory
+//  is returned as per the environment variable ( SPARSE_FILE_PATH )
+func TestGetSparseFileDir(t *testing.T) {
+
+	tests := map[string]struct {
+		envSparseDir string
+		expectedPath string
+	}{
+		"When path is not set":     {envSparseDir: "", expectedPath: ""},
+		"When invalid path is set": {envSparseDir: "invalid", expectedPath: ""},
+		"When valid path is set":   {envSparseDir: "/tmp", expectedPath: "/tmp"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv(ENV_SPARSE_FILE_DIR, test.envSparseDir)
+			assert.Equal(t, test.expectedPath, GetSparseFileDir())
+		})
+	}
+
+}
+
+// TestGetSparseFileCount verifies that a valid sparse file count
+//  is returned as per the environment variable ( SPARSE_FILE_COUNT ).
+//  If no value is set, default count is returned.
+func TestGetSparseFileCount(t *testing.T) {
+
+	defaultCount, econv := strconv.Atoi(SPARSE_FILE_DEFAULT_COUNT)
+	if econv != nil {
+		defaultCount = 0
+	}
+
+	tests := map[string]struct {
+		envFileCount  string
+		expectedCount int
+	}{
+		"When count is not set":     {envFileCount: "", expectedCount: defaultCount},
+		"When valid count is set":   {envFileCount: "2", expectedCount: 2},
+		"When invalid count is set": {envFileCount: "z", expectedCount: 0},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv(ENV_SPARSE_FILE_COUNT, test.envFileCount)
+			assert.Equal(t, test.expectedCount, GetSparseFileCount())
+		})
+	}
+
+}
+
+// TestGetSparseFileSize verifies that a valid sparse file size
+//  is returned as per the environment variable ( SPARSE_FILE_SIZE ).
+//  If no value is set, default size is returned.
+func TestGetSparseFileSize(t *testing.T) {
+
+	defaultSize, econv := strconv.ParseInt(SPARSE_FILE_DEFAULT_SIZE, 10, 64)
+	if econv != nil {
+		defaultSize = int64(0)
+	}
+
+	tests := map[string]struct {
+		envFileSize  string
+		expectedSize int64
+	}{
+		"When size is not set":     {envFileSize: "", expectedSize: defaultSize},
+		"When valid size is set":   {envFileSize: "1000", expectedSize: int64(1000)},
+		"When invalid size is set": {envFileSize: "z", expectedSize: 0},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			os.Setenv(ENV_SPARSE_FILE_SIZE, test.envFileSize)
+			assert.Equal(t, test.expectedSize, GetSparseFileSize())
+		})
+	}
+
+}

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -36,6 +36,7 @@ var (
 	fakeModel      = "fake-disk-model"
 	fakeSerial     = "fake-disk-serial"
 	fakeVendor     = "fake-disk-vendor"
+	fakeDiskType   = "disk"
 )
 
 // mockEmptyDiskCr returns empty diskCr
@@ -122,6 +123,7 @@ func TestAddDiskEvent(t *testing.T) {
 	// Create one fake disk resource
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
 	fakeDr.Spec.Details.Model = fakeModel
 	fakeDr.Spec.Details.Serial = fakeSerial
 	fakeDr.Spec.Details.Vendor = fakeVendor
@@ -157,6 +159,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 	// Create one fake disk resource
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
 	fakeController.CreateDisk(fakeDr)
 
 	probeEvent := &ProbeEvent{

--- a/cmd/probe/smartprobe_test.go
+++ b/cmd/probe/smartprobe_test.go
@@ -99,6 +99,7 @@ func TestFillDiskDetailsBySmart(t *testing.T) {
 	expectedDiskInfo.FirmwareRevision = mockOsDiskDetails.FirmwareRevision
 	expectedDiskInfo.SPCVersion = mockOsDiskDetails.SPCVersion
 	expectedDiskInfo.LogicalSectorSize = mockOsDiskDetails.LBSize
+	expectedDiskInfo.DiskType = "disk"
 	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
 }
 
@@ -173,6 +174,7 @@ func TestSmartProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
 
 	tests := map[string]struct {
 		actualDisk    apis.Disk

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -109,6 +109,7 @@ func TestFillDiskDetails(t *testing.T) {
 	expectedDiskInfo.Path = mockOsDiskDetails.DevNode
 	expectedDiskInfo.Serial = mockOsDiskDetails.Serial
 	expectedDiskInfo.Vendor = mockOsDiskDetails.Vendor
+	expectedDiskInfo.DiskType = "disk"
 	expectedDiskInfo.ByIdDevLinks = mockOsDiskDetails.ByIdDevLinks
 	expectedDiskInfo.ByPathDevLinks = mockOsDiskDetails.ByPathDevLinks
 	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
@@ -171,6 +172,7 @@ func TestUdevProbe(t *testing.T) {
 		t.Fatal(err)
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
 	tests := map[string]struct {
 		actualDisk    apis.Disk
 		expectedDisk  apis.Disk

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -147,12 +147,24 @@ spec:
           mountPath: /run/udev
         - name: procmount
           mountPath: /host/mounts
+        - name: sparsepath
+          mountPath: /var/openebs
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
+        - name: SPARSE_FILE_DIR
+          value: "/var/openebs"
+        # Size of the sparse file to be created.
+        - name: SPARSE_FILE_SIZE
+          value: "1073741824"
+        # Specify the number of sparse files to be created
+        - name: SPARSE_FILE_COUNT
+          value: "1"
       volumes:
       - name: config
         configMap:
@@ -166,3 +178,6 @@ spec:
       # to read which partition is mounted on / path
         hostPath:
           path: /proc/1/mounts
+      - name: sparsepath
+        hostPath:
+          path: /var/openebs

--- a/pkg/util/sparsefile.go
+++ b/pkg/util/sparsefile.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "os"
+
+//import "syscall"
+
+//SparseFileCreate will create a new sparse file if none exists
+// at the give path and will set the size to specified value
+func SparseFileCreate(path string, size int64) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	return f.Truncate(size)
+}
+
+//SparseFileDelete will delete the sparse file if it exists
+func SparseFileDelete(path string) error {
+	err := os.Remove(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+//SparseFileInfo will return the stats of the sparse file
+func SparseFileInfo(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}

--- a/pkg/util/sparsefile_test.go
+++ b/pkg/util/sparsefile_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The OpenEBS Author
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSparseFileCreate(t *testing.T) {
+	tests := map[string]struct {
+		path string
+		size int64
+	}{
+		"Create a sparse file of 1G - test-1g.img": {path: "/tmp/test-1g.img", size: 1073741824},
+		"Retry with same file":                     {path: "/tmp/test-1g.img", size: 1073741824},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := SparseFileCreate(test.path, test.size)
+			assert.Equal(t, nil, err)
+		})
+	}
+}
+
+func TestSparseFileDelete(t *testing.T) {
+	tests := map[string]struct {
+		path string
+	}{
+		"Delete the sparse file of 1G -test-1g.img":       {path: "/tmp/test-1g.img"},
+		"Retry Delete on deleted file of 1G -test-1g.img": {path: "/tmp/test-1g.img"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := SparseFileDelete(test.path)
+			assert.Equal(t, nil, err)
+		})
+	}
+}

--- a/pkg/util/sparsefile_test.go
+++ b/pkg/util/sparsefile_test.go
@@ -26,11 +26,11 @@ func TestSparseFileCreate(t *testing.T) {
 	tests := map[string]struct {
 		path string
 		size int64
-		err  bool 
+		err  bool
 	}{
-		"Create a sparse file": {path: "/tmp/test.img", size: 1024, err : false},
-		"Retry with same file": {path: "/tmp/test.img", size: 1024, err : false},
-		"Fail to create sub-dir file" : {path: "/tmp/0/test.img", size: 1024, err : true},
+		"Create a sparse file":        {path: "/tmp/test.img", size: 1024, err: false},
+		"Retry with same file":        {path: "/tmp/test.img", size: 1024, err: false},
+		"Fail to create sub-dir file": {path: "/tmp/0/test.img", size: 1024, err: true},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -44,7 +44,7 @@ func TestSparseFileDelete(t *testing.T) {
 	tests := map[string]struct {
 		path string
 	}{
-		"Delete the sparse file "      : {path: "/tmp/test.img"},
+		"Delete the sparse file ":       {path: "/tmp/test.img"},
 		"Retry Delete on deleted file ": {path: "/tmp/test.img"},
 	}
 	for name, test := range tests {
@@ -55,33 +55,31 @@ func TestSparseFileDelete(t *testing.T) {
 	}
 }
 
-
 func TestSparseFileInfo(t *testing.T) {
 
 	testFile := "/tmp/test.img"
-        testFileSize := int64(1024)
+	testFileSize := int64(1024)
 
-	_ = SparseFileCreate( testFile, testFileSize )
+	_ = SparseFileCreate(testFile, testFileSize)
 
 	tests := map[string]struct {
 		path string
 		size int64
-		err  bool 
+		err  bool
 	}{
-		"Valid FileInfo": {path: testFile, err : false},
-		"Invalid FileInfo": {path: "invalid", err : true},
+		"Valid FileInfo":   {path: testFile, err: false},
+		"Invalid FileInfo": {path: "invalid", err: true},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			info, infoErr := SparseFileInfo( test.path )
-			if  infoErr == nil {
-				assert.Equal(t, testFileSize, info.Size() )
+			info, infoErr := SparseFileInfo(test.path)
+			if infoErr == nil {
+				assert.Equal(t, testFileSize, info.Size())
 			}
 			assert.Equal(t, test.err, infoErr != nil)
 		})
 	}
 
-	_ = SparseFileDelete( testFile )
+	_ = SparseFileDelete(testFile)
 }
-


### PR DESCRIPTION
For testing with nodes that have no additional disks, sparse disks provide a
mechanism to create a sparse file and use as a disk resource.

The NDM sparse file creation can be configured via the following
environment variables:
- SPARSE_FILE_DIR : A valid directory where sparse files need to be created
- SPARSE_FILE_SIZE : Size of each sparse file in byte. Defaults to 1GB
- SPRASE_FILE_COUNT: Number of files to be created. Defaults to 1

To differentiate between sparse disks and regular disk, a disk-type label
as been introduced. For sparse disks, this disk-type will be `sparse`, where
as for regular disks it will be set as `disk`.

Like disk resources, the sparse disk resource's state will be marked as
`Uknown` when NDM is shutdown and is made `Active` when the NDM is restarted
on the same node.

Note:
- If a sparse disk already exists in the directory, it will be reused as is.
- The naming convention for sparse disk is <user specified dir>/<count>-ndm-sparse.img
  count starts with 0 to n-1, where n is the count specified by user as
  SPARSE_FILE_COUNT


The Sparse Disk CR is as follows:
```
- apiVersion: openebs.io/v1alpha1
  kind: Disk
  metadata:
    clusterName: ""
    creationTimestamp: 2018-08-16T14:54:06Z
    labels:
      kubernetes.io/hostname: gke-kmova-helm-default-pool-5116437a-l3rp
      ndm.io/disk-type: sparse
    name: sparsef594eb00eecf63247f655aaf524bd46b
    namespace: ""
    resourceVersion: "34776"
    selfLink: /apis/openebs.io/v1alpha1/sparsef594eb00eecf63247f655aaf524bd46b
    uid: 393cfa91-a164-11e8-b06f-42010a80004b
  spec:
    capacity:
      logicalSectorSize: 0
      storage: 1073741824
    details:
      firmwareRevision: ""
      model: ""
      serial: ""
      spcVersion: ""
      vendor: ""
    path: /var/openebs/0-ndm-sparse.img
  status:
    state: Active
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

Signed-off-by: kmova <kiran.mova@openebs.io>