### PR TITLE
Support yaml config for node-disk-manager

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -659,6 +659,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9f02be0b4d62fcafa9c48bef02fe28e1b184bf21a86c453e7c9ead21a4a0f1b3"
+  inputs-digest = "c193b1aac11efb53a865cd225f08addc4d337696b310bb3aecb0bd47597269fc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,3 +60,7 @@ required = [
 [[override]]
   name = "gopkg.in/fsnotify.v1"
   source = "https://github.com/fsnotify/fsnotify.git"
+
+[[constraint]]
+  name = "github.com/ghodss/yaml"
+  version = "1.0.0"

--- a/cmd/controller/ndmconfig.go
+++ b/cmd/controller/ndmconfig.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 )
 
@@ -57,11 +58,18 @@ func (c *Controller) SetNDMConfig() {
 		glog.Error("unable to set ndm config : ", err)
 		return
 	}
+
 	var ndmConfig NodeDiskManagerConfig
-	if err := json.Unmarshal(data, &ndmConfig); err != nil {
+	if json.Valid(data) {
+		err = json.Unmarshal(data, &ndmConfig)
+	} else {
+		err = yaml.Unmarshal(data, &ndmConfig)
+	}
+	if err != nil {
 		c.NDMConfig = nil
 		glog.Error("unable to set ndm config : ", err)
 		return
 	}
+
 	c.NDMConfig = &ndmConfig
 }

--- a/cmd/controller/ndmconfig_test.go
+++ b/cmd/controller/ndmconfig_test.go
@@ -95,3 +95,42 @@ func TestSetNDMConfig(t *testing.T) {
 	os.Remove(fakeConfigFilePath)
 	ConfigFilePath = defaultConfigFilePath
 }
+
+func TestController_SetNDMConfig_yaml(t *testing.T) {
+	fakeConfigFilePath := "/tmp/fakendm-yaml.config"
+	writeTestYaml(t, fakeConfigFilePath)
+	defer os.Remove(fakeConfigFilePath)
+
+	ConfigFilePath = fakeConfigFilePath
+
+	ctrl := &Controller{}
+	ctrl.SetNDMConfig()
+
+	assert.NotNil(t, ctrl.NDMConfig)
+
+	assert.Len(t, ctrl.NDMConfig.ProbeConfigs, 1)
+	expectedProbeConfig := ProbeConfig{Key: "udev-probe", Name: "udev probe", State: "true"}
+	assert.Equal(t, expectedProbeConfig, ctrl.NDMConfig.ProbeConfigs[0])
+
+	assert.Len(t, ctrl.NDMConfig.FilterConfigs, 1)
+	expectedFilterConfig := FilterConfig{Key: "os-disk-exclude-filter", Name: "os disk exclude filter", State: "true", Include: "", Exclude: "/,/etc/hosts,/boot"}
+	assert.Equal(t, expectedFilterConfig, ctrl.NDMConfig.FilterConfigs[0])
+}
+
+func writeTestYaml(t *testing.T, fpath string) {
+	data := `
+probeconfigs:
+  - key: udev-probe
+    name: udev probe
+    state: true
+filterconfigs:
+  - key: os-disk-exclude-filter
+    name: os disk exclude filter
+    state: true
+    include: ""
+    exclude: /,/etc/hosts,/boot
+`
+
+	err := ioutil.WriteFile(fpath, []byte(data), 0644)
+	assert.NoError(t, err)
+}

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -18,42 +18,29 @@ data:
   # filterconfigs contails configs of filters. To provide a group of include
   # and exclude values add it as , separated string
   node-disk-manager.config: |
-    {
-      "probeconfigs": [
-        {
-          "key": "udev-probe",
-          "name": "udev probe",
-          "state": "true"
-        },
-        {
-          "key": "smart-probe",
-          "name": "smart probe",
-          "state": "true"
-        }
-      ],
-      "filterconfigs": [
-        {
-          "key": "os-disk-exclude-filter",
-          "name": "os disk exclude filter",
-          "state": "true",
-          "exclude": "/,/etc/hosts,/boot"
-        },
-        {
-          "key": "vendor-filter",
-          "name": "vendor filter",
-          "state": "true",
-          "include":"",
-          "exclude":"CLOUDBYT,OpenEBS"
-        },
-        {
-          "key": "path-filter",
-          "name": "path filter",
-          "state": "true",
-          "include":"",
-          "exclude":"loop"
-        }
-      ]
-    }
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+        exclude: "/,/etc/hosts,/boot"
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: "CLOUDBYT,OpenEBS"
+      - key: path-filter
+        name: path filter
+        state: true
+        include: ""
+        exclude: loop
+
 ---
 # Create NDM Service Account
 apiVersion: v1

--- a/samples/node-disk-manager-config.yaml
+++ b/samples/node-disk-manager-config.yaml
@@ -11,31 +11,19 @@ data:
   # filterconfigs contails configs of filters. To provide a group of include
   # and exclude values add it as , separated string
   node-disk-manager.config: |
-    {
-      "probeconfigs": [
-        {
-          "key": "udev-probe",
-          "name": "udev probe",
-          "state": "true"
-        },
-        {
-          "key": "smart-probe",
-          "name": "smart probe",
-          "state": "true"
-        }
-      ],
-      "filterconfigs": [
-        {
-          "key": "os-disk-exclude-filter",
-          "name": "os disk exclude filter",
-          "state": "true"
-        },
-        {
-          "key": "vendor-filter",
-          "name": "vendor filter",
-          "state": "true",
-          "include":"",
-          "exclude":""
-        }
-      ]
-    }
+    probeconfigs:
+      - key: udev-probe
+        name: udev probe
+        state: true
+      - key: smart-probe
+        name: smart probe
+        state: true
+    filterconfigs:
+      - key: os-disk-exclude-filter
+        name: os disk exclude filter
+        state: true
+      - key: vendor-filter
+        name: vendor filter
+        state: true
+        include: ""
+        exclude: ""


### PR DESCRIPTION
Add yaml support for NDM config. json support is preserved.

Fixes #148
