### PR TITLE
feat(filters): include/exclude disks based on device path

### DIFF
--- a/cmd/filter/filter.go
+++ b/cmd/filter/filter.go
@@ -27,7 +27,10 @@ const (
 )
 
 // RegisteredFilters contains register function of filters which we want to register
-var RegisteredFilters = []func(){oSDiskExcludeFilterRegister, vendorFilterRegister}
+var RegisteredFilters = []func(){
+	oSDiskExcludeFilterRegister,
+	vendorFilterRegister,
+	pathFilterRegister}
 
 type registerFilter struct {
 	name       string

--- a/cmd/filter/pathfilter.go
+++ b/cmd/filter/pathfilter.go
@@ -31,7 +31,7 @@ var (
 	pathFilterName  = "path filter"  // filter device paths
 	pathFilterState = defaultEnabled // filter state
 	includePaths    = ""
-	excludePaths    = ""
+	excludePaths    = "loop"
 )
 
 // pathFilterRegister contains registration process of PathFilter

--- a/cmd/filter/pathfilter.go
+++ b/cmd/filter/pathfilter.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"strings"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	"github.com/openebs/node-disk-manager/pkg/util"
+)
+
+const (
+	pathFilterKey = "path-filter"
+)
+
+var (
+	pathFilterName  = "path filter"  // filter device paths
+	pathFilterState = defaultEnabled // filter state
+	includePaths    = ""
+	excludePaths    = ""
+)
+
+// pathFilterRegister contains registration process of PathFilter
+var pathFilterRegister = func() {
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		return
+	}
+	if ctrl.NDMConfig != nil {
+		for _, filterConfig := range ctrl.NDMConfig.FilterConfigs {
+			if filterConfig.Key == pathFilterKey {
+				pathFilterName = filterConfig.Name
+				pathFilterState = util.CheckTruthy(filterConfig.State)
+				includePaths = filterConfig.Include
+				excludePaths = filterConfig.Exclude
+				break
+			}
+		}
+	}
+	var fi controller.FilterInterface = newPathFilter(ctrl)
+	newRegisterFilter := &registerFilter{
+		name:       pathFilterName,
+		state:      pathFilterState,
+		fi:         fi,
+		controller: ctrl,
+	}
+	newRegisterFilter.register()
+}
+
+// pathFilter contains controller and include and exclude keywords
+type pathFilter struct {
+	controller   *controller.Controller
+	excludePaths []string
+	includePaths []string
+}
+
+// newPathFilter returns new pointer PathFilter
+func newPathFilter(ctrl *controller.Controller) *pathFilter {
+	return &pathFilter{
+		controller: ctrl,
+	}
+}
+
+// Start sets include and exclude path keywords list
+func (pf *pathFilter) Start() {
+	pf.includePaths = make([]string, 0)
+	pf.excludePaths = make([]string, 0)
+	if includePaths != "" {
+		pf.includePaths = strings.Split(includePaths, ",")
+	}
+	if excludePaths != "" {
+		pf.excludePaths = strings.Split(excludePaths, ",")
+	}
+}
+
+// Include returns true if the disk path matches with given list
+// of keywords
+func (pf *pathFilter) Include(d *controller.DiskInfo) bool {
+	if len(pf.includePaths) == 0 {
+		return true
+	}
+	return util.MatchIgnoredCase(pf.includePaths, d.Path)
+}
+
+// Exclude returns true if the disk path does not matche any given
+// keywords
+func (pf *pathFilter) Exclude(d *controller.DiskInfo) bool {
+	if len(pf.excludePaths) == 0 {
+		return true
+	}
+	return !util.MatchIgnoredCase(pf.excludePaths, d.Path)
+}

--- a/cmd/filter/pathfilter_test.go
+++ b/cmd/filter/pathfilter_test.go
@@ -38,7 +38,7 @@ func TestPathFilterRegister(t *testing.T) {
 	var fi controller.FilterInterface = &pathFilter{
 		controller:   fakeController,
 		includePaths: make([]string, 0),
-		excludePaths: make([]string, 0),
+		excludePaths: []string{"loop"},
 	}
 	filter := &controller.Filter{
 		Name:      pathFilterName,

--- a/cmd/filter/pathfilter_test.go
+++ b/cmd/filter/pathfilter_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openebs/node-disk-manager/cmd/controller"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathFilterRegister(t *testing.T) {
+	expectedFilterList := make([]*controller.Filter, 0)
+	fakeController := &controller.Controller{
+		Filters: make([]*controller.Filter, 0),
+		Mutex:   &sync.Mutex{},
+	}
+	go func() {
+		controller.ControllerBroadcastChannel <- fakeController
+	}()
+	pathFilterRegister()
+	var fi controller.FilterInterface = &pathFilter{
+		controller:   fakeController,
+		includePaths: make([]string, 0),
+		excludePaths: make([]string, 0),
+	}
+	filter := &controller.Filter{
+		Name:      pathFilterName,
+		State:     pathFilterState,
+		Interface: fi,
+	}
+	expectedFilterList = append(expectedFilterList, filter)
+	tests := map[string]struct {
+		actualFilterList   []*controller.Filter
+		expectedFilterList []*controller.Filter
+	}{
+		"add one filter and check if it is present or not": {actualFilterList: fakeController.Filters, expectedFilterList: expectedFilterList},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedFilterList, test.actualFilterList)
+		})
+	}
+}
+
+func TestPathStart(t *testing.T) {
+	fakePathFilter1 := pathFilter{}
+	fakePathFilter2 := pathFilter{}
+	tests := map[string]struct {
+		filter      pathFilter
+		includePath string
+		excludePath string
+	}{
+		"includePath is empty":         {filter: fakePathFilter1, includePath: "", excludePath: ""},
+		"includePath and path is same": {filter: fakePathFilter2, includePath: "loop", excludePath: "loop"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			includePaths = test.includePath
+			excludePaths = test.excludePath
+			test.filter.Start()
+			if test.excludePath != "" {
+				assert.Equal(t, strings.Split(test.excludePath, ","), test.filter.excludePaths)
+			} else {
+				assert.Equal(t, make([]string, 0), test.filter.excludePaths)
+			}
+			if test.includePath != "" {
+				assert.Equal(t, strings.Split(test.excludePath, ","), test.filter.includePaths)
+			} else {
+				assert.Equal(t, make([]string, 0), test.filter.includePaths)
+			}
+		})
+	}
+}
+
+func TestPathFilterExclude(t *testing.T) {
+	fakePathFilter1 := pathFilter{}
+	fakePathFilter2 := pathFilter{}
+	fakePathFilter3 := pathFilter{}
+	tests := map[string]struct {
+		filter      pathFilter
+		excludePath string
+		path        string
+		expected    bool
+	}{
+		"excludePath is empty":             {filter: fakePathFilter1, excludePath: "", path: "/dev/loop0", expected: true},
+		"excludePath and path is same":     {filter: fakePathFilter2, excludePath: "loop", path: "/dev/loop0", expected: false},
+		"excludePath and path is not same": {filter: fakePathFilter3, excludePath: "loop", path: "/dev/sdb", expected: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			disk := &controller.DiskInfo{}
+			disk.Path = test.path
+			if test.excludePath != "" {
+				test.filter.excludePaths = strings.Split(test.excludePath, ",")
+			}
+			assert.Equal(t, test.expected, test.filter.Exclude(disk))
+		})
+	}
+}
+
+func TestPathFilterInclude(t *testing.T) {
+	fakePathFilter1 := pathFilter{}
+	fakePathFilter2 := pathFilter{}
+	fakePathFilter3 := pathFilter{}
+	tests := map[string]struct {
+		filter      pathFilter
+		includePath string
+		path        string
+		expected    bool
+	}{
+		"includePath is empty":             {filter: fakePathFilter1, includePath: "", path: "/dev/loop0", expected: true},
+		"includePath and path is same":     {filter: fakePathFilter2, includePath: "loop", path: "/dev/loop0", expected: true},
+		"includePath and path is not same": {filter: fakePathFilter3, includePath: "loop", path: "/dev/sdb", expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			disk := &controller.DiskInfo{}
+			disk.Path = test.path
+			if test.includePath != "" {
+				test.filter.includePaths = strings.Split(test.includePath, ",")
+			}
+			assert.Equal(t, test.expected, test.filter.Include(disk))
+		})
+	}
+}

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -43,6 +43,13 @@ data:
           "state": "true",
           "include":"",
           "exclude":"CLOUDBYT,OpenEBS"
+        },
+        {
+          "key": "path-filter",
+          "name": "path filter",
+          "state": "true",
+          "include":"",
+          "exclude":"loop"
         }
       ]
     }

--- a/pkg/util/strmatch.go
+++ b/pkg/util/strmatch.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+)
+
+// Contains is a util function which returns true if one key is present in array
+// else it returns false
+func Contains(s []string, k string) bool {
+	for _, e := range s {
+		if e == k {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsIgnoredCase is a util function which returns true if one key is present
+// in array else it returns false. This function is not case sensitive.
+func ContainsIgnoredCase(s []string, k string) bool {
+	for _, e := range s {
+		if strings.ToLower(e) == strings.ToLower(k) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchIgnoredCase is a util function which returns true if any of the keys
+// are present as a string in given string - s
+// This function is not case sensitive.
+func MatchIgnoredCase(keys []string, s string) bool {
+	for _, k := range keys {
+		if strings.Contains(strings.ToLower(s), strings.ToLower(k)) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/strmatch_test.go
+++ b/pkg/util/strmatch_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContains(t *testing.T) {
+	diskList := make([]string, 0)
+	diskList = append(diskList, "Key1")
+	diskList = append(diskList, "Key3")
+	tests := map[string]struct {
+		diskName string
+		expected bool
+	}{
+		"giving a key which is not present in slice": {diskName: "Key0", expected: false},
+		"giving a key which is present in slice":     {diskName: "Key3", expected: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, Contains(diskList, test.diskName))
+		})
+	}
+}
+
+func TestContainsIgnoredCase(t *testing.T) {
+	diskList := make([]string, 0)
+	diskList = append(diskList, "Key1")
+	diskList = append(diskList, "Key3")
+	tests := map[string]struct {
+		diskName string
+		expected bool
+	}{
+		"giving a key which is not present in slice": {diskName: "keY0", expected: false},
+		"giving a key which is present in slice":     {diskName: "KEy3", expected: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, ContainsIgnoredCase(diskList, test.diskName))
+		})
+	}
+}
+
+func TestMatchIgnoredCase(t *testing.T) {
+	mkList := make([]string, 0)
+	mkList = append(mkList, "loop")
+	mkList = append(mkList, "/dev/sr0")
+	tests := map[string]struct {
+		diskPath string
+		expected bool
+	}{
+		"diskPath contains one of the keys ": {diskPath: "/dev/loop0", expected: true},
+		"diskPath matches complete key":      {diskPath: "/dev/sr0", expected: true},
+		"diskPath does not match any keys":   {diskPath: "/dev/sdb", expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, MatchIgnoredCase(mkList, test.diskPath))
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -112,40 +112,6 @@ func Hash(s string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-// Contains is a util function which returns true if one key is present in array
-// else it returns false
-func Contains(s []string, k string) bool {
-	for _, e := range s {
-		if e == k {
-			return true
-		}
-	}
-	return false
-}
-
-// ContainsIgnoredCase is a util function which returns true if one key is present
-// in array else it returns false. This function is not case sensitive.
-func ContainsIgnoredCase(s []string, k string) bool {
-	for _, e := range s {
-		if strings.ToLower(e) == strings.ToLower(k) {
-			return true
-		}
-	}
-	return false
-}
-
-// MatchIgnoredCase is a util function which returns true if any of the keys
-// are present as a string in given string - s
-// This function is not case sensitive.
-func MatchIgnoredCase(keys []string, s string) bool {
-	for _, k := range keys {
-		if strings.Contains(strings.ToLower(s), strings.ToLower(k)) {
-			return true
-		}
-	}
-	return false
-}
-
 // StateStatus returns enable if state is true and disable if state is false
 func StateStatus(state bool) string {
 	var status = map[bool]string{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -134,6 +134,18 @@ func ContainsIgnoredCase(s []string, k string) bool {
 	return false
 }
 
+// MatchIgnoredCase is a util function which returns true if any of the keys
+// are present as a string in given string - s
+// This function is not case sensitive.
+func MatchIgnoredCase(keys []string, s string) bool {
+	for _, k := range keys {
+		if strings.Contains(strings.ToLower(s), strings.ToLower(k)) {
+			return true
+		}
+	}
+	return false
+}
+
 // StateStatus returns enable if state is true and disable if state is false
 func StateStatus(state bool) string {
 	var status = map[bool]string{

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -170,6 +170,24 @@ func TestContainsIgnoredCase(t *testing.T) {
 	}
 }
 
+func TestMatchIgnoredCase(t *testing.T) {
+	mkList := make([]string, 0)
+	mkList = append(mkList, "loop")
+	mkList = append(mkList, "feedback")
+	tests := map[string]struct {
+		diskPath string
+		expected bool
+	}{
+		"diskPath contains one of the keys ": {diskPath: "/dev/loop0", expected: true},
+		"diskPath does not match any keys":   {diskPath: "/dev/sdb", expected: false},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, MatchIgnoredCase(mkList, test.diskPath))
+		})
+	}
+}
+
 func TestStateStatus(t *testing.T) {
 	tests := map[string]struct {
 		status string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -134,61 +134,6 @@ func TestCheckErr(t *testing.T) {
 	CheckErr(nil, handlerFunc)
 }
 
-func TestContains(t *testing.T) {
-	diskList := make([]string, 0)
-	diskList = append(diskList, "Key1")
-	diskList = append(diskList, "Key3")
-	tests := map[string]struct {
-		diskName string
-		expected bool
-	}{
-		"giving a key which is not present in slice": {diskName: "Key0", expected: false},
-		"giving a key which is present in slice":     {diskName: "Key3", expected: true},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, Contains(diskList, test.diskName))
-		})
-	}
-}
-
-func TestContainsIgnoredCase(t *testing.T) {
-	diskList := make([]string, 0)
-	diskList = append(diskList, "Key1")
-	diskList = append(diskList, "Key3")
-	tests := map[string]struct {
-		diskName string
-		expected bool
-	}{
-		"giving a key which is not present in slice": {diskName: "keY0", expected: false},
-		"giving a key which is present in slice":     {diskName: "KEy3", expected: true},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, ContainsIgnoredCase(diskList, test.diskName))
-		})
-	}
-}
-
-func TestMatchIgnoredCase(t *testing.T) {
-	mkList := make([]string, 0)
-	mkList = append(mkList, "loop")
-	mkList = append(mkList, "/dev/sr0")
-	tests := map[string]struct {
-		diskPath string
-		expected bool
-	}{
-		"diskPath contains one of the keys ": {diskPath: "/dev/loop0", expected: true},
-		"diskPath matches complete key":      {diskPath: "/dev/sr0", expected: true},
-		"diskPath does not match any keys":   {diskPath: "/dev/sdb", expected: false},
-	}
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, MatchIgnoredCase(mkList, test.diskPath))
-		})
-	}
-}
-
 func TestStateStatus(t *testing.T) {
 	tests := map[string]struct {
 		status string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -173,12 +173,13 @@ func TestContainsIgnoredCase(t *testing.T) {
 func TestMatchIgnoredCase(t *testing.T) {
 	mkList := make([]string, 0)
 	mkList = append(mkList, "loop")
-	mkList = append(mkList, "feedback")
+	mkList = append(mkList, "/dev/sr0")
 	tests := map[string]struct {
 		diskPath string
 		expected bool
 	}{
 		"diskPath contains one of the keys ": {diskPath: "/dev/loop0", expected: true},
+		"diskPath matches complete key":      {diskPath: "/dev/sr0", expected: true},
 		"diskPath does not match any keys":   {diskPath: "/dev/sdb", expected: false},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
Depending on where NDM is running - cloud or virtual hardware,
the host (udev) modules don't always provide all the required
details.

For instance, GKE nodes display loop back devices as disks,
where as disks in AWS don't always show typical device attributes
like - model, vendor or serial number.

This PR introduces a feature where, user can specify a list of
include/exclude keywords that can appear in the device path. For
exampke, the default configuration provided, excludes loop back
devices from being added as disks.

Signed-off-by: kmova <kiran.mova@openebs.io>