### PR TITLE
refactor(disk): Refactor sparse disk to sparse block device

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -176,7 +176,7 @@ func (c *Controller) GetExistingBlockDeviceResource(blockDeviceList *apis.BlockD
 // list of active resources. Active resource which is present in etcd not in
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
-	listDevices := append(devices, GetActiveSparseDisksUuids(c.HostName)...)
+	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.HostName)...)
 	blockDeviceList, err := c.ListBlockDeviceResource()
 	if err != nil {
 		glog.Error(err)

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -162,14 +162,13 @@ func (c *Controller) GetExistingDiskResource(listDr *apis.DiskList, uuid string)
 // list of active resources. One active resource which is present in etcd not in
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleDiskResource(devices []string) {
-	listDisks := append(devices, GetActiveSparseDisksUuids(c.HostName)...)
 	listDR, err := c.ListDiskResource()
 	if err != nil {
 		glog.Error(err)
 		return
 	}
 	for _, item := range listDR.Items {
-		if !util.Contains(listDisks, item.ObjectMeta.Name) {
+		if !util.Contains(devices, item.ObjectMeta.Name) {
 			c.DeactivateDisk(item)
 		}
 	}

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -161,14 +161,14 @@ func (c *Controller) GetExistingDiskResource(listDr *apis.DiskList, uuid string)
 // It gets list of resources which are present in system and queries etcd to get
 // list of active resources. One active resource which is present in etcd not in
 // system that will be marked as inactive.
-func (c *Controller) DeactivateStaleDiskResource(devices []string) {
+func (c *Controller) DeactivateStaleDiskResource(disks []string) {
 	listDR, err := c.ListDiskResource()
 	if err != nil {
 		glog.Error(err)
 		return
 	}
 	for _, item := range listDR.Items {
-		if !util.Contains(devices, item.ObjectMeta.Name) {
+		if !util.Contains(disks, item.ObjectMeta.Name) {
 			c.DeactivateDisk(item)
 		}
 	}

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -177,7 +177,7 @@ func CheckAndCreateSparseFile(sparseFile string, sparseFileSize int64) error {
 
 // GetSparseBlockDeviceUUID returns a fixed UUID for the sparse
 //  disk on a given node.
-func GetSparseBlockDeviceUUID(hostname string, sparseFile string) string {
+func GetSparseBlockDeviceUUID(hostname, sparseFile string) string {
 	return SparseBlockDevicePrefix + util.Hash(hostname+sparseFile)
 }
 

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -46,13 +46,11 @@ On Shutdown, the status of the sparse file Disk CR will be marked as Unknown.
 
 const (
 
-	/*
-	 * EnvSparseFileDir - defines a sparse directory
-	 * if it is specified as a environment variable,
-	 * a sparse file with specified size (EnvSparseFileSize) will
-	 * be created inside specified directory (EnvSparseFileDir)
-	 * and an associated Disk CR will be added to Kubernetes.
-	 */
+	// EnvSparseFileDir - defines a sparse directory.
+	// if it is specified as a environment variable,
+	// a sparse file with specified size (EnvSparseFileSize) will
+	// be created inside specified directory (EnvSparseFileDir)
+	// and an associated BlockDevice CR will be added to Kubernetes.
 	EnvSparseFileDir = "SPARSE_FILE_DIR"
 	//EnvSparseFileSize define the size of created sparse file
 	EnvSparseFileSize = "SPARSE_FILE_SIZE"
@@ -75,7 +73,7 @@ const (
 )
 
 // GetSparseFileDir returns the full path to the sparse
-//  file directory on the node.
+// file directory on the node.
 func GetSparseFileDir() string {
 
 	sparseFileDir := os.Getenv(EnvSparseFileDir)

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -68,9 +68,9 @@ const (
 	//SparseFileDefaultCount defines the default sparse count files
 	SparseFileDefaultCount = "1"
 
-	//SparseBlockDeviceType defines sparse disk type
+	//SparseBlockDeviceType defines sparse device type
 	SparseBlockDeviceType = "sparse"
-	//SparseBlockDevicePrefix defines the prefix for the sparse disk
+	//SparseBlockDevicePrefix defines the prefix for the sparse device
 	SparseBlockDevicePrefix = "sparse-"
 )
 
@@ -138,7 +138,7 @@ func GetSparseFileSize() int64 {
 }
 
 // InitializeSparseFiles will check if the sparse file exist or have to be
-//  created and will update or create the associated Disk CR accordingly
+// created and will update or create the associated Disk CR accordingly
 func (c *Controller) InitializeSparseFiles() {
 	sparseFileDir := GetSparseFileDir()
 	sparseFileSize := GetSparseFileSize()
@@ -188,7 +188,7 @@ func GetActiveSparseBlockDevicesUUID(hostname string) []string {
 	sparseUuids := make([]string, 0)
 	files, err := ioutil.ReadDir(sparseFileLocation)
 	if err != nil {
-		glog.Error("Failed to read sperse file names : ", err)
+		glog.Error("Failed to read sparse file names : ", err)
 		return sparseUuids
 	}
 	for _, file := range files {
@@ -222,7 +222,6 @@ func (c *Controller) MarkSparseBlockDeviceStateActive(sparseFile string, sparseF
 	BlockDeviceDetails.Capacity = uint64(sparseFileInfo.Size())
 
 	//If a BlockDevice CR already exits, update it. If not create a new one.
-	glog.Info("Updating the BlockDevice CR for Sparse Disk: ", BlockDeviceDetails.UUID)
+	glog.Info("Updating the BlockDevice CR for Sparse file: ", BlockDeviceDetails.UUID)
 	c.CreateBlockDevice(BlockDeviceDetails.ToDevice())
-
 }

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -161,8 +161,8 @@ func (c *Controller) InitializeSparseFiles() {
 }
 
 // CheckAndCreateSparseFile will reuse the existing sparse file if it already exists,
-//   for handling cases where NDM is upgraded or restarted. If the file doesn't exist
-//   a new file will be created.
+// for handling cases where NDM is upgraded or restarted. If the file doesn't exist
+// a new file will be created.
 func CheckAndCreateSparseFile(sparseFile string, sparseFileSize int64) error {
 	sparseFileInfo, err := util.SparseFileInfo(sparseFile)
 	if err != nil {
@@ -176,7 +176,7 @@ func CheckAndCreateSparseFile(sparseFile string, sparseFileSize int64) error {
 }
 
 // GetSparseBlockDeviceUUID returns a fixed UUID for the sparse
-//  disk on a given node.
+// disk on a given node.
 func GetSparseBlockDeviceUUID(hostname, sparseFile string) string {
 	return SparseBlockDevicePrefix + util.Hash(hostname+sparseFile)
 }

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
@@ -142,7 +142,7 @@ func TestCheckAndCreateSparseFile(t *testing.T) {
 	util.SparseFileDelete(testFile)
 }
 
-func TestGetActiveSparseDisksUuids(t *testing.T) {
+func TestGetActiveSparseBlockDevicesUUID(t *testing.T) {
 	if _, err := os.Create("/tmp/0-ndm-sparse.img"); err != nil {
 		t.Fatal(err)
 	}
@@ -155,16 +155,16 @@ func TestGetActiveSparseDisksUuids(t *testing.T) {
 	sparseUids = append(sparseUids, "sparse-2b3468d4b928c7e048ad8747ba710e4c")
 	sparseUids = append(sparseUids, "sparse-af2cd3d402e3447e315aadb7e7b46a34")
 	tests := map[string]struct {
-		expectedSparseDiskUuids []string
-		sparseFileDir           string
+		expectedSparseBlockDeviceUUID []string
+		sparseFileDir                 string
 	}{
-		"When dir is valid":                  {sparseFileDir: "/tmp", expectedSparseDiskUuids: sparseUids},
-		"When dir is invalid or not present": {sparseFileDir: "/invalid", expectedSparseDiskUuids: make([]string, 0)},
+		"When dir is valid":                  {sparseFileDir: "/tmp", expectedSparseBlockDeviceUUID: sparseUids},
+		"When dir is invalid or not present": {sparseFileDir: "/invalid", expectedSparseBlockDeviceUUID: make([]string, 0)},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			os.Setenv(EnvSparseFileDir, test.sparseFileDir)
-			assert.Equal(t, test.expectedSparseDiskUuids, GetActiveSparseDisksUuids("instance-1"))
+			assert.Equal(t, test.expectedSparseBlockDeviceUUID, GetActiveSparseBlockDevicesUUID("instance-1"))
 			os.Unsetenv(EnvSparseFileDir)
 		})
 	}

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -107,6 +107,12 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 func (r *ReconcileBlockDevice) CheckBackingDiskStatusAndUpdateDeviceCR(
 	instance *openebsv1alpha1.BlockDevice, nameSpace string, reqLogger logr.Logger) error {
 
+	// If the BlockDevice is of type sparse, then we need not check the backing disk
+	// status, As sparse block devices does not have a backing disk.
+	if instance.Spec.Details.DeviceType == ndm.SparseBlockDeviceType {
+		return nil
+	}
+
 	// Find the name of diskCR that need to be read from etcd
 	// TODO: This need to be changed, Currently name of disk and blockdevice
 	// are using same string except prefix which would be "blockdevice"/"disk"


### PR DESCRIPTION
Sparse disk is refactored  to block device resource. Only block device resources will be created for sparse files. These block devices of type sparse can be used for creating sparse pool.

Fixes https://github.com/openebs/node-disk-manager/issues/250