### PR TITLE
Add logic to show correct SPC version for disks rather than raw value

### DIFF
--- a/cmd/controller/disk.go
+++ b/cmd/controller/disk.go
@@ -40,7 +40,7 @@ type DiskInfo struct {
 	ByPathDevLinks    []string        // ByPathDevLinks contains by-path devlinks
 	FirmwareRevision  string          // FirmwareRevision is the firmware revision for a disk
 	LogicalSectorSize uint32          // LogicalSectorSize is the Logical size of a disk in bytes
-	SPCVersion        string          // SPCVersion is implemented specifications version i.e. SPC-1, SPC-2, etc
+	Compliance        string          // Compliance is implemented specifications version i.e. SPC-1, SPC-2, etc
 	DiskType          string          // DiskType represents the type of disk like Disk, Sparse etc.,
 }
 
@@ -138,7 +138,7 @@ func (di *DiskInfo) getDiskDetails() apis.DiskDetails {
 	diskDetails.Serial = di.Serial
 	diskDetails.Vendor = di.Vendor
 	diskDetails.FirmwareRevision = di.FirmwareRevision
-	diskDetails.SPCVersion = di.SPCVersion
+	diskDetails.Compliance = di.Compliance
 	return diskDetails
 }
 

--- a/cmd/probe/smartprobe.go
+++ b/cmd/probe/smartprobe.go
@@ -100,7 +100,7 @@ func (sp *smartProbe) FillDiskDetails(d *controller.DiskInfo) {
 		glog.Error(err)
 	}
 
-	d.SPCVersion = deviceBasicSCSIInfo.SPCVersion
+	d.Compliance = deviceBasicSCSIInfo.Compliance
 	d.FirmwareRevision = deviceBasicSCSIInfo.FirmwareRevision
 	d.Capacity = deviceBasicSCSIInfo.Capacity
 	d.LogicalSectorSize = deviceBasicSCSIInfo.LBSize

--- a/cmd/probe/smartprobe_test.go
+++ b/cmd/probe/smartprobe_test.go
@@ -43,7 +43,7 @@ func mockOsDiskToAPIBySmart() (apis.Disk, error) {
 	}
 
 	fakeDetails := apis.DiskDetails{
-		SPCVersion:       mockOsDiskDetails.SPCVersion,
+		Compliance:       mockOsDiskDetails.Compliance,
 		FirmwareRevision: mockOsDiskDetails.FirmwareRevision,
 	}
 
@@ -97,7 +97,7 @@ func TestFillDiskDetailsBySmart(t *testing.T) {
 	expectedDiskInfo.ProbeIdentifiers.SmartIdentifier = mockOsDiskDetails.DevPath
 	expectedDiskInfo.Capacity = mockOsDiskDetails.Capacity
 	expectedDiskInfo.FirmwareRevision = mockOsDiskDetails.FirmwareRevision
-	expectedDiskInfo.SPCVersion = mockOsDiskDetails.SPCVersion
+	expectedDiskInfo.Compliance = mockOsDiskDetails.Compliance
 	expectedDiskInfo.LogicalSectorSize = mockOsDiskDetails.LBSize
 	expectedDiskInfo.DiskType = "disk"
 	assert.Equal(t, expectedDiskInfo, actualDiskInfo)

--- a/docs/design.md
+++ b/docs/design.md
@@ -113,7 +113,7 @@ The workflow with _*node-disk-manager*_ would be to integrate into current appro
       firmwareRevision: '1   '
       model: PersistentDisk
       serial: disk-2
-      spcVersion: "6"
+      compliance: "SPC-4"
       vendor: Google
     devlinks:
     - kind: by-id
@@ -173,7 +173,7 @@ items:
       firmwareRevision: '1   '
       model: PersistentDisk
       serial: disk-2
-      spcVersion: "6"
+      compliance: "SPC-4"
       vendor: Google
     devlinks:
     - kind: by-id
@@ -206,7 +206,7 @@ items:
       firmwareRevision: ""
       model: PersistentDisk
       serial: disk-3
-      spcVersion: ""
+      compliance: ""
       vendor: Google
     devlinks:
     - kind: by-id

--- a/pkg/apis/openebs.io/v1alpha1/types.go
+++ b/pkg/apis/openebs.io/v1alpha1/types.go
@@ -39,7 +39,7 @@ type DiskCapacity struct {
 // DiskDetails contains basic and static info of a disk
 type DiskDetails struct {
 	Model            string `json:"model"`            // Model is model of disk
-	SPCVersion       string `json:"spcVersion"`       // Implemented standards/specifications version such as SPC-1, SPC-2, etc
+	Compliance       string `json:"compliance"`       // Implemented standards/specifications version such as SPC-1, SPC-2, etc
 	Serial           string `json:"serial"`           // Serial is serial no of disk
 	Vendor           string `json:"vendor"`           // Vendor is vendor of disk
 	FirmwareRevision string `json:"firmwareRevision"` // disk firmware revision

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -14,13 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server_test
+package server
 
 import (
 	"net"
 	"testing"
-
-	"github.com/openebs/node-disk-manager/pkg/server"
 )
 
 func TestStartHttpServer(t *testing.T) {
@@ -28,16 +26,14 @@ func TestStartHttpServer(t *testing.T) {
 	ErrorMessages := make(chan error)
 	go func() {
 		//Block port 9090 and attempt to start http server at 9090.
-		p1, err := net.Listen("tcp", "localhost:9090")
-		defer p1.Close()
-		if err != nil {
-			t.Log(err)
+		if p1, err := net.Listen("tcp", "localhost:9090"); err == nil {
+			defer p1.Close()
 		}
-		ErrorMessages <- server.StartHttpServer()
+		ErrorMessages <- StartHttpServer()
 	}()
 	msg := <-ErrorMessages
 	if msg != nil {
-		t.Log("Try to start http server in a port which is busy.")
+		t.Log("Trying to start http server in a port which is busy.")
 		t.Log(msg)
 	}
 }

--- a/pkg/smart/doc.go
+++ b/pkg/smart/doc.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	fmt.Printf("Vendor :%s \n",deviceBasicSCSIInfo.Vendor)
-	fmt.Printf("SPCVersion :%s \n",deviceBasicSCSIInfo.SPCVersion)
+	fmt.Printf("Compliance :%s \n",deviceBasicSCSIInfo.Compliance)
 	fmt.Printf("FirmwareRevision :%s \n",deviceBasicSCSIInfo.FirmwareRevision)
 	fmt.Printf("Capacity :%d \n",deviceBasicSCSIInfo.Capacity)
 }

--- a/pkg/smart/mockdata.go
+++ b/pkg/smart/mockdata.go
@@ -19,7 +19,7 @@ package smart
 import "github.com/openebs/node-disk-manager/pkg/udev"
 
 type MockOsDiskDetails struct {
-	SPCVersion       string
+	Compliance       string
 	FirmwareRevision string
 	Capacity         uint64
 	LBSize           uint32
@@ -42,7 +42,7 @@ func (d *SCSIDev) getCommonSCSIDetails(cDetail MockOsDiskDetails) (MockOsDiskDet
 	if err != nil {
 		return cDetail, err
 	}
-	cDetail.SPCVersion = InqRes.getValue()[SPCVersion]
+	cDetail.Compliance = InqRes.getValue()[Compliance]
 	cDetail.FirmwareRevision = InqRes.getValue()[FirmwareRev]
 
 	// Scsi readDeviceCapacity command to get the capacity of a disk

--- a/pkg/smart/scsidevice.go
+++ b/pkg/smart/scsidevice.go
@@ -157,7 +157,7 @@ func (d *SCSIDev) fillDiskInfoUsingSI(diskDetails DiskAttr) (DiskAttr, error) {
 	if err != nil {
 		return diskDetails, err
 	}
-	diskDetails.SPCVersion = InqRes.getValue()[SPCVersion]
+	diskDetails.Compliance = InqRes.getValue()[Compliance]
 	diskDetails.Vendor = InqRes.getValue()[Vendor]
 	diskDetails.ModelNumber = InqRes.getValue()[ModelNumber]
 	diskDetails.FirmwareRevision = InqRes.getValue()[FirmwareRev]

--- a/pkg/smart/scsiinquirypage.go
+++ b/pkg/smart/scsiinquirypage.go
@@ -57,7 +57,10 @@ func (d *SCSIDev) scsiInquiry() (InquiryResponse, error) {
 // command using Inquiry response struct
 func (inquiry InquiryResponse) getValue() map[string]string {
 	InqRespMap := make(map[string]string)
-	InqRespMap[SPCVersion] = fmt.Sprintf("%.d", inquiry.Version)
+
+	SPCVersionValue := fmt.Sprintf("%.d", (inquiry.Version - 0x02))
+
+	InqRespMap[Compliance] = "SPC-" + SPCVersionValue
 	InqRespMap[Vendor] = fmt.Sprintf("%.8s", inquiry.VendorID)
 	InqRespMap[ModelNumber] = fmt.Sprintf("%.16s", inquiry.ProductID)
 	InqRespMap[FirmwareRev] = fmt.Sprintf("%.4s", inquiry.ProductRev)

--- a/pkg/smart/types.go
+++ b/pkg/smart/types.go
@@ -33,7 +33,7 @@ const (
 
 // Constants being used by switch case for returning disk details
 const (
-	SPCVersion         = "SPCVersion"
+	Compliance         = "Compliance"
 	Vendor             = "Vendor"
 	Capacity           = "Capacity"
 	LogicalSectorSize  = "LogicalSectorSize"
@@ -148,7 +148,7 @@ var serialATAType = map[int]string{
 
 // ScsiInqAttr is the list of attributes fetched by SCSI Inquiry command
 var ScsiInqAttr = map[string]bool{
-	SPCVersion:   true,
+	Compliance:   true,
 	Vendor:       true,
 	SerialNumber: true,
 	ModelNumber:  true,
@@ -249,7 +249,7 @@ type DiskAttr struct {
 
 // BasicDiskAttr is the structure being used for returning basic disk details
 type BasicDiskAttr struct {
-	SPCVersion       string
+	Compliance       string
 	Vendor           string
 	ModelNumber      string
 	SerialNumber     string

--- a/samples/disk.yaml
+++ b/samples/disk.yaml
@@ -14,7 +14,7 @@ spec:
     firmwareRevision: '1   '
     model: PersistentDisk
     serial: disk-2
-    spcVersion: "6"
+    compliance: "SPC-4"
     vendor: Google
   devlinks:
   - kind: by-id


### PR DESCRIPTION
This PR will introduce the following changes -
-  It will add logic to show the correct SPC version (i.e implemented specifications) of a disk instead of showing the raw version value obtained from scsi inquiry command.

-  It will change field **SPCVersion** to **Compliance** which seems to be a more generic term than SPCVersion.

- It will fix the nil pointer reference error in server_test file which occurs when the port to be checked is already on use and calling net.Listen returns error.

Changes committed:
	
    modified:   cmd/controller/disk.go
	modified:   cmd/probe/smartprobe.go
	modified:   cmd/probe/smartprobe_test.go
	modified:   docs/design.md
	modified:   pkg/apis/openebs.io/v1alpha1/types.go
	modified:   pkg/smart/doc.go
	modified:   pkg/smart/mockdata.go
	modified:   pkg/smart/scsidevice.go
	modified:   pkg/smart/scsiinquirypage.go
	modified:   pkg/smart/types.go
    modified:   pkg/server/server_test.go
	modified:   samples/disk.yaml

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>