### PR TITLE
fix(udev) : added udev nil check (cherry-pick #230)

### DIFF
--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -94,20 +94,20 @@ func newUdevProbe(c *controller.Controller) *udevProbe {
 // newUdevProbeForFillDiskDetails returns udevProbe struct which helps populate diskInfo struct.
 // it contains copy of udevDevice struct to populate diskInfo use defer free in caller function
 // to free c pointer memory
-func newUdevProbeForFillDiskDetails(sysPath string) *udevProbe {
+func newUdevProbeForFillDiskDetails(sysPath string) (*udevProbe, error) {
 	udev, err := libudevwrapper.NewUdev()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevDevice, err := udev.NewDeviceFromSysPath(sysPath)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevProbe := &udevProbe{
 		udev:       udev,
 		udevDevice: udevDevice,
 	}
-	return udevProbe
+	return udevProbe, nil
 }
 
 // Start setup udev probe listener and make a single scan of system
@@ -168,7 +168,11 @@ func (up *udevProbe) scan() error {
 
 // fillDiskDetails filles details in diskInfo struct using probe information
 func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
-	udevDevice := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	if err != nil {
+		glog.Error(err)
+		return
+	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()
 	defer udevDevice.free()
 	d.ProbeIdentifiers.SmartIdentifier = udevDiskDetails.Path

--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -170,7 +170,7 @@ func (up *udevProbe) scan() error {
 func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
 	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
 	if err != nil {
-		glog.Error(err)
+		glog.Errorf("%s : %s", d.ProbeIdentifiers.UdevIdentifier, err)
 		return
 	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package probe
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -187,6 +188,46 @@ func TestUdevProbe(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, test.expectedDisk, test.actualDisk)
+			assert.Equal(t, test.expectedError, test.actualError)
+		})
+	}
+}
+
+func TestNewUdevProbeForFillDiskDetails(t *testing.T) {
+	// Creating the actual udev probe struct
+	mockDisk, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sysPath := mockDisk.SysPath
+	udev, err := libudevwrapper.NewUdev()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualUdevProbe := &udevProbe{
+		udev: udev,
+	}
+	actualUdevProbe.udevDevice, err = actualUdevProbe.udev.NewDeviceFromSysPath(sysPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	udevProbeError := errors.New("unable to create Udevice object for null struct struct_udev_device")
+
+	// expected cases
+	expectedUdevProbe1, expectedError1 := newUdevProbeForFillDiskDetails(sysPath)
+	expectedUdevProbe2, expectedError2 := newUdevProbeForFillDiskDetails("")
+	tests := map[string]struct {
+		actualUdevProbe   *udevProbe
+		expectedUdevProbe *udevProbe
+		actualError       error
+		expectedError     error
+	}{
+		"udev probe with correct syspath": {actualUdevProbe: actualUdevProbe, expectedUdevProbe: expectedUdevProbe1, actualError: nil, expectedError: expectedError1},
+		"udev probe with empty syspath":   {actualUdevProbe: nil, expectedUdevProbe: expectedUdevProbe2, actualError: udevProbeError, expectedError: expectedError2},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedUdevProbe, test.actualUdevProbe)
 			assert.Equal(t, test.expectedError, test.actualError)
 		})
 	}

--- a/pkg/udev/device.go
+++ b/pkg/udev/device.go
@@ -34,7 +34,7 @@ type UdevDevice struct {
 // it returns nil if the pointer passed is NULL.
 func newUdevDevice(ptr *C.struct_udev_device) (*UdevDevice, error) {
 	if ptr == nil {
-		return nil, errors.New("unable to create Udevice object for for null struct struct_udev_device")
+		return nil, errors.New("unable to create Udevice object for null struct struct_udev_device")
 	}
 	ud := &UdevDevice{
 		udptr: ptr,

--- a/pkg/udev/monitor_test.go
+++ b/pkg/udev/monitor_test.go
@@ -117,6 +117,6 @@ func TestUdevMonitorNewDevice(t *testing.T) {
 	defer udevMonitor.UdevMonitorUnref()
 	_, err = udevMonitor.ReceiveDevice()
 	if err != nil {
-		assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+		assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	}
 }

--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -80,7 +80,7 @@ func TestNewDeviceFromSysPath(t *testing.T) {
 	if device1 != nil {
 		t.Fatal("device should be nil for invalid syspath")
 	}
-	assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+	assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When libudev return an invalid address/ nil pointer, the error was not logged and handled. Enabled logging and error handling for this case.

cherry-pick #230 