### PR TITLE
style(ndm): Fixed `golint` error in pkg/metrics/common.go

### DIFF
--- a/pkg/apis/openebs.io/v1alpha1/types.go
+++ b/pkg/apis/openebs.io/v1alpha1/types.go
@@ -13,7 +13,7 @@ import (
 // Disk describes disk resource.
 type Disk struct {
 	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata, omitempty"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   DiskSpec   `json:"spec"`
 	Status DiskStatus `json:"status"`

--- a/pkg/metrics/common.go
+++ b/pkg/metrics/common.go
@@ -23,6 +23,8 @@ import (
 )
 
 var (
+	// StartingTime represents
+	// the starting of time
 	StartingTime time.Time
 	Uptime       = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "Uptime",

--- a/pkg/metrics/common.go
+++ b/pkg/metrics/common.go
@@ -23,8 +23,7 @@ import (
 )
 
 var (
-	// StartingTime represents
-	// the starting of time
+	// StartingTime represents the starting time of ndm process
 	StartingTime time.Time
 	Uptime       = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "Uptime",


### PR DESCRIPTION
Fixes the linting in `metrics/common.go` file.

Signed-off-by: Richard Burk Orofeo chardy.orofeo@yahoo.com.ph

reference issue: #98 
