### PR TITLE
[DE153] Probe failure error handle

### DIFF
--- a/cmd/ndm_daemonset/controller/probe_test.go
+++ b/cmd/ndm_daemonset/controller/probe_test.go
@@ -39,10 +39,11 @@ func (np *fakeProbe) Start() {
 	messageChannel <- message
 }
 
-func (np *fakeProbe) FillDiskDetails(fakeDiskInfo *DiskInfo) {
+func (np *fakeProbe) FillDiskDetails(fakeDiskInfo *DiskInfo) error {
 	fakeDiskInfo.Model = fakeModel
 	fakeDiskInfo.Serial = fakeSerial
 	fakeDiskInfo.Vendor = fakeVendor
+	return nil
 }
 
 //Add one new probe and get the list of the probes and match them

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -45,9 +45,13 @@ func (pe *ProbeEvent) addDiskEvent(msg controller.EventMessage) {
 		go pe.initOrErrorEvent()
 		return
 	}
+	mismatch := false
 	for _, diskDetails := range msg.Devices {
 		glog.Info("Processing details for ", diskDetails.ProbeIdentifiers.Uuid)
-		pe.Controller.FillDiskDetails(diskDetails)
+		if err := pe.Controller.FillDiskDetails(diskDetails); err != nil {
+			mismatch = true
+			continue
+		}
 		// if ApplyFilter returns true then we process the event further
 		if !pe.Controller.ApplyFilter(diskDetails) {
 			continue
@@ -99,6 +103,9 @@ func (pe *ProbeEvent) addDiskEvent(msg controller.EventMessage) {
 			go pe.initOrErrorEvent()
 			return
 		}
+	}
+	if mismatch {
+		go pe.initOrErrorEvent()
 	}
 }
 

--- a/cmd/ndm_daemonset/probe/probe_test.go
+++ b/cmd/ndm_daemonset/probe/probe_test.go
@@ -30,10 +30,11 @@ type fakeProbe struct {
 
 func (p *fakeProbe) Start() {}
 
-func (p *fakeProbe) FillDiskDetails(fakeDiskInfo *controller.DiskInfo) {
+func (p *fakeProbe) FillDiskDetails(fakeDiskInfo *controller.DiskInfo) error {
 	fakeDiskInfo.Model = fakeModel
 	fakeDiskInfo.Serial = fakeSerial
 	fakeDiskInfo.Vendor = fakeVendor
+	return nil
 }
 
 func TestRegisterProbe(t *testing.T) {

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -88,17 +88,17 @@ func newSeachestProbe(devPath string) *seachestProbe {
 func (scp *seachestProbe) Start() {}
 
 // fillDiskDetails fills details in diskInfo struct using information it gets from probe
-func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
+func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) error {
 	if d.ProbeIdentifiers.SeachestIdentifier == "" {
 		glog.Error("seachestIdentifier is found empty, seachest probe will not fill disk details.")
-		return
+		return controller.ProbeErrors(controller.SkipRescan)
 	}
 
 	seachestProbe := newSeachestProbe(d.ProbeIdentifiers.SeachestIdentifier)
 	driveInfo, err := seachestProbe.SeachestIdentifier.SeachestBasicDiskInfo()
 	if err != 0 {
 		glog.Error(err)
-		return
+		return controller.ProbeErrors(controller.SkipRescan)
 	}
 
 	if d.Path == "" {
@@ -173,12 +173,12 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 
 	if d.DeviceUtilizationRate == 0 {
 		d.DeviceUtilizationRate = seachestProbe.SeachestIdentifier.GetDeviceUtilizationRate(driveInfo)
-		glog.Infof("Disk: %s DeviceUtilizationRate:%d filled by seachest.", d.Path, d.DeviceUtilizationRate)
+		glog.Infof("Disk: %s DeviceUtilizationRate:%v filled by seachest.", d.Path, d.DeviceUtilizationRate)
 	}
 
 	if d.PercentEnduranceUsed == 0 {
 		d.PercentEnduranceUsed = seachestProbe.SeachestIdentifier.GetPercentEnduranceUsed(driveInfo)
-		glog.Infof("Disk: %s PercentEnduranceUsed:%d filled by seachest.", d.Path, d.PercentEnduranceUsed)
+		glog.Infof("Disk: %s PercentEnduranceUsed:%v filled by seachest.", d.Path, d.PercentEnduranceUsed)
 	}
 
 	d.TemperatureInfo.TemperatureDataValid = seachestProbe.
@@ -217,4 +217,5 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 		glog.Infof("Disk: %s LowestTemperature:%d filled by seachest.",
 			d.Path, d.TemperatureInfo.LowestTemperature)
 	}
+	return nil
 }

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -168,23 +168,44 @@ func (up *udevProbe) scan() error {
 }
 
 // fillDiskDetails filles details in diskInfo struct using probe information
-func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
+func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) error {
 	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
 	if err != nil {
-		glog.Errorf("%s : %s", d.ProbeIdentifiers.UdevIdentifier, err)
-		return
+		glog.Error(err)
+		return controller.ProbeErrors(controller.InitiateRescan)
 	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()
 	defer udevDevice.free()
-	d.ProbeIdentifiers.SmartIdentifier = udevDiskDetails.Path
-	d.ProbeIdentifiers.SeachestIdentifier = udevDiskDetails.Path
-	d.Model = udevDiskDetails.Model
-	d.Path = udevDiskDetails.Path
-	d.Serial = udevDiskDetails.Serial
-	d.Vendor = udevDiskDetails.Vendor
-	d.ByIdDevLinks = udevDiskDetails.ByIdDevLinks
-	d.ByPathDevLinks = udevDiskDetails.ByPathDevLinks
+	if udevDiskDetails.Path != "" {
+		d.Path = udevDiskDetails.Path
+		d.ProbeIdentifiers.SmartIdentifier = udevDiskDetails.Path
+		glog.Infof("Disk: %s SmartIdentifier:%s filled by udev probe.", d.Path, d.ProbeIdentifiers.SmartIdentifier)
+		d.ProbeIdentifiers.SeachestIdentifier = udevDiskDetails.Path
+		glog.Infof("Disk: %s SeachestIdentifier:%s filled by udev probe.", d.Path, d.ProbeIdentifiers.SeachestIdentifier)
+		glog.Infof("Disk: %s Path:%s filled by udev probe.", d.Path, d.Path)
+	}
+	if udevDiskDetails.Model != "" {
+		d.Model = udevDiskDetails.Model
+		glog.Infof("Disk: %s Model:%s filled by udev probe.", d.Path, d.Model)
+	}
+	if udevDiskDetails.Serial != "" {
+		d.Serial = udevDiskDetails.Serial
+		glog.Infof("Disk: %s Serial:%s filled by udev probe.", d.Path, d.Serial)
+	}
+	if udevDiskDetails.Vendor != "" {
+		d.Vendor = udevDiskDetails.Vendor
+		glog.Infof("Disk: %s Vendor:%s filled by udev probe.", d.Path, d.Vendor)
+	}
+	if len(udevDiskDetails.ByIdDevLinks) != 0 {
+		d.ByIdDevLinks = udevDiskDetails.ByIdDevLinks
+		glog.Infof("Disk: %s ByIdDevLinks:%s filled by udev probe.", d.Path, d.ByIdDevLinks)
+	}
+	if len(udevDiskDetails.ByPathDevLinks) != 0 {
+		d.ByPathDevLinks = udevDiskDetails.ByPathDevLinks
+		glog.Infof("Disk: %s ByPathDevLinks:%s filled by udev probe.", d.Path, d.ByPathDevLinks)
+	}
 	d.FileSystemInfo = udevDiskDetails.FileSystem
+	return nil
 }
 
 // listen listens for event message over UdevEventMessages channel


### PR DESCRIPTION
If a probe produces some error during filling disk details or some other works. It was not retrying to put those details againg or rescan system again. This PR will add capability to return custom error from probe and probe handler will take action depending on error.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

Co-authored-by: Akhil Mohan <akhil.mohan@mayadata.io>