### PR TITLE
[US4256] feat(operator-sdk): Changing go version to work with operator-sdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: go
 
 go:
-  - 1.9.2
+  - 1.10.3
 
 env:
   global:


### PR DESCRIPTION
Operator-sdk work on go version "1.10.3" or later. This PR is to make NDM use "1.10.3" go version.

Signed-off-by: satbir <satbir.singh@mayadata.io>