### PR TITLE
docs(contributor): add governance and maintainers files

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,2 @@
+This is a OpenEBS sub project and abides by the 
+[OpenEBS Project Governance](https://github.com/openebs/openebs/blob/master/GOVERNANCE.md).

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,17 @@
+# Official list of OpenEBS Maintainers.
+#
+# Names added to this file should be in the following format:
+#     Individual's name,@githubhandle, Company Name
+#
+# Please keep the below list sorted in ascending order.
+#
+#Maintainers
+"Kiran Mova",@kmova,MayaData
+"Jeffry Molanus",@gila,MayaData
+"Richard Elling",@richardelling,Viking Enterprise Solutions a division of Sanmina Corporation
+
+#Reviewers
+"Akhil Mohan",@akhilerm,MayaData
+"Pawan Prakash",@pawanpraka1,MayaData
+"Satbir Singh",@satbirchhikara,MayaData
+"Sagar Kumar",@sagarkrsd,MayaData

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,5 @@
+The source code developed for the OpenEBS Project is licensed under Apache 2.0. 
+
+However, the OpenEBS project contains unmodified/modified subcomponents from other Open Source Projects with separate copyright notices and license terms. 
+
+Your use of the source code for these subcomponents is subject to the terms and conditions as defined by those source projects.


### PR DESCRIPTION
docs(contributor): add governance and maintainers files

This PR adds the current maintainer and reviewer list
for the openebs/maya project. Also links to the Governance
process outlined for the overall openebs projects in openebs/openebs#2547

Signed-off-by: kmova <kiran.mova@openebs.io>