### PR TITLE
fix(yaml): change directory to create sparse file

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -155,7 +155,7 @@ spec:
         # specify the directory where the sparse files need to be created.
         # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR
-          value: "/var/openebs"
+          value: "/var/openebs/sparse"
         # Size of the sparse file to be created.
         - name: SPARSE_FILE_SIZE
           value: "1073741824"


### PR DESCRIPTION
sparse file will be now created in `/var/openebs/sparse`, instead of `/var/openebs`.

Fixes changes missed in #233

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>