### PR TITLE
feat(scrub-job): scrub job to clean data on released block devices

### DIFF
--- a/integration_tests/sanity/deviceclaim_test.go
+++ b/integration_tests/sanity/deviceclaim_test.go
@@ -183,7 +183,7 @@ var _ = Describe("BlockDevice Claim tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			for _, bd := range bdList.Items {
 				if bd.Name == bdName {
-					Expect(string(bd.Status.ClaimState)).To(Equal(apis.BlockDeviceUnclaimed))
+					Expect(string(bd.Status.ClaimState)).To(Equal(apis.BlockDeviceReleased))
 				}
 			}
 

--- a/integration_tests/sanity/deviceclaim_test.go
+++ b/integration_tests/sanity/deviceclaim_test.go
@@ -178,12 +178,12 @@ var _ = Describe("BlockDevice Claim tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			k8s.WaitForReconcilation()
 
-			// check status of BD again to check it has been unclaimed
+			// check status of BD again to check it has been released
 			bdList, err = k8sClient.ListBlockDevices()
 			Expect(err).NotTo(HaveOccurred())
 			for _, bd := range bdList.Items {
 				if bd.Name == bdName {
-					Expect(bd.Status.ClaimState).To(Equal(apis.BlockDeviceUnclaimed))
+					Expect(bd.Status.ClaimState).To(Equal(apis.BlockDeviceReleased))
 				}
 			}
 

--- a/integration_tests/sanity/deviceclaim_test.go
+++ b/integration_tests/sanity/deviceclaim_test.go
@@ -134,7 +134,7 @@ var _ = Describe("BlockDevice Claim tests", func() {
 
 			for _, bd := range bdList.Items {
 				if bd.Name == bdName {
-					Expect(string(bd.Status.ClaimState)).To(Equal(apis.BlockDeviceClaimed))
+					Expect(bd.Status.ClaimState).To(Equal(apis.BlockDeviceClaimed))
 				}
 			}
 
@@ -170,7 +170,7 @@ var _ = Describe("BlockDevice Claim tests", func() {
 
 			for _, bd := range bdList.Items {
 				if bd.Name == bdName {
-					Expect(string(bd.Status.ClaimState)).To(Equal(apis.BlockDeviceClaimed))
+					Expect(bd.Status.ClaimState).To(Equal(apis.BlockDeviceClaimed))
 				}
 			}
 
@@ -183,7 +183,7 @@ var _ = Describe("BlockDevice Claim tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			for _, bd := range bdList.Items {
 				if bd.Name == bdName {
-					Expect(string(bd.Status.ClaimState)).To(Equal(apis.BlockDeviceReleased))
+					Expect(bd.Status.ClaimState).To(Equal(apis.BlockDeviceUnclaimed))
 				}
 			}
 

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -269,3 +269,5 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "node-disk-operator"
+            - name: CLEANUP_JOB_IMAGE
+              value: "openebs/openebs-tools:3.8"

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -61,7 +61,7 @@ metadata:
   name: openebs-ndm-operator
 rules:
 - apiGroups: ["*"]
-  resources: ["disks", "blockdevices", "blockdeviceclaims", "pods", "services", "endpoints", "events", "configmaps", "secrets"]
+  resources: ["disks", "blockdevices", "blockdeviceclaims", "pods", "services", "endpoints", "events", "configmaps", "secrets", "jobs"]
   verbs:
   - '*'
 - apiGroups:

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -270,4 +270,4 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/openebs-tools:3.8"
+              value: "quay.io/openebs/openebs-tools:3.8"

--- a/pkg/apis/openebs/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdevice_types.go
@@ -65,12 +65,12 @@ type DeviceClaimState string
 const (
 	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC,
 	// all cleanup jobs have been completed and is available for claiming.
-	BlockDeviceUnclaimed = "Unclaimed"
+	BlockDeviceUnclaimed DeviceClaimState = "Unclaimed"
 	// BlockDeviceReleased represents that the block device is released from the BDC,
 	// pending cleanup jobs
-	BlockDeviceReleased = "Released"
+	BlockDeviceReleased DeviceClaimState = "Released"
 	// BlockDeviceClaimed represents that the block device is bound to a BDC
-	BlockDeviceClaimed = "Claimed"
+	BlockDeviceClaimed DeviceClaimState = "Claimed"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/openebs/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdevice_types.go
@@ -63,8 +63,12 @@ type DeviceStatus struct {
 type DeviceClaimState string
 
 const (
-	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC
+	// BlockDeviceUnclaimed represents that the block device is not bound to any BDC,
+	// all cleanup jobs have been completed and is available for claiming.
 	BlockDeviceUnclaimed = "Unclaimed"
+	// BlockDeviceReleased represents that the block device is released from the BDC,
+	// pending cleanup jobs
+	BlockDeviceReleased = "Released"
 	// BlockDeviceClaimed represents that the block device is bound to a BDC
 	BlockDeviceClaimed = "Claimed"
 )

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -30,10 +30,13 @@ type Cleaner struct {
 	CleanupStatus *CleanupStatusTracker
 }
 
+// CleanupStatusTracker is used to track the cleanup state using
+// info provided by JobController
 type CleanupStatusTracker struct {
 	JobController JobController
 }
 
+// NewCleaner creates a new cleaner which can be used for cleaning BD, and checking status of the job
 func NewCleaner(client client.Client, namespace string, cleanupTracker *CleanupStatusTracker) *Cleaner {
 	return &Cleaner{
 		Client:        client,
@@ -42,6 +45,9 @@ func NewCleaner(client client.Client, namespace string, cleanupTracker *CleanupS
 	}
 }
 
+// Clean will launch a job to delete data on the BD depending on the
+// volume mode. Job will be launched only if another job is not running or a
+// job is in unknown state
 func (c *Cleaner) Clean(blockDevice *v1alpha1.BlockDevice) (bool, error) {
 	bdName := blockDevice.Name
 	if c.CleanupStatus.InProgress(bdName) {
@@ -65,14 +71,19 @@ func (c *Cleaner) Clean(blockDevice *v1alpha1.BlockDevice) (bool, error) {
 	return false, err
 }
 
+// InProgress returns whether a cleanup job is currently being done
+// for the given BD
 func (c *CleanupStatusTracker) InProgress(bdName string) bool {
 	return c.JobController.IsCleaningJobRunning(bdName)
 }
 
+// RemoveStatus returns the Cleanupstate of a job. If job is succeeded, it will
+// be deleted
 func (c *CleanupStatusTracker) RemoveStatus(bdName string) (CleanupState, error) {
 	return c.JobController.RemoveJob(bdName)
 }
 
+// runJob creates a new cleanup job in the namespace
 func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error {
 	job, err := NewCleanupJob(bd, volumeMode, c.Namespace)
 	if err != nil {
@@ -81,6 +92,7 @@ func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error 
 	return c.Client.Create(context.TODO(), job)
 }
 
+// getVolumeMode returns the volume mode of the BD that is being released
 func getVolumeMode(spec v1alpha1.DeviceSpec) VolumeMode {
 	if spec.FileSystem.Mountpoint != "" {
 		return VolumeModeFileSystem

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -12,6 +12,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+This pkg is inspired from the deleter pkg in local-static-provisioner
+in kubernetes-sigs
+	https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/tree/master/pkg/deleter
 */
 
 package cleaner

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -1,0 +1,90 @@
+package cleaner
+
+import (
+	"context"
+	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CleanupState int
+
+const (
+	CleanupStateUnknown CleanupState = iota + 1
+	CleanupStateRunning
+	CleanupStateSucceeded
+)
+
+type VolumeMode string
+
+const (
+	VolumeModeBlock      = "BlockVolumeMode"
+	VolumeModeFileSystem = "FileSystemVolumeMode"
+)
+
+// Cleaner handles BD cleanup
+// For filesystem/mount based block devices, it deletes the contents of the directory
+// For raw block devices, a `dd` command will be issued.
+type Cleaner struct {
+	Client        client.Client
+	Namespace     string
+	CleanupStatus *CleanupStatusTracker
+}
+
+type CleanupStatusTracker struct {
+	JobController JobController
+}
+
+func NewCleaner(client client.Client, namespace string, cleanupTracker *CleanupStatusTracker) *Cleaner {
+	return &Cleaner{
+		Client:        client,
+		Namespace:     namespace,
+		CleanupStatus: cleanupTracker,
+	}
+}
+
+func (c *Cleaner) Clean(blockDevice *v1alpha1.BlockDevice) (bool, error) {
+	bdName := blockDevice.Name
+	if c.CleanupStatus.InProgress(bdName) {
+		return false, nil
+	}
+	// Check if cleaning was just completed.
+	state, err := c.CleanupStatus.RemoveStatus(bdName)
+	if err != nil {
+		return false, nil
+	}
+
+	switch state {
+	case CleanupStateSucceeded:
+		return true, nil
+	}
+
+	volMode := getVolumeMode(blockDevice.Spec)
+
+	err = c.runJob(blockDevice, volMode)
+
+	return false, err
+}
+
+func (c *CleanupStatusTracker) InProgress(bdName string) bool {
+	return c.JobController.IsCleaningJobRunning(bdName)
+}
+
+func (c *CleanupStatusTracker) RemoveStatus(bdName string) (CleanupState, error) {
+	return c.JobController.RemoveJob(bdName)
+}
+
+func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error {
+	job, err := NewCleanupJob(bd, volumeMode, c.Namespace)
+	if err != nil {
+		return err
+	}
+	return c.Client.Create(context.TODO(), job)
+}
+
+func getVolumeMode(spec v1alpha1.DeviceSpec) VolumeMode {
+	if spec.FileSystem.Mountpoint != "" {
+		return VolumeModeFileSystem
+	} else {
+		return VolumeModeBlock
+	}
+}

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -10,6 +10,7 @@ type CleanupState int
 
 const (
 	CleanupStateUnknown CleanupState = iota + 1
+	CleanupStateNotFound
 	CleanupStateRunning
 	CleanupStateSucceeded
 )

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -108,7 +108,6 @@ func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error 
 func getVolumeMode(spec v1alpha1.DeviceSpec) VolumeMode {
 	if spec.FileSystem.Mountpoint != "" {
 		return VolumeModeFileSystem
-	} else {
-		return VolumeModeBlock
 	}
+	return VolumeModeBlock
 }

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -6,19 +6,30 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// CleanupState represents the current state of the cleanup job
 type CleanupState int
 
 const (
+	// CleanupStateUnknown represents an unknown state of the cleanup job
 	CleanupStateUnknown CleanupState = iota + 1
+	// CleanupStateNotFound defines the state when a job does not exist
 	CleanupStateNotFound
+	// CleanupStateRunning represents a running cleanup job
 	CleanupStateRunning
+	// CleanupStateSucceeded represents that the cleanup job has been completed successfully
 	CleanupStateSucceeded
 )
 
+// VolumeMode defines the volume mode of the BlockDevice. It can be either block mode or
+// filesystem mode
 type VolumeMode string
 
 const (
-	VolumeModeBlock      = "BlockVolumeMode"
+	// VolumeModeBlock defines a raw block volume mode which means the block device should
+	// be treated as raw block device
+	VolumeModeBlock = "BlockVolumeMode"
+	// VolumeModeFileSystem defines that the blockdevice should be treated as a block
+	// formatted with filesystem and is mounted
 	VolumeModeFileSystem = "FileSystemVolumeMode"
 )
 

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cleaner
+
+import "os"
+
+const (
+	EnvCleanUpJobImage = "CLEANUP_JOB_IMAGE"
+)
+
+var (
+	defaultCleanUpJobImage = "quay.io/openebs/openebs-tools:3.8"
+)
+
+// getCleanUpImage gets the image to be used for the cleanup job
+func getCleanUpImage() string {
+	image, ok := os.LookupEnv(EnvCleanUpJobImage)
+	if !ok {
+		return defaultCleanUpJobImage
+	}
+	return image
+}

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -19,10 +19,13 @@ package cleaner
 import "os"
 
 const (
+	// EnvCleanUpJobImage is the environment variable for getting the
+	// job container image
 	EnvCleanUpJobImage = "CLEANUP_JOB_IMAGE"
 )
 
 var (
+	// defaultCleanUpJobImage is the default job container image
 	defaultCleanUpJobImage = "quay.io/openebs/openebs-tools:3.8"
 )
 

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -1,0 +1,155 @@
+package cleaner
+
+import (
+	"context"
+	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+const (
+	JobContainerName    = "cleaner"
+	JobNamePrefix       = "cleanup-"
+	JobImageName        = "busybox"
+	BDLabel             = "blockdevice"
+	BlockCleanerCommand = "dd if=/dev/zero of="
+	FSCleanerCommand    = "rm -rf /tmp"
+)
+
+// JobController defines the interface for the job controller.
+type JobController interface {
+	IsCleaningJobRunning(bdName string) bool
+	RemoveJob(bdName string) (CleanupState, error)
+}
+
+var _ JobController = &jobController{}
+
+type jobController struct {
+	client    client.Client
+	namespace string
+}
+
+func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace string) (*batchv1.Job, error) {
+	nodeName := bd.Labels[controller.NDMHostKey]
+
+	priv := true
+	jobContainer := v1.Container{
+		Name:  JobContainerName,
+		Image: JobImageName,
+		SecurityContext: &v1.SecurityContext{
+			Privileged: &priv,
+		},
+	}
+
+	podSpec := v1.PodSpec{}
+
+	if volMode == VolumeModeBlock {
+		jobContainer.Command = getCommand(BlockCleanerCommand + bd.Spec.Path)
+	} else if volMode == VolumeModeFileSystem {
+		jobContainer.Command = getCommand(FSCleanerCommand)
+		mountName := "fsMount"
+		volumes := []v1.Volume{
+			{
+				Name: mountName,
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: bd.Spec.FileSystem.Mountpoint,
+					},
+				},
+			},
+		}
+		jobContainer.VolumeMounts = []v1.VolumeMount{{
+			Name:      mountName,
+			MountPath: "/tmp",
+		}}
+		podSpec.Volumes = volumes
+	}
+
+	podSpec.Containers = []v1.Container{jobContainer}
+	podSpec.NodeSelector = map[string]string{controller.NDMHostKey: nodeName}
+
+	podTemplate := v1.Pod{}
+	podTemplate.Spec = podSpec
+
+	labels := map[string]string{
+		controller.NDMHostKey: nodeName,
+		BDLabel:               bd.Name,
+	}
+
+	podTemplate.ObjectMeta = v12.ObjectMeta{
+		Name:      generateCleaningJobName(bd.Name),
+		Namespace: namespace,
+		Labels:    labels,
+	}
+
+	job := &batchv1.Job{}
+	job.ObjectMeta = podTemplate.ObjectMeta
+	job.Spec.Template.Spec = podTemplate.Spec
+	job.Spec.Template.Spec.RestartPolicy = v1.RestartPolicyOnFailure
+
+	return job, nil
+}
+
+func NewJobController(client client.Client, namespace string) *jobController {
+	return &jobController{
+		client:    client,
+		namespace: namespace,
+	}
+}
+
+func (c *jobController) IsCleaningJobRunning(bdName string) bool {
+	jobName := generateCleaningJobName(bdName)
+	objKey := client.ObjectKey{
+		Namespace: c.namespace,
+		Name:      jobName,
+	}
+	job := &batchv1.Job{}
+
+	err := c.client.Get(context.TODO(), objKey, job)
+	if errors.IsNotFound(err) {
+		return false
+	}
+
+	if err != nil {
+		// failed to check whether it is running, assuming job is still running
+		return true
+	}
+
+	return job.Status.Succeeded <= 0
+}
+
+func (c *jobController) RemoveJob(bdName string) (CleanupState, error) {
+	jobName := generateCleaningJobName(bdName)
+	objKey := client.ObjectKey{
+		Namespace: c.namespace,
+		Name:      jobName,
+	}
+	job := &batchv1.Job{}
+
+	err := c.client.Get(context.TODO(), objKey, job)
+	if err != nil {
+		return CleanupStateUnknown, err
+	}
+	if job.Status.Succeeded == 0 {
+		return CleanupStateRunning, nil
+	}
+
+	if err = c.client.Delete(context.TODO(), job); err != nil {
+		return CleanupStateUnknown, err
+	}
+
+	return CleanupStateSucceeded, nil
+}
+
+func generateCleaningJobName(bdName string) string {
+	return JobNamePrefix + bdName
+}
+
+func getCommand(cmd string) []string {
+	return strings.Split(cmd, " ")
+}

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -12,6 +12,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+This pkg is inspired from the deleter pkg in local-static-provisioner
+in kubernetes-sigs
+	https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/tree/master/pkg/deleter
 */
 
 package cleaner

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -41,8 +41,6 @@ const (
 	BDLabel = "blockdevice"
 	// BlockCleanerCommand is the command used to clean raw block
 	BlockCleanerCommand = "dd"
-	// FSCleanerCommand is the command to clear data on the filesystem
-	FSCleanerCommand = "rm"
 )
 
 // JobController defines the interface for the job controller.
@@ -83,9 +81,8 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 		count := "count=" + strconv.FormatUint(blockCount, 10)
 		jobContainer.Command = getCommand(BlockCleanerCommand, input, output, blockSize, count)
 	} else if volMode == VolumeModeFileSystem {
-		deleteOptions := "-rf"
-		directory := "/tmp/*"
-		jobContainer.Command = getCommand(FSCleanerCommand, deleteOptions, directory)
+		jobContainer.Command = []string{"/bin/sh", "-c"}
+		jobContainer.Args = []string{"find /tmp -mindepth 1 -maxdepth 1 -print0 | xargs -0 rm -rf"}
 		mountName := "vol-mount"
 		volumes := []v1.Volume{
 			{

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cleaner
 
 import (
@@ -14,12 +30,17 @@ import (
 
 const (
 	// JobContainerName is the name of the cleanup job container
-	JobContainerName    = "cleaner"
-	JobNamePrefix       = "cleanup-"
-	JobImageName        = "busybox"
-	BDLabel             = "blockdevice"
+	JobContainerName = "cleaner"
+	// JobNamePrefix is the prefix for the cleanup job name
+	JobNamePrefix = "cleanup-"
+	// JobImageName is the image to be used for the cleanup job container
+	JobImageName = "busybox"
+	// BDLabel is the label set on the job for identification of the BD
+	BDLabel = "blockdevice"
+	// BlockCleanerCommand is the command used to clean raw block
 	BlockCleanerCommand = "dd"
-	FSCleanerCommand    = "rm"
+	// FSCleanerCommand is the command to clear data on the filesystem
+	FSCleanerCommand = "rm"
 )
 
 // JobController defines the interface for the job controller.
@@ -164,8 +185,11 @@ func generateCleaningJobName(bdName string) string {
 	return JobNamePrefix + bdName
 }
 
-func getCommand(cmd string, options ...string) []string {
+func getCommand(cmd string, args ...string) []string {
 	var command []string
 	command = append(command, cmd)
-	return append(command, options)
+	for _, arg := range args {
+		command = append(command, arg)
+	}
+	return command
 }

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -34,6 +34,8 @@ type jobController struct {
 	namespace string
 }
 
+// NewCleanupJob creates a new cleanup job in the  namespace. It returns a Job object which can be used to
+// start the job
 func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace string) (*batchv1.Job, error) {
 	nodeName := bd.Labels[controller.NDMHostKey]
 
@@ -95,6 +97,8 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 	return job, nil
 }
 
+// NewJobController returns a job controller struct which can be used to get the status
+// of the running job
 func NewJobController(client client.Client, namespace string) *jobController {
 	return &jobController{
 		client:    client,

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -37,8 +37,6 @@ const (
 	JobContainerName = "cleaner"
 	// JobNamePrefix is the prefix for the cleanup job name
 	JobNamePrefix = "cleanup-"
-	// JobImageName is the image to be used for the cleanup job container
-	JobImageName = "busybox"
 	// BDLabel is the label set on the job for identification of the BD
 	BDLabel = "blockdevice"
 	// BlockCleanerCommand is the command used to clean raw block
@@ -68,7 +66,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 	priv := true
 	jobContainer := v1.Container{
 		Name:  JobContainerName,
-		Image: JobImageName,
+		Image: getCleanUpImage(),
 		SecurityContext: &v1.SecurityContext{
 			Privileged: &priv,
 		},

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -262,7 +262,7 @@ func (r *ReconcileBlockDeviceClaim) deleteClaimedBlockDevice(
 		// ObjRef and mark blockdevice unclaimed in etcd
 		dvr := item.DeepCopy()
 		dvr.Spec.ClaimRef = nil
-		dvr.Status.ClaimState = apis.BlockDeviceUnclaimed
+		dvr.Status.ClaimState = apis.BlockDeviceReleased
 		err := r.client.Update(context.TODO(), dvr)
 		if err != nil {
 			reqLogger.Error(err, "Error while updating ObjRef", "BlockDevice-CR:", dvr.ObjectMeta.Name)

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -177,7 +177,7 @@ func (r *ReconcileBlockDeviceClaim) FinalizerHandling(
 	// The object is being deleted
 	if util.Contains(instance.ObjectMeta.Finalizers, BlockDeviceClaimFinalizer) {
 		// Finalizer is set, lets handle external dependency
-		if err := r.deleteClaimedBlockDevice(instance, reqLogger); err != nil {
+		if err := r.releaseClaimedBlockDevice(instance, reqLogger); err != nil {
 			reqLogger.Error(err, "Could not delete external dependency", "BlockDeviceClaim-CR:", instance.ObjectMeta.Name)
 			return err
 		}
@@ -235,8 +235,8 @@ func (r *ReconcileBlockDeviceClaim) isDeviceRequestedByThisDeviceClaim(
 	return true
 }
 
-// deleteClaimedBlockDevice unclaims the block device claimed by this BlockDeviceClaim
-func (r *ReconcileBlockDeviceClaim) deleteClaimedBlockDevice(
+// releaseClaimedBlockDevice releases the block device claimed by this BlockDeviceClaim
+func (r *ReconcileBlockDeviceClaim) releaseClaimedBlockDevice(
 	instance *apis.BlockDeviceClaim, reqLogger logr.Logger) error {
 
 	reqLogger.Info("Deleting external dependencies for CR:" + instance.Name)
@@ -254,12 +254,12 @@ func (r *ReconcileBlockDeviceClaim) deleteClaimedBlockDevice(
 
 	// Check if same deviceclaim holding the ObjRef
 	for _, item := range listDVR.Items {
-		if r.isDeviceRequestedByThisDeviceClaim(instance, item, reqLogger) == false {
+		if !r.isDeviceRequestedByThisDeviceClaim(instance, item, reqLogger) {
 			continue
 		}
 
 		// Found a blockdevice ObjRef with BlockDeviceClaim, Clear
-		// ObjRef and mark blockdevice unclaimed in etcd
+		// ObjRef and mark blockdevice released in etcd
 		dvr := item.DeepCopy()
 		dvr.Spec.ClaimRef = nil
 		dvr.Status.ClaimState = apis.BlockDeviceReleased


### PR DESCRIPTION
When a BDC was deleted, the BD was unclaimed and could be claimed by other BDCs. In this case the data on the BD remains. This PR introduces a scrub job which will delete the data on the BD. 

The new workflow will be like: When a BDC is deleted, the BD will be marked as `Released`. The reconcile loop will pick up all BDs in released state and creates a scrub job for those BDs. If a job is already in progress, then new job will not be created.

The job can perform 2 opertions depending on the BD: 
1. If the BD is used as a raw block device, a `dd` command will be issued on the BD to wipe out all the data. This takes significantly long duration.
2. If the BD is used as a volume i.e it was preformatted and mounted before claiming, then an `rm -rf` will be issued by the job. Only the data will be removed. The filesystem on the BD will remain as it is. This job is much quicker than wiping the disk

Once the job is completed, the BD will be marked as `Unclaimed` and can be claimed by other BDCs.