### PR TITLE
mention a special case related to `GOPATH` in `docs/developer-setup.md`

### DIFF
--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -36,6 +36,7 @@ git remote set-url --push upstream no_push
 # Confirm that your remotes make sense:
 git remote -v
 ```
+> **Note:** If your `GOPATH` has more than one (`:` separated) paths in it, then you should use *one of your go path* instead of `$GOPATH` in the commands mentioned here. This statement holds throughout this document.
 
 Install the build dependencies.
   * By default node-disk-manager enables fetching disk attributes using udev. This requires udev develop files. For Ubuntu, `libudev-dev` package should be installed.


### PR DESCRIPTION
Mention about the case when someone's GOPATH consists of more than one path in the `docs/developer-setup.md`

If above case holds true for anyone then he might get an error while running
some of the commands mentioned in this document. I think it is good to
at least mension about this case once in the document.

Changes committed:
	modified:   docs/developer-setup.md

Signed-off-by: Abhishek Kashyap <abhishek.kashyap@mayadata.io>