### PR TITLE
(fix): ndm cleanup process for graceful shutdown

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -107,7 +107,7 @@ echo "==> Removing old bin contents..."
 deleteOldContents
 
 # If its dev mode, only build for ourself
-if [[ "${NDM_AGENT_DEV}" ]]; then
+if [[ -n "${NDM_AGENT_DEV}" ]]; then
     XC_OS=$(go env GOOS)
     XC_ARCH=$(go env GOARCH)
 fi

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,7 +1,33 @@
 #!/bin/bash
 
+echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
-
 echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+env GOTRACEBACK=crash
+echo "[entrypoint.sh] launching ndm process."
+/usr/sbin/ndm start &
 
-env GOTRACEBACK=crash /usr/sbin/ndm start
+#sigterm caught SIGTERM signal and forward it to child process
+_sigterm() {
+  echo "[entrypoint.sh] caught SIGTERM signal forwarding to pid [$child]."
+  kill -TERM "$child" 2> /dev/null
+  waitForChildProcessToFinish
+}
+
+#sigint caught SIGINT signal and forward it to child process
+_sigint() {
+  echo "[entrypoint.sh] caught SIGINT signal forwarding to pid [$child]."
+  kill -INT "$child" 2> /dev/null
+  waitForChildProcessToFinish
+}
+
+#waitForChildProcessToFinish waits for child process to finish
+waitForChildProcessToFinish(){
+    while ps -p "$child" > /dev/null; do sleep 1; done;
+}
+
+trap _sigint INT
+trap _sigterm SIGTERM
+
+child=$!
+wait $child


### PR DESCRIPTION
Previously ndm process was main process of ndm pod (pid-1). Now ndm process is launched by `entrypoint.sh` for that 2 process are running inside ndm pod.

```
root@shovan-Latitude-3560:/# ps -aux
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root         1  0.0  0.0  18040  2756 ?        Ss   06:53   0:00 /bin/bash /usr/local/bin/entrypoint.sh
root         7  0.0  0.2 564108 21200 ?        Sl   06:53   0:00 /usr/sbin/ndm start
```

K8s sends `SIGKILL`, `SIGINT`, `SIGTERM` signals to main process (pid-1) and there were some cleanup process done by ndm when it gets `SIGKILL`, `SIGINT`, `SIGTERM` signals. NDM process was not getting these signals for this cleanup process stuck. Code in this pr caught `SIGINT` and `SIGTERM` signals and pass it to ndm process (chield process).

Changes committed:
modified:   hack/build.sh
modified:   hack/entrypoint.sh

Signed-off-by: Shovan Maity <shovan.cse91@gmail.com>