### PR TITLE
fix(probe): exclude kubelet mountpoints from mount-probe

### DIFF
--- a/cmd/ndm_daemonset/probe/mountprobe.go
+++ b/cmd/ndm_daemonset/probe/mountprobe.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/mount"
 	"github.com/openebs/node-disk-manager/pkg/util"
+	"strings"
 )
 
 // mountProbe contains required variables for populating diskInfo
@@ -35,6 +36,7 @@ type mountProbe struct {
 const (
 	mountProbePriority = 5
 	mountConfigKey     = "mount-probe"
+	k8sLocalVolumePath = "kubernetes.io/local-volume"
 )
 
 var (
@@ -97,6 +99,11 @@ func (mp *mountProbe) FillDiskDetails(d *controller.DiskInfo) {
 	basicMountInfo, err := mountProbe.MountIdentifier.DeviceBasicMountInfo()
 	if err != nil {
 		glog.Error(err)
+		return
+	}
+	// if mount point contains kubernetes.io/local-volume it means that the device is mounted
+	// by kubelet. In that case we ignore the mountpoint.
+	if strings.Contains(basicMountInfo.MountPoint, k8sLocalVolumePath) {
 		return
 	}
 	d.FileSystemInformation.MountPoint = basicMountInfo.MountPoint


### PR DESCRIPTION
kubelet mount points are excluded by mount probe. If mount probe detects a kubelet mountpoint for a disk, the mount info and file system info is skipped from being added into the custom resources.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>