### PR TITLE
Remove ineffectual assignments in udev_test.go

### DIFF
--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -61,7 +61,7 @@ func TestNewUdevEnumerate(t *testing.T) {
 		t.Fatal(err)
 	}
 	devenu1.UnrefUdevEnumerate()
-	dev2, err := newUdev(nil)
+	dev2, _ := newUdev(nil)
 	if dev2 != nil {
 		t.Fatal("udev object should be nil for null pointer")
 	}
@@ -85,10 +85,9 @@ func TestNewDeviceFromSysPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	device2, err := udev.NewDeviceFromSysPath(diskDetails.SysPath)
+	device2, _ := udev.NewDeviceFromSysPath(diskDetails.SysPath)
 	if device2 != nil {
 		assert.Equal(t, diskDetails.SysPath, device2.GetSyspath())
 		defer device2.UdevDeviceUnref()
 	}
-
 }


### PR DESCRIPTION
Fixes #166

According to the Go Report Card for this project, there are two occurrences where the `err` variables are declared, but not used:

![image](https://user-images.githubusercontent.com/13009507/47446649-af84af80-d789-11e8-9588-e48f41a85f4b.png)
