### PR TITLE
Error handling in seachest probe

### DIFF
--- a/cmd/probe/seachestprobe.go
+++ b/cmd/probe/seachestprobe.go
@@ -98,6 +98,7 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 	driveInfo, err := seachestProbe.SeachestIdentifier.SeachestBasicDiskInfo()
 	if err != 0 {
 		glog.Error(err)
+		return
 	}
 
 	if d.Path == "" {


### PR DESCRIPTION
If NDM is run in unprivileged mode, Seachest probe was causing the pod into `CrashLoopBackOff` state. This was because Seachest was having insufficient permissions to fetch the details. The PR aborts filling the details by Seachest probe if its not able to get the `driveInfo` pointer.