### PR TITLE
fix (yaml): changed pull policy and upgrade strategy

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -110,6 +110,8 @@ kind: DaemonSet
 metadata:
   name: node-disk-manager
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -129,7 +129,7 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         # make udev database available inside container

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -20,9 +20,6 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        command:
-        - /usr/sbin/ndm
-        - start
         image: openebs/node-disk-manager-amd64:ci
         imagePullPolicy: IfNotPresent
         securityContext:

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -24,7 +24,7 @@ spec:
         - /usr/sbin/ndm
         - start
         image: openebs/node-disk-manager-amd64:ci
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Changed `ImagePullPolicy` to `IfNotPresent`. Earlier, during integration testing the old image from docker-hub was pulled which overwrite the newly built images. This resulted in integration tests being performed on the old image and also the old image was retagged and pushed. With the change, only the newly built image will be used.

The update strategy of Daemonset is now set to RollingUpdate, so that the new image will be applied without manual deletion.