### PR TITLE
[WIP][US4295] feat(diskCR): detecting change/delete udev events

### DIFF
--- a/cmd/ndm_daemonset/controller/probe.go
+++ b/cmd/ndm_daemonset/controller/probe.go
@@ -98,8 +98,8 @@ func (c *Controller) ListProbe() []*Probe {
 
 // FillDiskDetails lists registered probes and fills details from each probe
 func (c *Controller) FillDiskDetails(diskDetails *DiskInfo) {
+	glog.Info("started filling details for ", diskDetails.ProbeIdentifiers.Uuid)
 	diskDetails.HostName = c.HostName
-	diskDetails.DiskType = NDMDefaultDiskType
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
 	probes := c.ListProbe()
 	for _, probe := range probes {

--- a/cmd/ndm_daemonset/controller/probe_test.go
+++ b/cmd/ndm_daemonset/controller/probe_test.go
@@ -189,7 +189,6 @@ func TestFillDetails(t *testing.T) {
 	expectedDr.Model = fakeModel
 	expectedDr.Serial = fakeSerial
 	expectedDr.Vendor = fakeVendor
-	expectedDr.DiskType = NDMDefaultDiskType
 
 	// create one fake Disk struct
 	actualDr := &DiskInfo{}

--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -116,7 +116,7 @@ func (nf *fakeFilter) Exclude(fakeDiskInfo *controller.DiskInfo) bool {
 	return fakeDiskInfo.Uuid != ignoreDiskUuid
 }
 
-func TestAddDiskEvent(t *testing.T) {
+func TestAddEvent(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
 	fakeKubeClient := fake.NewSimpleClientset()
 	fakeController := &controller.Controller{
@@ -151,17 +151,19 @@ func TestAddDiskEvent(t *testing.T) {
 	eventmsg := make([]*controller.DiskInfo, 0)
 	device1Details := &controller.DiskInfo{}
 	device1Details.ProbeIdentifiers.Uuid = mockuid
+	device1Details.DiskType = libudevwrapper.UDEV_DISK
 	eventmsg = append(eventmsg, device1Details)
 	// device-2 details
 	device2Details := &controller.DiskInfo{}
 	device2Details.ProbeIdentifiers.Uuid = ignoreDiskUuid
+	device2Details.DiskType = libudevwrapper.UDEV_DISK
 	eventmsg = append(eventmsg, device2Details)
 	// Creating one event message
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: eventmsg,
 	}
-	probeEvent.addDiskEvent(eventDetails)
+	probeEvent.addEvent(eventDetails)
 	// Retrieve disk resource
 	cdr1, err1 := fakeController.GetDisk(mockuid)
 
@@ -195,7 +197,7 @@ func TestAddDiskEvent(t *testing.T) {
 	}
 }
 
-func TestDeleteDiskEvent(t *testing.T) {
+func TestDeleteEvent(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
 	fakeKubeClient := fake.NewSimpleClientset()
 	probes := make([]*controller.Probe, 0)
@@ -220,12 +222,13 @@ func TestDeleteDiskEvent(t *testing.T) {
 	eventmsg := make([]*controller.DiskInfo, 0)
 	deviceDetails := &controller.DiskInfo{}
 	deviceDetails.ProbeIdentifiers.Uuid = mockuid
+	deviceDetails.DiskType = libudevwrapper.UDEV_DISK
 	eventmsg = append(eventmsg, deviceDetails)
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_REMOVE,
 		Devices: eventmsg,
 	}
-	probeEvent.deleteDiskEvent(eventDetails)
+	probeEvent.deleteEvent(eventDetails)
 
 	// Retrieve disk resource
 	cdr1, err1 := fakeController.GetDisk(mockuid)

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -173,12 +173,12 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 
 	if d.DeviceUtilizationRate == 0 {
 		d.DeviceUtilizationRate = seachestProbe.SeachestIdentifier.GetDeviceUtilizationRate(driveInfo)
-		glog.Infof("Disk: %s DeviceUtilizationRate:%d filled by seachest.", d.Path, d.DeviceUtilizationRate)
+		glog.Infof("Disk: %s DeviceUtilizationRate:%v filled by seachest.", d.Path, d.DeviceUtilizationRate)
 	}
 
 	if d.PercentEnduranceUsed == 0 {
 		d.PercentEnduranceUsed = seachestProbe.SeachestIdentifier.GetPercentEnduranceUsed(driveInfo)
-		glog.Infof("Disk: %s PercentEnduranceUsed:%d filled by seachest.", d.Path, d.PercentEnduranceUsed)
+		glog.Infof("Disk: %s PercentEnduranceUsed:%v filled by seachest.", d.Path, d.PercentEnduranceUsed)
 	}
 
 	d.TemperatureInfo.TemperatureDataValid = seachestProbe.

--- a/cmd/ndm_daemonset/probe/smartprobe_test.go
+++ b/cmd/ndm_daemonset/probe/smartprobe_test.go
@@ -157,13 +157,14 @@ func TestSmartProbe(t *testing.T) {
 	deviceDetails := &controller.DiskInfo{}
 	deviceDetails.ProbeIdentifiers.Uuid = mockOsDiskDetailsUsingUdev.Uid
 	deviceDetails.ProbeIdentifiers.SmartIdentifier = mockOsDiskDetails.DevPath
+	deviceDetails.DiskType = libudevwrapper.UDEV_DISK
 	eventmsg = append(eventmsg, deviceDetails)
 
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: eventmsg,
 	}
-	probeEvent.addDiskEvent(eventDetails)
+	probeEvent.addEvent(eventDetails)
 
 	// Retrieve disk resource
 	cdr1, err1 := fakeController.GetDisk(mockOsDiskDetailsUsingUdev.Uid)

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -50,9 +50,14 @@ func mockOsDiskToAPI() (apis.Disk, error) {
 		Serial: mockOsDiskDetails.Serial,
 		Vendor: mockOsDiskDetails.Vendor,
 	}
+	fileSystem := ""
+	if mockOsDiskDetails.FileSystem != libudevwrapper.UDEV_FS_NONE {
+		fileSystem = mockOsDiskDetails.FileSystem
+	}
 	fakeObj := apis.DiskSpec{
-		Path:    mockOsDiskDetails.DevNode,
-		Details: fakeDetails,
+		Path:       mockOsDiskDetails.DevNode,
+		Details:    fakeDetails,
+		FileSystem: fileSystem,
 	}
 
 	devLinks := make([]apis.DiskDevLink, 0)
@@ -167,7 +172,7 @@ func TestUdevProbe(t *testing.T) {
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: eventmsg,
 	}
-	probeEvent.addDiskEvent(eventDetails)
+	probeEvent.addEvent(eventDetails)
 	// Retrieve disk resource
 	cdr1, err1 := fakeController.GetDisk(mockOsDiskDetails.Uid)
 	fakeDr, err := mockOsDiskToAPI()

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -36,6 +36,7 @@ const (
 	NDMDevicePrefix     = "device-"            // NDMdevicePrefix used as device's uuid prefix
 	UDEV_SUBSYSTEM      = "block"              // udev to filter this device type
 	UDEV_SYSTEM         = "disk"               // used to filter devices other than disk which udev tracks (eg. CD ROM)
+	UDEV_DISK           = UDEV_SYSTEM          // used to filter out disks
 	UDEV_PARTITION      = "partition"          // used to filter out partitions
 	UDEV_PATH           = "DEVPATH"            // udev attribute to get device path
 	UDEV_WWN            = "ID_WWN"             // udev attribute to get device WWN number
@@ -73,7 +74,9 @@ type UdevDiskDetails struct {
 	Path           string   // Path is Path of a disk.
 	ByIdDevLinks   []string // ByIdDevLinks contains by-id devlinks
 	ByPathDevLinks []string // ByPathDevLinks contains by-path devlinks
+	DiskType       string   // DeviceType can be disk, partition
 	FileSystem     string   // FileSystem on the disk
+	PartitionType  string   // Partitiontype on the disk/device
 }
 
 // freeCharPtr frees c pointer
@@ -84,7 +87,7 @@ func freeCharPtr(s *C.char) {
 //DiskInfoFromLibudev returns disk attribute extracted using libudev apicalls.
 func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 	devLinks := device.GetDevLinks()
-	fileSystem := device.GetPropertyValue(UDEV_FS_TYPE)
+	fileSystem := device.GetFileSystemInfo()
 	if len(fileSystem) == 0 {
 		fileSystem = UDEV_FS_NONE
 	}
@@ -95,7 +98,9 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 		Path:           device.GetPropertyValue(UDEV_DEVNAME),
 		ByIdDevLinks:   devLinks[BY_ID_LINK],
 		ByPathDevLinks: devLinks[BY_PATH_LINK],
+		DiskType:       device.GetDevtype(),
 		FileSystem:     fileSystem,
+		PartitionType:  device.GetPartitionType(),
 	}
 	return diskDetails
 }

--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -84,6 +84,7 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 		ByIdDevLinks:   diskDetails.ByIdDevLinks,
 		ByPathDevLinks: diskDetails.ByPathDevLinks,
 		FileSystem:     diskDetails.FileSystem,
+		DiskType:       diskDetails.DevType,
 	}
 	assert.Equal(t, expectedDiskDetails, device.DiskInfoFromLibudev())
 	tests := map[string]struct {

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -45,6 +45,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 	deviceDetails := &controller.DiskInfo{}
 	deviceDetails.ProbeIdentifiers.Uuid = uuid
 	deviceDetails.ProbeIdentifiers.UdevIdentifier = device.GetSyspath()
+	deviceDetails.DiskType = device.GetDevtype()
 	diskInfo = append(diskInfo, deviceDetails)
 	e.eventDetails.Action = action
 	e.eventDetails.Devices = diskInfo

--- a/pkg/udevevent/event_test.go
+++ b/pkg/udevevent/event_test.go
@@ -53,6 +53,7 @@ func TestProcess(t *testing.T) {
 	deviceDetails := &controller.DiskInfo{}
 	deviceDetails.ProbeIdentifiers.Uuid = osDiskDetails.Uid
 	deviceDetails.ProbeIdentifiers.UdevIdentifier = osDiskDetails.SysPath
+	deviceDetails.DiskType = libudevwrapper.UDEV_DISK
 	diskInfo = append(diskInfo, deviceDetails)
 	expectedEvent.eventDetails.Action = ""
 	expectedEvent.eventDetails.Devices = diskInfo

--- a/pkg/udevevent/monitor.go
+++ b/pkg/udevevent/monitor.go
@@ -93,7 +93,7 @@ func (m *monitor) process(fd int) error {
 	if err != nil {
 		return err
 	}
-	if !device.IsDisk() {
+	if !device.IsDisk() && !device.IsParitition() {
 		device.UdevDeviceUnref()
 		return nil
 	}

--- a/pkg/util/strmatch.go
+++ b/pkg/util/strmatch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"regexp"
 	"strings"
 )
 
@@ -52,4 +53,11 @@ func MatchIgnoredCase(keys []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// MatchRegex is a utility function which returns true if the string -s
+// matches with the regex specified.
+func MatchRegex(regex, s string) bool {
+	r := regexp.MustCompile(regex)
+	return r.MatchString(s)
 }

--- a/pkg/util/strmatch_test.go
+++ b/pkg/util/strmatch_test.go
@@ -76,3 +76,32 @@ func TestMatchIgnoredCase(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchRegex(t *testing.T) {
+	tests := map[string]struct {
+		regex    string
+		str      string
+		expected bool
+	}{
+		"string matches without the need of regex portion": {
+			regex:    "/dev/sda(([0-9]*|p[0-9]+))$",
+			str:      "/dev/sda",
+			expected: true,
+		},
+		"string matches with regex": {
+			regex:    "/dev/sda(([0-9]*|p[0-9]+))$",
+			str:      "/dev/sda1",
+			expected: true,
+		},
+		"string does not match the regex": {
+			regex:    "/dev/sda(([0-9]*|p[0-9]+))$",
+			str:      "/dev/sdaa",
+			expected: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, MatchRegex(test.regex, test.str))
+		})
+	}
+}


### PR DESCRIPTION
Add/delete events for partitions will be now monitored and the corresponding changes will be updated in the diskCR. When a partition is deleted, the details of the last partition will be removed from the diskCR instead of removing the exact partition. This is because a unique id to detect partitions is yet to be implemented. Changes in disk/devices (add/delete) will be now monitored through udev events and corresponding updates will be made in the diskCR.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>