### PR TITLE
fix(eventhandler): fix blockdevice not getting deactivated

### DIFF
--- a/cmd/ndm_daemonset/controller/disk_to_device_converter_test.go
+++ b/cmd/ndm_daemonset/controller/disk_to_device_converter_test.go
@@ -1,0 +1,13 @@
+package controller
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDiskToDeviceUUID(t *testing.T) {
+	ctrl := Controller{}
+	diskUID := "disk-adb1b23f7ba395988d029d78ef7bda58"
+	blockDeviceUID := "blockdevice-adb1b23f7ba395988d029d78ef7bda58"
+	assert.Equal(t, blockDeviceUID, ctrl.DiskToDeviceUUID(diskUID))
+}

--- a/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
+++ b/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
@@ -26,8 +26,7 @@ func (c *Controller) NewDeviceInfoFromDiskInfo(diskDetails *DiskInfo) *DeviceInf
 	deviceDetails := NewDeviceInfo()
 
 	deviceDetails.HostName = c.HostName
-	Uuid := strings.TrimPrefix(diskDetails.ProbeIdentifiers.Uuid, udev.NDMDiskPrefix)
-	deviceDetails.UUID = udev.NDMBlockDevicePrefix + Uuid
+	deviceDetails.UUID = c.DiskToDeviceUUID(diskDetails.ProbeIdentifiers.Uuid)
 	deviceDetails.Capacity = diskDetails.Capacity
 	deviceDetails.Model = diskDetails.Model
 	deviceDetails.Serial = diskDetails.Serial
@@ -42,4 +41,11 @@ func (c *Controller) NewDeviceInfoFromDiskInfo(diskDetails *DiskInfo) *DeviceInf
 	deviceDetails.FileSystemInfo.FileSystem = diskDetails.FileSystemInformation.FileSystem
 	deviceDetails.FileSystemInfo.MountPoint = diskDetails.FileSystemInformation.MountPoint
 	return deviceDetails
+}
+
+// DiskToDeviceUUID converts a disk UUID (disk-xxx) to a block-
+// device UUID (blockdevice-xxx)
+func (c *Controller) DiskToDeviceUUID(diskUUID string) string {
+	uuid := strings.TrimPrefix(diskUUID, udev.NDMDiskPrefix)
+	return udev.NDMBlockDevicePrefix + uuid
 }

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
-	"strings"
 )
 
 // EventAction action type for disk events like attach or detach events
@@ -124,8 +123,7 @@ func (pe *ProbeEvent) deleteBlockDevice(msg controller.EventMessage) bool {
 	}
 	ok := true
 	for _, diskDetails := range msg.Devices {
-		UUID := strings.TrimPrefix(diskDetails.ProbeIdentifiers.Uuid, libudevwrapper.NDMDiskPrefix)
-		bdUUID := libudevwrapper.NDMBlockDevicePrefix + UUID
+		bdUUID := pe.Controller.DiskToDeviceUUID(diskDetails.ProbeIdentifiers.Uuid)
 		oldBDResource := pe.Controller.GetExistingBlockDeviceResource(bdList, bdUUID)
 		if oldBDResource == nil {
 			ok = false

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
+	"strings"
 )
 
 // EventAction action type for disk events like attach or detach events
@@ -123,7 +124,9 @@ func (pe *ProbeEvent) deleteBlockDevice(msg controller.EventMessage) bool {
 	}
 	ok := true
 	for _, diskDetails := range msg.Devices {
-		oldBDResource := pe.Controller.GetExistingBlockDeviceResource(bdList, diskDetails.ProbeIdentifiers.Uuid)
+		UUID := strings.TrimPrefix(diskDetails.ProbeIdentifiers.Uuid, libudevwrapper.NDMDiskPrefix)
+		bdUUID := libudevwrapper.NDMBlockDevicePrefix + UUID
+		oldBDResource := pe.Controller.GetExistingBlockDeviceResource(bdList, bdUUID)
 		if oldBDResource == nil {
 			ok = false
 			continue

--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -34,13 +34,15 @@ import (
 )
 
 var (
-	mockuid        = "fake-disk-uid"
+	mockDiskuid    = "disk-fake-uid"
+	mockBDuid      = "blockdevice-fake-uid"
 	ignoreDiskUuid = "ignore-disk-uuid"
 	fakeHostName   = "node-name"
 	fakeModel      = "fake-disk-model"
 	fakeSerial     = "fake-disk-serial"
 	fakeVendor     = "fake-disk-vendor"
 	fakeDiskType   = "disk"
+	fakeBDType     = "blockdevice"
 )
 
 // mockEmptyDiskCr returns empty diskCr
@@ -48,7 +50,7 @@ func mockEmptyDiskCr() apis.Disk {
 	fakeDr := apis.Disk{}
 	fakeObjectMeta := metav1.ObjectMeta{
 		Labels: make(map[string]string),
-		Name:   mockuid,
+		Name:   mockDiskuid,
 	}
 	fakeTypeMeta := metav1.TypeMeta{
 		Kind:       controller.NDMDiskKind,
@@ -65,7 +67,7 @@ func mockEmptyBlockDeviceCr() apis.BlockDevice {
 	fakeBDr := apis.BlockDevice{}
 	fakeObjectMeta := metav1.ObjectMeta{
 		Labels: make(map[string]string),
-		Name:   mockuid,
+		Name:   mockBDuid,
 	}
 	fakeTypeMeta := metav1.TypeMeta{
 		Kind:       controller.NDMBlockDeviceKind,
@@ -167,7 +169,7 @@ func TestAddDiskEvent(t *testing.T) {
 	// blockdevice-1 details
 	eventmsg := make([]*controller.DiskInfo, 0)
 	device1Details := &controller.DiskInfo{}
-	device1Details.ProbeIdentifiers.Uuid = mockuid
+	device1Details.ProbeIdentifiers.Uuid = mockDiskuid
 	eventmsg = append(eventmsg, device1Details)
 	// blockdevice-2 details
 	device2Details := &controller.DiskInfo{}
@@ -180,7 +182,7 @@ func TestAddDiskEvent(t *testing.T) {
 	}
 	probeEvent.addDiskEvent(eventDetails)
 	// Retrieve disk resource
-	cdr1, err1 := fakeController.GetDisk(mockuid)
+	cdr1, err1 := fakeController.GetDisk(mockDiskuid)
 
 	// Retrieve disk resource
 	cdr2, _ := fakeController.GetDisk(ignoreDiskUuid)
@@ -234,7 +236,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 	// Create one fake block device resource
 	fakeBDr := mockEmptyBlockDeviceCr()
 	fakeBDr.ObjectMeta.Labels[controller.NDMHostKey] = fakeController.HostName
-	fakeBDr.ObjectMeta.Labels[controller.NDMDiskTypeKey] = fakeDiskType
+	fakeBDr.ObjectMeta.Labels[controller.NDMDeviceTypeKey] = fakeBDType
 	fakeBDr.ObjectMeta.Labels[controller.NDMManagedKey] = controller.TrueString
 	fakeController.CreateBlockDevice(fakeBDr)
 
@@ -243,7 +245,7 @@ func TestDeleteDiskEvent(t *testing.T) {
 	}
 	eventmsg := make([]*controller.DiskInfo, 0)
 	deviceDetails := &controller.DiskInfo{}
-	deviceDetails.ProbeIdentifiers.Uuid = mockuid
+	deviceDetails.ProbeIdentifiers.Uuid = mockDiskuid
 	eventmsg = append(eventmsg, deviceDetails)
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_REMOVE,
@@ -252,8 +254,8 @@ func TestDeleteDiskEvent(t *testing.T) {
 	probeEvent.deleteEvent(eventDetails)
 
 	// Retrieve resources
-	cdr1, err1 := fakeController.GetDisk(mockuid)
-	bdR1, err1 := fakeController.GetBlockDevice(mockuid)
+	cdr1, err1 := fakeController.GetDisk(mockDiskuid)
+	bdR1, err1 := fakeController.GetBlockDevice(mockBDuid)
 
 	fakeDr.Status.State = controller.NDMInactive
 	fakeBDr.Status.State = controller.NDMInactive


### PR DESCRIPTION
The UUID used earlier was of the format 'disk-xxx', this need to be changed to `blockdevice-xxx`

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>