### PR TITLE
fix (udev) : index out of bound error while scanning partitions

### DIFF
--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -162,7 +162,6 @@ func (up *udevProbe) scan() error {
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: diskInfo,
 	}
-	glog.Info("Partition Data to channel: ", eventDetails.Devices[3].PartitionData)
 	udevevent.UdevEventMessageChannel <- eventDetails
 	return nil
 }


### PR DESCRIPTION
Removes a hardcoded log message which caused an index out of bound
error while performing the initial scan on udev

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>