### PR TITLE
[Issue #179] Enable core dump in node-disk-manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
   # a particular scsi device, sudo or root permissions are required.
   - sudo -E env "PATH=$PATH" make test
   - make integration-test
+  - kubectl describe pod
 
 after_success:
   - DIMAGE=openebs/node-disk-manager-$ARCH ./hack/push;

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,4 +14,4 @@ COPY ./hack/entrypoint.sh /usr/local/bin
 EXPOSE 9090
 
 #Set the default command
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -9,7 +9,7 @@ ARG ARCH
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm
-COPY entrypoint.sh /usr/local/bin
+COPY ./hack/entrypoint.sh /usr/local/bin
 #Expose port 9090
 EXPOSE 9090
 

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -9,9 +9,9 @@ ARG ARCH
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm
-COPY ./hack/entrypoint.sh /usr/local/bin
+COPY ./hack/entrypoint.sh /usr/local/bin/entrypoint.sh
 #Expose port 9090
 EXPOSE 9090
 
 #Set the default command
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,4 +14,4 @@ COPY ./hack/entrypoint.sh /usr/local/bin/entrypoint.sh
 EXPOSE 9090
 
 #Set the default command
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -9,9 +9,9 @@ ARG ARCH
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm
-
+COPY entrypoint.sh /usr/local/bin
 #Expose port 9090
 EXPOSE 9090
 
 #Set the default command
-ENTRYPOINT ["ndm", "start"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,4 +14,4 @@ COPY ./hack/entrypoint.sh /usr/local/bin/entrypoint.sh
 EXPOSE 9090
 
 #Set the default command
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+ulimit -c unlimited
+echo "/var/ndm/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+env GOTRACEBACK=crash /usr/sbin/ndm start

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 ulimit -c unlimited
-echo "/var/ndm/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 env GOTRACEBACK=crash /usr/sbin/ndm start

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
 ulimit -c unlimited
+
+echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+
 env GOTRACEBACK=crash /usr/sbin/ndm start

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -141,8 +141,6 @@ spec:
           mountPath: /host/mounts
         - name: sparsepath
           mountPath: /var/openebs
-        - name: ndm
-          mountPath: /var/ndm
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -175,6 +173,3 @@ spec:
       - name: sparsepath
         hostPath:
           path: /var/openebs
-      - name: ndm 
-        hostPath:
-          path: /var/ndm

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -126,7 +126,7 @@ spec:
       containers:
       - name: node-disk-manager
         command:
-        - /usr/local/bin/entrypoint.sh
+        - entrypoint.sh
         image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: Always
         securityContext:

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -125,8 +125,6 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager
-        command:
-        - entrypoint.sh
         image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: Always
         securityContext:

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -126,8 +126,7 @@ spec:
       containers:
       - name: node-disk-manager
         command:
-        - /usr/sbin/ndm
-        - start
+        - entrypoint.sh
         image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: Always
         securityContext:
@@ -144,6 +143,8 @@ spec:
           mountPath: /host/mounts
         - name: sparsepath
           mountPath: /var/openebs
+        - name: ndm
+          mountPath: /var/ndm
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -176,3 +177,6 @@ spec:
       - name: sparsepath
         hostPath:
           path: /var/openebs
+      - name: ndm 
+        hostPath:
+          path: /var/ndm

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -126,7 +126,7 @@ spec:
       containers:
       - name: node-disk-manager
         command:
-        - entrypoint.sh
+        - /usr/local/bin/entrypoint.sh
         image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: Always
         securityContext:


### PR DESCRIPTION
Enable core dump in node-disk-manager.

Signed-off-by: satbir <satbir.chhikara@gmail.com>