### PR TITLE
fix(smartProbe):fix smart probe to fill larger(>2TB) disk capacity also

### DIFF
--- a/cmd/probe/capacityprobe.go
+++ b/cmd/probe/capacityprobe.go
@@ -106,4 +106,5 @@ func (cp *capacityProbe) FillDiskDetails(d *controller.DiskInfo) {
 	if d.LogicalSectorSize == 0 {
 		d.LogicalSectorSize = uint32(sectorSize)
 	}
+	glog.Infof("Capacity probe successfully filled the disk details for disk having uuid, %+v", d.Uuid)
 }

--- a/cmd/probe/smartprobe.go
+++ b/cmd/probe/smartprobe.go
@@ -97,7 +97,7 @@ func (sp *smartProbe) FillDiskDetails(d *controller.DiskInfo) {
 	smartProbe := newSmartProbe(d.ProbeIdentifiers.SmartIdentifier)
 	deviceBasicSCSIInfo, err := smartProbe.SmartIdentifier.SCSIBasicDiskInfo()
 	if len(err) != 0 {
-		glog.Error(err)
+		glog.Errorf("Smart Probe is unable to fill all the disk details for disk uuid, %+v. Error: %+v", d.Uuid, err)
 	}
 
 	d.Compliance = deviceBasicSCSIInfo.Compliance


### PR DESCRIPTION
smart probe is now able to fill disk capacity for disks having capacity larger than 2 TB also.

Earlier it was not able to fill disk capacity of a disk having capacity more than 2TB since it was only using ReadCapacity10 scsi command to get the capacity of a disk.
Now it is able to send ReadCapacity16 scsi command also if  the capacity is more than 2TB which is the maximum limit fetched using ReadCapacity10 scsi command.

Changes committed:

	modified:   cmd/probe/capacityprobe.go
	modified:   cmd/probe/smartprobe.go
	modified:   pkg/smart/common.go
	modified:   pkg/smart/scsicommands.go

Signed-off-by: sagarkrsd <sagar.kumar@openebs.io>