### PR TITLE
Fixed go vet command running issue on error: struct field tag  not co…

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/types.go
+++ b/pkg/apis/openebs.io/v1alpha1/types.go
@@ -13,7 +13,7 @@ import (
 // Disk describes disk resource.
 type Disk struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata, omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   DiskSpec   `json:"spec"`
 	Status DiskStatus `json:"status"`


### PR DESCRIPTION
…mpatible with reflect.StructTag.Get: suspicious space in struct tag value (vet)

Fixed `go vet` issue:
```
error: struct field tag `json:"metadata, omitempty"` not compatible with reflect.StructTag.Get: suspicious space in struct tag value (vet)
```

reference issue: #110 

Signed-off-by: Richard Burk Orofeo <chardy.orofeo@yahoo.com.ph>