### PR TITLE
NDM does not work well with the Virtual disks.

### DIFF
--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -24,6 +24,7 @@ package udev
 */
 import "C"
 import (
+	"os"
 	"strings"
 	"unsafe"
 
@@ -90,16 +91,29 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 
 // GetUid returns unique id for the disk block device
 func (device *UdevDevice) GetUid() string {
-	return NDMPrefix +
-		util.Hash(device.GetPropertyValue(UDEV_WWN)+
-			device.GetPropertyValue(UDEV_MODEL)+
-			device.GetPropertyValue(UDEV_SERIAL)+
-			device.GetPropertyValue(UDEV_VENDOR))
+	uid := device.GetPropertyValue(UDEV_WWN) +
+		device.GetPropertyValue(UDEV_MODEL) +
+		device.GetPropertyValue(UDEV_SERIAL) +
+		device.GetPropertyValue(UDEV_VENDOR)
+
+	idtype := device.GetPropertyValue(UDEV_TYPE)
+
+	// virtual disks either have no attributes or they all have
+	// the same attributes. Adding hostname in uid so that disks from different
+	// nodes can be differentiated. Also, putting devpath in uid so that disks
+	// from the same node also can be differentiated.
+	if len(idtype) == 0 {
+		// as hostNetwork is true, os.Hostname will give you the node's Hostname
+		host, _ := os.Hostname()
+		uid += host + device.GetPropertyValue(UDEV_DEVNAME)
+	}
+
+	return NDMPrefix + util.Hash(uid)
 }
 
 // IsDisk returns true if device is a disk
 func (device *UdevDevice) IsDisk() bool {
-	return device.GetDevtype() == UDEV_SYSTEM && device.GetPropertyValue(UDEV_TYPE) == UDEV_SYSTEM
+	return device.GetDevtype() == UDEV_SYSTEM
 }
 
 // GetSyspath returns syspath of a disk using syspath we can fell details

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -98,11 +98,16 @@ func (device *UdevDevice) GetUid() string {
 
 	idtype := device.GetPropertyValue(UDEV_TYPE)
 
-	// virtual disks either have no attributes or they all have
+	model := device.GetPropertyValue(UDEV_MODEL)
+
+	// Virtual disks either have no attributes or they all have
 	// the same attributes. Adding hostname in uid so that disks from different
 	// nodes can be differentiated. Also, putting devpath in uid so that disks
 	// from the same node also can be differentiated.
-	if len(idtype) == 0 {
+	// 	On Gke, we have the ID_TYPE property, but still disks will have
+	// same attributes. We have to put a special check to handle it and process
+	// it like a Virtual disk.
+	if len(idtype) == 0 || model == "EphemeralDisk" {
 		// as hostNetwork is true, os.Hostname will give you the node's Hostname
 		host, _ := os.Hostname()
 		uid += host + device.GetPropertyValue(UDEV_DEVNAME)


### PR DESCRIPTION
Virtuall disks generally have either all the disk
properties same (Model, serail, vendor, wwn) or the
propetties don't exits at all.

Here we are putting Hostname and devpath in the disk uid so
that NDM can differentiate the disk across the nodes and also
within the node.

After this change, we are able to see all the disks on the AWS cluster 
```
admin@ip-10-3-56-88:~/cstor_yaml$ kubectl get disks
NAME                                    AGE
disk-1d860ccc764933ec1200d5ed810b346b   1m
disk-79e82287d54cabca0a8e1d7abbed77eb   1m
disk-9636e82af96e4e681b2bb4c944c17fe7   1m
disk-9a8dfe972801dec81e7d31feb99c1f42   1m
disk-dc783fba0d1f3daf0ea0f3e9f4c45f50   1m
disk-dccd9baebf17a90f39e65859f3fadcbd   1m

```

```
admin@ip-10-3-40-249:~$ lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
xvda    202:0    0  128G  0 disk 
`-xvda1 202:1    0  128G  0 part /
xvdc    202:32   0   40G  0 disk /mnt
xvdd    202:48   0   40G  0 disk 
|-xvdd1 202:49   0   40G  0 part 
`-xvdd9 202:57   0    8M  0 part 
```

```
admin@ip-10-3-33-158:~$ lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
xvda    202:0    0  128G  0 disk 
`-xvda1 202:1    0  128G  0 part /
xvdc    202:32   0   40G  0 disk /mnt
xvdd    202:48   0   40G  0 disk 
|-xvdd1 202:49   0   40G  0 part 
`-xvdd9 202:57   0    8M  0 part 
```

```
admin@ip-10-3-35-115:~$ lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
xvda    202:0    0  128G  0 disk 
`-xvda1 202:1    0  128G  0 part /
xvdc    202:32   0   40G  0 disk /mnt
xvdd    202:48   0   40G  0 disk 
|-xvdd1 202:49   0   40G  0 part 
`-xvdd9 202:57   0    8M  0 part 

```


```
admin@ip-10-3-56-88:~/cstor_yaml$ kubectl describe disks
Name:         disk-1d860ccc764933ec1200d5ed810b346b
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-35-115.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70526
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-1d860ccc764933ec1200d5ed810b346b
  UID:                 e627e30d-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdd
Status:
  State:  Active
Events:   <none>


Name:         disk-79e82287d54cabca0a8e1d7abbed77eb
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-35-115.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70525
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-79e82287d54cabca0a8e1d7abbed77eb
  UID:                 e6275b6e-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdc
Status:
  State:  Active
Events:   <none>


Name:         disk-9636e82af96e4e681b2bb4c944c17fe7
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-40-249.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70514
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-9636e82af96e4e681b2bb4c944c17fe7
  UID:                 e5d974ad-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdd
Status:
  State:  Active
Events:   <none>


Name:         disk-9a8dfe972801dec81e7d31feb99c1f42
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-40-249.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70513
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-9a8dfe972801dec81e7d31feb99c1f42
  UID:                 e5d8fa8e-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdc
Status:
  State:  Active
Events:   <none>


Name:         disk-dc783fba0d1f3daf0ea0f3e9f4c45f50
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-33-158.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70512
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-dc783fba0d1f3daf0ea0f3e9f4c45f50
  UID:                 e5d5b93c-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdd
Status:
  State:  Active
Events:   <none>


Name:         disk-dccd9baebf17a90f39e65859f3fadcbd
Namespace:    
Labels:       kubernetes.io/hostname=ip-10-3-33-158.ec2.internal
              ndm.io/disk-type=disk
Annotations:  <none>
API Version:  openebs.io/v1alpha1
Kind:         Disk
Metadata:
  Cluster Name:        
  Creation Timestamp:  2018-08-31T07:38:48Z
  Generation:          1
  Resource Version:    70511
  Self Link:           /apis/openebs.io/v1alpha1/disks/disk-dccd9baebf17a90f39e65859f3fadcbd
  UID:                 e5d548f7-acf0-11e8-af31-0aa83959d580
Spec:
  Capacity:
    Logical Sector Size:  0
    Storage:              0
  Details:
    Firmware Revision:  
    Model:              
    Serial:             
    Spc Version:        
    Vendor:             
  Path:                 /dev/xvdc
Status:
  State:  Active
Events:   <none>
```