### PR TITLE
fix (sparsefile): parse file size in non-int format

### DIFF
--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -122,11 +122,12 @@ func GetSparseFileSize() int64 {
 		return SparseFileDefaultSize
 	}
 
-	sparseFileSize, econv := strconv.ParseInt(sparseFileSizeStr, 10, 64)
+	fileSize, econv := strconv.ParseFloat(sparseFileSizeStr, 64)
 	if econv != nil {
-		glog.Info("Error converting sparse file size:  ", sparseFileSizeStr)
+		glog.Error("Error converting sparse file size:  ", econv)
 		return 0
 	}
+	sparseFileSize := int64(fileSize)
 
 	if sparseFileSize < SparseFileMinSize {
 		glog.Info(fmt.Sprint(sparseFileSizeStr), " is less than minimum required. Setting the size to:  ", fmt.Sprint(SparseFileMinSize))

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
@@ -86,10 +86,11 @@ func TestGetSparseFileSize(t *testing.T) {
 		envFileSize  string
 		expectedSize int64
 	}{
-		"When size is not set":           {envFileSize: "", expectedSize: defaultSize},
-		"When valid size is set":         {envFileSize: "2000000000", expectedSize: int64(2000000000)},
-		"When less than min size is set": {envFileSize: "100", expectedSize: minSize},
-		"When invalid size is set":       {envFileSize: "z", expectedSize: 0},
+		"When size is not set":                {envFileSize: "", expectedSize: defaultSize},
+		"When valid size is set":              {envFileSize: "2000000000", expectedSize: int64(2000000000)},
+		"When file size is given as exponent": {envFileSize: "1.073741824e+11", expectedSize: int64(107374182400)},
+		"When less than min size is set":      {envFileSize: "100", expectedSize: minSize},
+		"When invalid size is set":            {envFileSize: "z", expectedSize: 0},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
When sparse file size is specified in exponential notation from platform like rancher and pharos, ndm could not parse it. Now this parsing is enabled by first parsing the string to float64 and then converting to int64

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>