### PR TITLE
fix(travis): push node-disk-operator image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,6 @@ script:
   - sudo -E env "PATH=$PATH" make test
 
 after_success:
-  - DIMAGE=openebs/node-disk-manager-$ARCH ./hack/push;
+  - DIMAGE=openebs/node-disk-manager-$ARCH ./build/push;
+  - DIMAGE=openebs/node-disk-operator-$ARCH ./build/push;
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
changes to push node-disk-operator images to docker hub and quay

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>