### PR TITLE
fix(event-handler): fix ClaimRef missing when updating Block Devices.

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -88,6 +88,8 @@ func (c *Controller) UpdateBlockDevice(blockDevice apis.BlockDevice, oldBlockDev
 	}
 
 	blockDeviceCopy.ObjectMeta.ResourceVersion = oldBlockDevice.ObjectMeta.ResourceVersion
+	blockDeviceCopy.Spec.ClaimRef = oldBlockDevice.Spec.ClaimRef
+	blockDeviceCopy.Status.ClaimState = oldBlockDevice.Status.ClaimState
 	err = c.Clientset.Update(context.TODO(), blockDeviceCopy)
 	if err != nil {
 		glog.Error("Unable to update blockdevice object : ", err)


### PR DESCRIPTION
Fixes an issue where ClaimRef and ClaimState were being blanked out after a block device is detached and attached to a node.

Steps to reproduce: 
1. A disk is attached to the node. NDM daemon detects it and creates a block device resource with status as active
2. A BDC is created which claims this BD. When the BD is claimed , claimRef field is added and claimState is changed to Claimed in the BD by the NDM operator.
3. The disk is now removed from the node. The disk status will be updated as Inactive by the Daemonset.
4. The disk is reattached . DS fetches all the details of the disk, and update this information into the BD. At this point the claimRef and claimState that was updated by the operator is lost.

The fix will update the claimRef and claimState values from old CR to the new CR. 

Note: In a following PR, this approach could be changed to patch a CR instead of an update. 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>