### PR TITLE
fix(blockdevice): deactivate block device when Device is removed

### DIFF
--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -249,7 +249,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 		Action:  libudevwrapper.UDEV_ACTION_REMOVE,
 		Devices: eventmsg,
 	}
-	probeEvent.deleteDiskEvent(eventDetails)
+	probeEvent.deleteEvent(eventDetails)
 
 	// Retrieve resources
 	cdr1, err1 := fakeController.GetDisk(mockuid)

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -214,7 +214,7 @@ func (up *udevProbe) listen() {
 		case string(AttachEA):
 			probeEvent.addDiskEvent(msg)
 		case string(DetachEA):
-			probeEvent.deleteDiskEvent(msg)
+			probeEvent.deleteEvent(msg)
 		}
 	}
 }


### PR DESCRIPTION
BlockDevice will get deactivated when the corresponding device is removed from the host.
Fixes #255 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>