### PR TITLE
fix(yaml): changed host path for creating sparse file

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -4,7 +4,7 @@ export GOTRACEBACK=crash
 
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
-echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+echo "/var/openebs/sparse/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -180,7 +180,7 @@ spec:
         - name: procmount
           mountPath: /host/mounts
         - name: sparsepath
-          mountPath: /var/openebs
+          mountPath: /var/openebs/sparse
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -212,7 +212,7 @@ spec:
           path: /proc/1/mounts
       - name: sparsepath
         hostPath:
-          path: /var/openebs
+          path: /var/openebs/sparse
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
changed the hostpath at which sparse file is created by NDM. Now sparse file will be created at `/var/openebs/sparse` directory. Also, the core-dump will be stored at the same location.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>