### PR TITLE
fix(controller): fixed client init and CR update

### DIFF
--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -135,7 +135,7 @@ func NewController(kubeconfig string) (*Controller, error) {
 		return controller, err
 	}
 
-	controller.Clientset = controller.mgr.GetClient()
+	controller.Clientset, err = client.New(cfg, client.Options{})
 	if err != nil {
 		return controller, err
 	}

--- a/cmd/ndm_daemonset/controller/devicestore.go
+++ b/cmd/ndm_daemonset/controller/devicestore.go
@@ -77,17 +77,17 @@ func (c *Controller) UpdateDevice(dvr apis.Device, oldDvr *apis.Device) error {
 
 	dvrCopy := dvr.DeepCopy()
 	if oldDvr == nil {
-		oldDvrCopy := dvr.DeepCopy()
+		oldDvr = dvr.DeepCopy()
 		err = c.Clientset.Get(context.TODO(), client.ObjectKey{
-			Namespace: oldDvrCopy.Namespace,
-			Name:      oldDvrCopy.Name}, oldDvrCopy)
+			Namespace: oldDvr.Namespace,
+			Name:      oldDvr.Name}, oldDvr)
 		if err != nil {
-			glog.Error("Unable to get device object : ", err)
+			glog.Errorf("Unable to get device object:%v, err:%v", oldDvr.ObjectMeta.Name, err)
 			return err
 		}
-		dvrCopy.ObjectMeta.ResourceVersion = oldDvrCopy.ObjectMeta.ResourceVersion
 	}
 
+	dvrCopy.ObjectMeta.ResourceVersion = oldDvr.ObjectMeta.ResourceVersion
 	err = c.Clientset.Update(context.TODO(), dvrCopy)
 	if err != nil {
 		glog.Error("Unable to update device object : ", err)

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -64,18 +64,18 @@ func (c *Controller) UpdateDisk(dr apis.Disk, oldDr *apis.Disk) error {
 	drCopy := dr.DeepCopy()
 
 	if oldDr == nil {
-		oldDrCopy := dr.DeepCopy()
+		oldDr = dr.DeepCopy()
 		var err error
 		err = c.Clientset.Get(context.TODO(), client.ObjectKey{
-			Namespace: oldDrCopy.Namespace,
-			Name:      oldDrCopy.Name}, oldDrCopy)
+			Namespace: oldDr.Namespace,
+			Name:      oldDr.Name}, oldDr)
 		if err != nil {
-			glog.Errorf("Unable to get disk object:%v, err:%v", oldDrCopy.ObjectMeta.Name, err)
+			glog.Errorf("Unable to get disk object:%v, err:%v", oldDr.ObjectMeta.Name, err)
 			return err
 		}
-		drCopy.ObjectMeta.ResourceVersion = oldDrCopy.ObjectMeta.ResourceVersion
 	}
 
+	drCopy.ObjectMeta.ResourceVersion = oldDr.ObjectMeta.ResourceVersion
 	err := c.Clientset.Update(context.TODO(), drCopy)
 	if err != nil {
 		glog.Errorf("Unable to update disk object:%v, err:%v", drCopy.ObjectMeta.Name, err)


### PR DESCRIPTION
runtime client is now created using client.New() instead of from the manager. update on the disk/device CR now takes the latest resource version and updates the resource

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>