### PR TITLE
feat(blockdevice): add support for managed=false on BlockDevices

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -73,6 +73,7 @@ func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
 	}
 	objectMeta.Labels[NDMHostKey] = di.HostName
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
+	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta
 }
 

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -155,6 +155,7 @@ func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
 	}
 
 	filter := NDMHostKey + "=" + c.HostName
+	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
 	err := c.Clientset.List(context.TODO(), opts, blockDeviceList)

--- a/cmd/ndm_daemonset/controller/blockdevicestore_test.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore_test.go
@@ -395,6 +395,7 @@ func TestPushDeviceResource(t *testing.T) {
 	fakeDr := mockEmptyDeviceCr()
 	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
 	fakeDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
+	fakeDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 
 	// Pass 1st argument as nil then it creates one disk resource
 	fakeController.PushBlockDeviceResource(nil, deviceDetails)

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -7,6 +7,7 @@ import (
 	openebsv1alpha1 "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/cleaner"
 	"github.com/openebs/node-disk-manager/pkg/udev"
+	"github.com/openebs/node-disk-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
@@ -128,6 +129,11 @@ func (r *ReconcileBlockDevice) CheckBackingDiskStatusAndUpdateDeviceCR(
 	// If the BlockDevice is of type sparse, then we need not check the backing disk
 	// status, As sparse block devices does not have a backing disk.
 	if instance.Spec.Details.DeviceType == ndm.SparseBlockDeviceType {
+		return nil
+	}
+
+	// if NDM managed label
+	if util.CheckFalsy(instance.Labels[ndm.NDMManagedKey]) {
 		return nil
 	}
 

--- a/pkg/controller/blockdevice/blockdevice_controller_test.go
+++ b/pkg/controller/blockdevice/blockdevice_controller_test.go
@@ -116,14 +116,14 @@ func TestDeviceController(t *testing.T) {
 
 func GetFakeDeviceObject() *openebsv1alpha1.BlockDevice {
 	device := &openebsv1alpha1.BlockDevice{}
+	labels := map[string]string{ndm.NDMManagedKey: ndm.TrueString}
 
 	TypeMeta := metav1.TypeMeta{
 		Kind:       ndm.NDMBlockDeviceKind,
 		APIVersion: ndm.NDMVersion,
 	}
-
 	ObjectMeta := metav1.ObjectMeta{
-		Labels:    make(map[string]string),
+		Labels:    labels,
 		Name:      deviceName,
 		Namespace: namespace,
 	}


### PR DESCRIPTION
Add `ndm.io/managed` labels for BlockDevices, similar to disk. BlockDevices which are not managed by NDM will not be made active/inactive by the DaemonSet. Also, unmanaged blockdevices are ignored by the operator to check whether the block devices have a backing disk or not.