### PR TITLE
style(ndm): fixed eventhandler lint error

### DIFF
--- a/cmd/probe/eventhandler.go
+++ b/cmd/probe/eventhandler.go
@@ -22,11 +22,14 @@ import (
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
 )
 
+// EventAction global variable to store eventAction
 type EventAction string
 
 const (
-	AttachEA EventAction = libudevwrapper.UDEV_ACTION_ADD    // AttachEA is attach disk event name
-	DetachEA EventAction = libudevwrapper.UDEV_ACTION_REMOVE // DetachEA is detach disk event name
+	// AttachEA is attach disk event name
+	AttachEA EventAction = libudevwrapper.UDEV_ACTION_ADD
+	// DetachEA is detach disk event name
+	DetachEA EventAction = libudevwrapper.UDEV_ACTION_REMOVE
 )
 
 // ProbeEvent struct contain a copy of controller it will update disk resources

--- a/cmd/probe/eventhandler.go
+++ b/cmd/probe/eventhandler.go
@@ -22,7 +22,7 @@ import (
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
 )
 
-// EventAction global type to store eventAction
+// EventAction action type for disk events like attach or detach events
 type EventAction string
 
 const (

--- a/cmd/probe/eventhandler.go
+++ b/cmd/probe/eventhandler.go
@@ -22,7 +22,7 @@ import (
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
 )
 
-// EventAction global variable to store eventAction
+// EventAction global type to store eventAction
 type EventAction string
 
 const (


### PR DESCRIPTION
After fixing mentioned lint error,
it throws following error 
`type name will be used as probe.ProbeEvent by other packages, and that stutters; consider calling this Event` [here](https://github.com/openebs/node-disk-manager/blob/master/cmd/probe/eventhandler.go#L33).

This error also came in other golang project, they solved it by changing the name. [Repo](https://github.com/giantswarm/inago/pull/43/files)

I have done what was asked in this issue. On your suggestion, I can work on the given lint error
g