### PR TITLE
fix(controller): remove BDC deletion

### DIFF
--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -104,8 +104,7 @@ func (r *ReconcileBlockDeviceClaim) Reconcile(request reconcile.Request) (reconc
 			return reconcile.Result{}, err
 		}
 	case apis.BlockDeviceClaimStatusInvalidCapacity:
-		// currently for invalid capacity, the device claim will be deleted
-		fallthrough
+		// currently for invalid capacity, the BDC will remain in that state
 	case apis.BlockDeviceClaimStatusDone:
 		reqLogger.Info("In process of deleting block device claim")
 		err := r.FinalizerHandling(instance, reqLogger)
@@ -199,12 +198,6 @@ func (r *ReconcileBlockDeviceClaim) updateClaimStatus(phase apis.DeviceClaimPhas
 	switch phase {
 	case apis.BlockDeviceClaimStatusDone:
 		instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, BlockDeviceClaimFinalizer)
-	case apis.BlockDeviceClaimStatusInvalidCapacity:
-		err := r.client.Delete(context.TODO(), instance)
-		if err != nil {
-			return fmt.Errorf("invalid capacity requested, deletion failed for BDC:%s, %v", instance.ObjectMeta.Name, err)
-		}
-		return nil
 	}
 	// Update BlockDeviceClaim CR
 	err := r.client.Update(context.TODO(), instance)

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
@@ -27,7 +27,7 @@ var (
 	deviceName                     = "blockdevice-example"
 	blockDeviceClaimName           = "blockdeviceclaim-example"
 	blockDeviceClaimUID  types.UID = "blockDeviceClaim-example-UID"
-	namespace                      = ""
+	namespace                      = "default"
 	capacity             uint64    = 1024000
 	claimCapacity                  = resource.MustParse("1024000")
 )
@@ -63,7 +63,7 @@ func TestBlockDeviceClaimController(t *testing.T) {
 	r.InvalidCapacityTest(t, req)
 
 	// Create new BlockDeviceClaim CR with right capacity,
-	// trigger reconilation event. This time, it should
+	// trigger reconcilation event. This time, it should
 	// bound.
 	blockDeviceClaimCR := GetFakeBlockDeviceClaimObject()
 	err := r.client.Create(context.TODO(), blockDeviceClaimCR)
@@ -208,11 +208,13 @@ func (r *ReconcileBlockDeviceClaim) InvalidCapacityTest(t *testing.T,
 
 	dvC := &openebsv1alpha1.BlockDeviceClaim{}
 	err = r.client.Get(context.TODO(), req.NamespacedName, dvC)
-	if errors.IsNotFound(err) {
-		t.Logf("BlockDeviceClaim is deleted, expected")
-		err = nil
-	} else if err != nil {
+	if err != nil {
 		t.Errorf("Get devRequestInst: (%v)", err)
+	}
+	if dvC.Status.Phase == openebsv1alpha1.BlockDeviceClaimStatusInvalidCapacity {
+		t.Log("BlockDeviceClaim is in Invalid Capacity State")
+	} else {
+		t.Errorf("BlockDeviceClaim has unexpected phase : %s", dvC.Status.Phase)
 	}
 }
 


### PR DESCRIPTION
Earlier, BDC was deleted by NDM-Operator, if the claim had an invalid capacity field. Now the BDC won't be deleted and its status/phase will be updated as `Invalid Capacity Requested`.