### PR TITLE
fix(script): Enabling core dump for ndm daemon-set

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+export GOTRACEBACK=crash
+
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
 echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
-env GOTRACEBACK=crash
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 


### PR DESCRIPTION
When `env GOTRACE` was used, the ndm daemon set was not receiving the environment variable. Now we `export` the variable so that it is set in the environment where ndm daemon-set binary is run.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>