### PR TITLE
(feat): add support for custom disk

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -51,7 +51,7 @@ const (
 	// NDMDiskTypeKey specifies the type of disk.
 	NDMDiskTypeKey = "ndm.io/disk-type"
 	// NDMUnmanagedDiskKey specifies disk cr should be managed by ndm or not.
-	NDMUnmanagedKey = "ndm.io/unmanaged"
+	NDMManagedKey = "ndm.io/managed"
 )
 
 const (

--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -34,6 +34,10 @@ import (
 const (
 	// NDMKind is the CR kind.
 	NDMKind = "Disk"
+	// FalseString contains string value of false
+	FalseString = "false"
+	// TrueString contains string value of true
+	TrueString = "true"
 	// NDMVersion is the CR version.
 	NDMVersion = "openebs.io/v1alpha1"
 	// NDMHostKey is host name label prefix.
@@ -46,6 +50,8 @@ const (
 	NDMUnknown = "Unknown"
 	// NDMDiskTypeKey specifies the type of disk.
 	NDMDiskTypeKey = "ndm.io/disk-type"
+	// NDMUnmanagedDiskKey specifies disk cr should be managed by ndm or not.
+	NDMUnmanagedKey = "ndm.io/unmanaged"
 )
 
 const (

--- a/cmd/controller/disk.go
+++ b/cmd/controller/disk.go
@@ -107,7 +107,7 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 	}
 	objectMeta.Labels[NDMHostKey] = di.HostName
 	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
-	objectMeta.Labels[NDMUnmanagedKey] = FalseString
+	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta
 }
 

--- a/cmd/controller/disk.go
+++ b/cmd/controller/disk.go
@@ -107,6 +107,7 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 	}
 	objectMeta.Labels[NDMHostKey] = di.HostName
 	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
+	objectMeta.Labels[NDMUnmanagedKey] = FalseString
 	return objectMeta
 }
 

--- a/cmd/controller/disk_test.go
+++ b/cmd/controller/disk_test.go
@@ -149,6 +149,7 @@ func TestGetObjectMeta(t *testing.T) {
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	fakeObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 
 	tests := map[string]struct {
 		actualObjectMeta   metav1.ObjectMeta
@@ -257,6 +258,7 @@ func TestToDisk(t *testing.T) {
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	fakeObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	expectedDisk.ObjectMeta = fakeObjectMeta
 	expectedDisk.Spec.DevLinks = fakeDevLinks
 	expectedDisk.Status.State = NDMActive

--- a/cmd/controller/disk_test.go
+++ b/cmd/controller/disk_test.go
@@ -149,7 +149,7 @@ func TestGetObjectMeta(t *testing.T) {
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	fakeObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	fakeObjectMeta.Labels[NDMManagedKey] = TrueString
 
 	tests := map[string]struct {
 		actualObjectMeta   metav1.ObjectMeta
@@ -258,7 +258,7 @@ func TestToDisk(t *testing.T) {
 	}
 	fakeObjectMeta.Labels[NDMHostKey] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	fakeObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	fakeObjectMeta.Labels[NDMManagedKey] = TrueString
 	expectedDisk.ObjectMeta = fakeObjectMeta
 	expectedDisk.Spec.DevLinks = fakeDevLinks
 	expectedDisk.Status.State = NDMActive

--- a/cmd/controller/diskstore.go
+++ b/cmd/controller/diskstore.go
@@ -103,6 +103,7 @@ func (c *Controller) DeleteDisk(name string) {
 // and returns list of disk resources.
 func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 	label := NDMHostKey + "=" + c.HostName
+	label = label + "," + NDMUnmanagedKey + "!=" + TrueString
 	filter := metav1.ListOptions{LabelSelector: label}
 	listDR, err := c.Clientset.OpenebsV1alpha1().Disks().List(filter)
 	return listDR, err

--- a/cmd/controller/diskstore.go
+++ b/cmd/controller/diskstore.go
@@ -103,7 +103,7 @@ func (c *Controller) DeleteDisk(name string) {
 // and returns list of disk resources.
 func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 	label := NDMHostKey + "=" + c.HostName
-	label = label + "," + NDMUnmanagedKey + "!=" + TrueString
+	label = label + "," + NDMManagedKey + "!=" + FalseString
 	filter := metav1.ListOptions{LabelSelector: label}
 	listDR, err := c.Clientset.OpenebsV1alpha1().Disks().List(filter)
 	return listDR, err

--- a/cmd/controller/diskstore_test.go
+++ b/cmd/controller/diskstore_test.go
@@ -57,7 +57,7 @@ func TestCreateDisk(t *testing.T) {
 	dr1 := fakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr1.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr1.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr1)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
@@ -65,7 +65,7 @@ func TestCreateDisk(t *testing.T) {
 	dr2 := fakeDr
 	dr2.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr2.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr2.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr2.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr2)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
@@ -73,7 +73,7 @@ func TestCreateDisk(t *testing.T) {
 	dr3 := newFakeDr
 	dr3.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr3.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr3.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr3.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr3)
 	cdr3, err3 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
 
@@ -107,7 +107,7 @@ func TestUpdateDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	err := fakeController.UpdateDisk(dr, nil)
 	if err == nil {
 		t.Error("error should not be nil as the resource is not present")
@@ -167,7 +167,7 @@ func TestDeactivateDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 	fakeController.DeactivateDisk(dr)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
@@ -175,13 +175,13 @@ func TestDeactivateDisk(t *testing.T) {
 	dr1 := newFakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr1.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr1.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.DeactivateDisk(dr1)
 	// create another resource and deactivate it.
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
 	fakeController.DeactivateDisk(newDr)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -216,7 +216,7 @@ func TestDeleteDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 	fakeController.DeleteDisk(fakeDiskUid)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
@@ -226,7 +226,7 @@ func TestDeleteDisk(t *testing.T) {
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
 	fakeController.DeleteDisk(newFakeDiskUid)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -261,13 +261,13 @@ func TestListDiskResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
 	listDevice, err := fakeController.ListDiskResource()
 	typeMeta := metav1.TypeMeta{}
@@ -309,13 +309,13 @@ func TestGetExistingResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
 
 	listDr, err := fakeController.ListDiskResource()
@@ -363,7 +363,7 @@ func TestPushResource(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	fakeDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	fakeDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 
 	// pass 1st argument as nil then it creates one disk resource
 	fakeController.PushDiskResource(nil, deviceDetails)
@@ -402,13 +402,13 @@ func TestDeactivateStaleDiskResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
 	//add one resource's uuid so state of the other resource should be inactive.
 	diskList := make([]string, 0)
@@ -445,7 +445,7 @@ func TestMarkDiskStatusToUnknown(t *testing.T) {
 	dr := mockEmptyDiskCr()
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
-	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
+	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 
 	fakeController.MarkDiskStatusToUnknown()

--- a/cmd/controller/diskstore_test.go
+++ b/cmd/controller/diskstore_test.go
@@ -57,6 +57,7 @@ func TestCreateDisk(t *testing.T) {
 	dr1 := fakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr1.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr1)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
@@ -64,6 +65,7 @@ func TestCreateDisk(t *testing.T) {
 	dr2 := fakeDr
 	dr2.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr2.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr2.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr2)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
 
@@ -71,6 +73,7 @@ func TestCreateDisk(t *testing.T) {
 	dr3 := newFakeDr
 	dr3.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr3.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr3.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr3)
 	cdr3, err3 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
 
@@ -104,6 +107,7 @@ func TestUpdateDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	err := fakeController.UpdateDisk(dr, nil)
 	if err == nil {
 		t.Error("error should not be nil as the resource is not present")
@@ -163,6 +167,7 @@ func TestDeactivateDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 	fakeController.DeactivateDisk(dr)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
@@ -170,11 +175,13 @@ func TestDeactivateDisk(t *testing.T) {
 	dr1 := newFakeDr
 	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr1.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.DeactivateDisk(dr1)
 	// create another resource and deactivate it.
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(newDr)
 	fakeController.DeactivateDisk(newDr)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -209,6 +216,7 @@ func TestDeleteDisk(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 	fakeController.DeleteDisk(fakeDiskUid)
 	cdr1, err1 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(fakeDiskUid, metav1.GetOptions{})
@@ -218,6 +226,7 @@ func TestDeleteDisk(t *testing.T) {
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(newDr)
 	fakeController.DeleteDisk(newFakeDiskUid)
 	cdr2, err2 := fakeController.Clientset.OpenebsV1alpha1().Disks().Get(newFakeDiskUid, metav1.GetOptions{})
@@ -252,11 +261,13 @@ func TestListDiskResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(newDr)
 	listDevice, err := fakeController.ListDiskResource()
 	typeMeta := metav1.TypeMeta{}
@@ -298,11 +309,13 @@ func TestGetExistingResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(newDr)
 
 	listDr, err := fakeController.ListDiskResource()
@@ -350,6 +363,7 @@ func TestPushResource(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	fakeDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 
 	// pass 1st argument as nil then it creates one disk resource
 	fakeController.PushDiskResource(nil, deviceDetails)
@@ -388,11 +402,13 @@ func TestDeactivateStaleDiskResource(t *testing.T) {
 	dr := fakeDr
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 	// create resource2
 	newDr := newFakeDr
 	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	newDr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(newDr)
 	//add one resource's uuid so state of the other resource should be inactive.
 	diskList := make([]string, 0)
@@ -429,6 +445,7 @@ func TestMarkDiskStatusToUnknown(t *testing.T) {
 	dr := mockEmptyDiskCr()
 	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
+	dr.ObjectMeta.Labels[NDMUnmanagedKey] = FalseString
 	fakeController.CreateDisk(dr)
 
 	fakeController.MarkDiskStatusToUnknown()

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -124,7 +124,7 @@ func TestAddDiskEvent(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
-	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
+	fakeDr.ObjectMeta.Labels[controller.NDMManagedKey] = controller.TrueString
 	fakeDr.Spec.Details.Model = fakeModel
 	fakeDr.Spec.Details.Serial = fakeSerial
 	fakeDr.Spec.Details.Vendor = fakeVendor
@@ -161,7 +161,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
-	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
+	fakeDr.ObjectMeta.Labels[controller.NDMManagedKey] = controller.TrueString
 	fakeController.CreateDisk(fakeDr)
 
 	probeEvent := &ProbeEvent{

--- a/cmd/probe/eventhandler_test.go
+++ b/cmd/probe/eventhandler_test.go
@@ -124,6 +124,7 @@ func TestAddDiskEvent(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
+	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
 	fakeDr.Spec.Details.Model = fakeModel
 	fakeDr.Spec.Details.Serial = fakeSerial
 	fakeDr.Spec.Details.Vendor = fakeVendor
@@ -160,6 +161,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 	fakeDr := mockEmptyDiskCr()
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
+	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
 	fakeController.CreateDisk(fakeDr)
 
 	probeEvent := &ProbeEvent{

--- a/cmd/probe/smartprobe_test.go
+++ b/cmd/probe/smartprobe_test.go
@@ -175,7 +175,7 @@ func TestSmartProbe(t *testing.T) {
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
-	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
+	fakeDr.ObjectMeta.Labels[controller.NDMManagedKey] = controller.TrueString
 
 	tests := map[string]struct {
 		actualDisk    apis.Disk

--- a/cmd/probe/smartprobe_test.go
+++ b/cmd/probe/smartprobe_test.go
@@ -175,6 +175,7 @@ func TestSmartProbe(t *testing.T) {
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
+	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
 
 	tests := map[string]struct {
 		actualDisk    apis.Disk

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -174,6 +174,7 @@ func TestUdevProbe(t *testing.T) {
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
+	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
 	tests := map[string]struct {
 		actualDisk    apis.Disk
 		expectedDisk  apis.Disk

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -174,7 +174,7 @@ func TestUdevProbe(t *testing.T) {
 	}
 	fakeDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = "disk"
-	fakeDr.ObjectMeta.Labels[controller.NDMUnmanagedKey] = controller.FalseString
+	fakeDr.ObjectMeta.Labels[controller.NDMManagedKey] = controller.TrueString
 	tests := map[string]struct {
 		actualDisk    apis.Disk
 		expectedDisk  apis.Disk

--- a/disk.yaml
+++ b/disk.yaml
@@ -1,0 +1,15 @@
+apiVersion: openebs.io/v1alpha1
+kind: Disk
+metadata:
+  name: disk-123345 #<name of disk> #should be unique like disk-random-unique-name
+  labels:
+    kubernetes.io/hostname: minikube #<host name in which disk/device is attached> # like gke-openebs-user-default-pool-044afcb8-bmc0
+    ndm.io/managed: "false" # for manual disk creation put true
+    ndm.io/disk-type: disk #<device type> # like disk, partition, sparse file
+status:
+  state: Active
+spec:
+  capacity:
+    logicalSectorSize: 512 #<logical sector size of disk> # like 512
+    storage: 1024 #<total capacity in bits> #like 53687091200
+  path: /dev/sda#<devpath> # like /dev/sdb

--- a/samples/custom-disk.yaml
+++ b/samples/custom-disk.yaml
@@ -1,7 +1,7 @@
 apiVersion: openebs.io/v1alpha1
 kind: Disk
 metadata:
-  name: disk-123345 #<name of disk> #should be unique like disk-random-unique-name
+  name: unique-disk-name #<name of disk> #should be unique like disk-random-unique-name
   labels:
     kubernetes.io/hostname: minikube #<host name in which disk/device is attached> # like gke-openebs-user-default-pool-044afcb8-bmc0
     ndm.io/managed: "false" # for manual disk creation put true
@@ -11,5 +11,5 @@ status:
 spec:
   capacity:
     logicalSectorSize: 512 #<logical sector size of disk> # like 512
-    storage: 1024 #<total capacity in bits> #like 53687091200
-  path: /dev/sda#<devpath> # like /dev/sdb
+    storage: 1073741824 #<total capacity in bits> #like 53687091200
+  path: /dev/sda7 #<devpath> # like /dev/sdb

--- a/samples/disk.yaml
+++ b/samples/disk.yaml
@@ -4,7 +4,7 @@ metadata:
   name: <name of disk> #should be unique like disk-random-unique-name
   labels:
     kubernetes.io/hostname: <host name in which disk/device is attached> # like gke-openebs-user-default-pool-044afcb8-bmc0
-    ndm.io/unmanage: "true" # for manual disk creation put true
+    ndm.io/managed: "false" # for manual disk creation put false
     ndm.io/disk-type: <device type> # like disk, partition, sparse file
 status:
   state: Active

--- a/samples/disk.yaml
+++ b/samples/disk.yaml
@@ -1,27 +1,29 @@
 apiVersion: openebs.io/v1alpha1
 kind: Disk
 metadata:
-  name: disk-3d8b1efad969208d6bf5971f2c34dd0c
+  name: <name of disk> #should be unique like disk-random-unique-name
   labels:
-    "kubernetes.io/hostname": "gke-openebs-user-default-pool-044afcb8-bmc0"
+    kubernetes.io/hostname: <host name in which disk/device is attached> # like gke-openebs-user-default-pool-044afcb8-bmc0
+    ndm.io/unmanage: "true" # for manual disk creation put true
+    ndm.io/disk-type: <device type> # like disk, partition, sparse file
 status:
   state: Active
 spec:
   capacity:
-    logicalSectorSize: 512
-    storage: 53687091200
+    logicalSectorSize: <logical sector size of disk> # like 512
+    storage: <total capacity in bits> #like 53687091200
   details:
-    firmwareRevision: '1   '
-    model: PersistentDisk
-    serial: disk-2
-    compliance: "SPC-4"
-    vendor: Google
+    firmwareRevision: <firmware revision>
+    model: <model name of disk> # like PersistentDisk
+    serial: <serial no of disk> # like google-disk-2
+    compliance: <compliance of disk> #like "SPC-4"
+    vendor: <vendor of disk> #like Google
   devlinks:
   - kind: by-id
     links:
-    - /dev/disk/by-id/scsi-0Google_PersistentDisk_disk-2
-    - /dev/disk/by-id/google-disk-2
+    - <link1> # like /dev/disk/by-id/scsi-0Google_PersistentDisk_disk-2
+    - <link2> # like /dev/disk/by-id/google-disk-2
   - kind: by-path
     links:
-    - /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:2:0
-  path: /dev/sdb
+    - <link1> # like /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:2:0
+  path: <devpath> # like /dev/sdb


### PR DESCRIPTION
If I create a custom disk using sample yaml ndm will make it's state inactive in every restart or if there is any error in ndm. This pr add one more label in disk cr to detect if the resource will be managed by
ndm or not.

NDM will manage those resources which contains `ndm.io/unmanage=false` in label.

To create a sable disk using spaese files or partition of a disk You need to modify (update disk/device attributes) and apply this [yaml](https://raw.githubusercontent.com/openebs/node-disk-manager/master/samples/disk.yaml) file.

Signed-off-by: Shovan Maity <shovan.cse91@gmail.com>