### PR TITLE
add support for virtual disk uuid generation

### DIFF
--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -107,7 +107,10 @@ func (device *UdevDevice) GetUid() string {
 	// 	On Gke, we have the ID_TYPE property, but still disks will have
 	// same attributes. We have to put a special check to handle it and process
 	// it like a Virtual disk.
-	if len(idtype) == 0 || model == "EphemeralDisk" {
+	localDiskModels := make([]string, 0)
+	localDiskModels = append(localDiskModels, "EphemeralDisk")
+	localDiskModels = append(localDiskModels, "Virtual_disk")
+	if len(idtype) == 0 || util.Contains(localDiskModels, model) {
 		// as hostNetwork is true, os.Hostname will give you the node's Hostname
 		host, _ := os.Hostname()
 		uid += host + device.GetPropertyValue(UDEV_DEVNAME)


### PR DESCRIPTION
ndm is not able to generate uuid of virtual disks whose model is `Virtual_disk` this pr will add `Virtual_disk` model as a special case and allows ndm to generate uuid of that disk as the way it generates for `EphemeralDisk` model.

Changes committed:
modified:   pkg/udev/common.go
Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>