### PR TITLE
fix(apis): change BD and BDC to namespace scoped

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -66,16 +66,10 @@ func (di *DeviceInfo) ToDevice() apis.BlockDevice {
 // labels and Name of resource. It is used to populate data
 // of BlockDevice struct of BlockDevice CR.
 func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
-	/*
-		namespace, err := k8sutil.GetWatchNamespace()
-		if err != nil && namespace == "" {
-			namespace = "default"
-		}
-	*/
 	objectMeta := metav1.ObjectMeta{
-		Labels: make(map[string]string),
-		Name:   di.UUID,
-		//Namespace: namespace,
+		Labels:    make(map[string]string),
+		Name:      di.UUID,
+		Namespace: Namespace,
 	}
 	objectMeta.Labels[NDMHostKey] = di.HostName
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType

--- a/cmd/ndm_daemonset/controller/controller_test.go
+++ b/cmd/ndm_daemonset/controller/controller_test.go
@@ -53,6 +53,29 @@ func TestSetNodeName(t *testing.T) {
 	}
 }
 
+func TestSetNamespace(t *testing.T) {
+	fakeNamespace := "openebs"
+	ns1, err1 := getNamespace()
+	os.Setenv("NAMESPACE", fakeNamespace)
+	ns2, err2 := getNamespace()
+	expectedErr2 := errors.New("error getting namespace")
+	tests := map[string]struct {
+		actualNamespace   string
+		expectedNamespace string
+		actualError       error
+		expectedError     error
+	}{
+		"call setNamespace when env variable not present": {actualNamespace: ns1, actualError: err1, expectedNamespace: "", expectedError: expectedErr2},
+		"call setNamespace when env variable present":     {actualNamespace: ns2, actualError: err2, expectedNamespace: fakeNamespace, expectedError: nil},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedNamespace, test.actualNamespace)
+			assert.Equal(t, test.expectedError, test.actualError)
+		})
+	}
+}
+
 /*
 	Broadcast start broadcasting controller pointer in ControllerBroadcastChannel channel
 	In this test case read ControllerBroadcastChannel channel and match controller pointer

--- a/deploy/crds/openebs_v1alpha1_disk_crd.yaml
+++ b/deploy/crds/openebs_v1alpha1_disk_crd.yaml
@@ -9,5 +9,5 @@ spec:
     listKind: DiskList
     plural: disks
     singular: disk
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -119,7 +119,9 @@ spec:
     listKind: BlockDeviceList
     plural: blockdevices
     singular: blockdevice
-  scope: Cluster
+    shortNames:
+    - bd
+  scope: Namespaced
   version: v1alpha1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -133,7 +135,9 @@ spec:
     listKind: BlockDeviceClaimList
     plural: blockdeviceclaims
     singular: blockdeviceclaim
-  scope: Cluster 
+    shortNames:
+    - bdc
+  scope: Namespaced
   version: v1alpha1
 ---
 apiVersion: extensions/v1beta1
@@ -161,12 +165,11 @@ spec:
       # Use host network as container network to monitor udev source using netlink
       # to detect disk attach and detach events using fd.
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         securityContext:
           privileged: true
         # make udev database available inside container
@@ -183,6 +186,12 @@ spec:
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
+        # namespace in which NDM is installed will be passed to NDM Daemonset
+        # as environment variable
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
           valueFrom:

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -91,8 +91,7 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	err = r.CheckBackingDiskStatusAndUpdateDeviceCR(instance,
-		request.NamespacedName.Namespace, reqLogger)
+	err = r.CheckBackingDiskStatusAndUpdateDeviceCR(instance, reqLogger)
 
 	if err != nil {
 		// Error while reading, updating object - requeue the request.
@@ -105,7 +104,7 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 // the status of Block Device. If the backing Disk of a block-device is marked inactive, then all block devices
 // which use that disk should be marked inactive.
 func (r *ReconcileBlockDevice) CheckBackingDiskStatusAndUpdateDeviceCR(
-	instance *openebsv1alpha1.BlockDevice, nameSpace string, reqLogger logr.Logger) error {
+	instance *openebsv1alpha1.BlockDevice, reqLogger logr.Logger) error {
 
 	// If the BlockDevice is of type sparse, then we need not check the backing disk
 	// status, As sparse block devices does not have a backing disk.
@@ -121,7 +120,7 @@ func (r *ReconcileBlockDevice) CheckBackingDiskStatusAndUpdateDeviceCR(
 
 	// Fetch the Disk CR
 	diskInstance := &openebsv1alpha1.Disk{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: Name, Namespace: nameSpace}, diskInstance)
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: Name}, diskInstance)
 	if err != nil {
 		reqLogger.Error(err, "Error while getting Disk-CR", "Disk-CR:", Name)
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Change BlockDevice and BlockDeviceClaims apis to namespace scoped. Corresponding changes are done in controller logic which creates BD, and also in reconcilation loop of BlockDevice

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>