### PR TITLE
fix(code,yaml): fix to mount the /proc directory of host

### DIFF
--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -31,7 +31,7 @@ const (
 var (
 	defaultMountFilePath     = "/proc/self/mounts"
 	mountPoints              = []string{"/", "/etc/hosts"}
-	hostMountFilePath        = "/host/mounts"           // hostMountFilePath is the file path mounted inside container
+	hostMountFilePath        = "/host/proc/1/mounts"    // hostMountFilePath is the file path mounted inside container
 	oSDiskExcludeFilterName  = "os disk exclude filter" // filter name
 	oSDiskExcludeFilterState = defaultEnabled           // filter state
 )

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -178,7 +178,8 @@ spec:
         - name: udev
           mountPath: /run/udev
         - name: procmount
-          mountPath: /host/mounts
+          mountPath: /host/proc
+          readOnly: true
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -209,7 +210,8 @@ spec:
       # mount /proc/1/mounts (mount file of process 1 of host) inside container
       # to read which partition is mounted on / path
         hostPath:
-          path: /proc/1/mounts
+          path: /proc
+          type: Directory
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse


### PR DESCRIPTION
`/proc/1/mounts` cannot be mounted into container in systems with selinux enabled. But `/proc` directory can be mounted. This fix mounts the `/proc` directory to `/host/proc` inside container and thus the mounts file will be available at `/host/proc/1/mounts`.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>