### PR TITLE
fix(udev): added nil check while getting udev devices

### DIFF
--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -171,7 +171,7 @@ func (up *udevProbe) scan() error {
 func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
 	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
 	if err != nil {
-		glog.Error(err)
+		glog.Errorf("%s : %s", d.ProbeIdentifiers.UdevIdentifier, err)
 		return
 	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -94,20 +94,20 @@ func newUdevProbe(c *controller.Controller) *udevProbe {
 // newUdevProbeForFillDiskDetails returns udevProbe struct which helps populate diskInfo struct.
 // it contains copy of udevDevice struct to populate diskInfo use defer free in caller function
 // to free c pointer memory
-func newUdevProbeForFillDiskDetails(sysPath string) *udevProbe {
+func newUdevProbeForFillDiskDetails(sysPath string) (*udevProbe, error) {
 	udev, err := libudevwrapper.NewUdev()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevDevice, err := udev.NewDeviceFromSysPath(sysPath)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevProbe := &udevProbe{
 		udev:       udev,
 		udevDevice: udevDevice,
 	}
-	return udevProbe
+	return udevProbe, nil
 }
 
 // Start setup udev probe listener and make a single scan of system
@@ -169,7 +169,11 @@ func (up *udevProbe) scan() error {
 
 // fillDiskDetails filles details in diskInfo struct using probe information
 func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
-	udevDevice := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	if err != nil {
+		glog.Error(err)
+		return
+	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()
 	defer udevDevice.free()
 	d.ProbeIdentifiers.SmartIdentifier = udevDiskDetails.Path

--- a/pkg/udev/device.go
+++ b/pkg/udev/device.go
@@ -34,7 +34,7 @@ type UdevDevice struct {
 // it returns nil if the pointer passed is NULL.
 func newUdevDevice(ptr *C.struct_udev_device) (*UdevDevice, error) {
 	if ptr == nil {
-		return nil, errors.New("unable to create Udevice object for for null struct struct_udev_device")
+		return nil, errors.New("unable to create Udevice object for null struct struct_udev_device")
 	}
 	ud := &UdevDevice{
 		udptr: ptr,

--- a/pkg/udev/monitor_test.go
+++ b/pkg/udev/monitor_test.go
@@ -117,6 +117,6 @@ func TestUdevMonitorNewDevice(t *testing.T) {
 	defer udevMonitor.UdevMonitorUnref()
 	_, err = udevMonitor.ReceiveDevice()
 	if err != nil {
-		assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+		assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	}
 }

--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -80,7 +80,7 @@ func TestNewDeviceFromSysPath(t *testing.T) {
 	if device1 != nil {
 		t.Fatal("device should be nil for invalid syspath")
 	}
-	assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+	assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
If `libudev` returns an invalid address/nil pointer while trying to create a udev struct from syspath, the error was not checked or logged. 

This PR enables logging and  error checking,  and aborts fetching details using udev probe if libudev returns nil.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>