### PR TITLE
Fix typo in scsicommands.go

### DIFF
--- a/pkg/smart/scsicommands.go
+++ b/pkg/smart/scsicommands.go
@@ -73,7 +73,7 @@ func (d *SCSIDev) runSCSIGen(header *sgIOHeader) error {
 	return nil
 }
 
-// Error returns error string of error occured while sending SGIO(scsi generic ioctl)
+// Error returns error string of error occurred while sending SGIO(scsi generic ioctl)
 // to a scsi device using the sgIOErr format
 func (s sgIOErr) Error() string {
 	return fmt.Sprintf("SCSI status: %#02x, host status: %#02x, driver status: %#02x",


### PR DESCRIPTION
fix typo occured -> occurred
Signed-off-by: vikash srivastava <srivastava.vikash@outlook.com>

fixes: #109 