### PR TITLE
fix(script): Enabling core dump for ndm daemon-set (cherry-pick #219)

### DIFF
--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+export GOTRACEBACK=crash
+
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
 echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
-env GOTRACEBACK=crash
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 


### PR DESCRIPTION
when `env GOTRACE` was used, the ndm daemon set was not receiving the environment variable. Now we export the variable so that it is set in the environment where ndm daemon-set binary is run.

cherry-pick #219 