### PR TITLE
fix (sparsefile): parse file-size in non-int format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
   # a particular scsi device, sudo or root permissions are required.
   - sudo -E env "PATH=$PATH" make test
   - make integration-test
-  - kubectl describe pod
 
 after_success:
   - DIMAGE=openebs/node-disk-manager-$ARCH ./hack/push;

--- a/cmd/controller/sparsefilegenerator.go
+++ b/cmd/controller/sparsefilegenerator.go
@@ -122,11 +122,12 @@ func GetSparseFileSize() int64 {
 		return SparseFileDefaultSize
 	}
 
-	sparseFileSize, econv := strconv.ParseInt(sparseFileSizeStr, 10, 64)
+	fileSize, econv := strconv.ParseFloat(sparseFileSizeStr, 64)
 	if econv != nil {
-		glog.Info("Error converting sparse file size:  ", sparseFileSizeStr)
+		glog.Error("Error converting sparse file size:  ", econv)
 		return 0
 	}
+	sparseFileSize := int64(fileSize)
 
 	if sparseFileSize < SparseFileMinSize {
 		glog.Info(fmt.Sprint(sparseFileSizeStr), " is less than minimum required. Setting the size to:  ", fmt.Sprint(SparseFileMinSize))


### PR DESCRIPTION
when sparsefile size is specified in exponential notation from platform like rancher, ndm could not parse it. Now this parsing is enabled by first parsing the string to float64 and then converting to int64

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>