### PR TITLE
fix(cleaner): change dd to wipefs

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -270,4 +270,4 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "quay.io/openebs/openebs-tools:3.8"
+              value: "openebs/linux-utils:3.9"

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -270,4 +270,4 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "openebs/linux-utils:3.9"
+              value: "quay.io/openebs/linux-utils:3.9"

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	// defaultCleanUpJobImage is the default job container image
-	defaultCleanUpJobImage = "quay.io/openebs/openebs-tools:3.8"
+	defaultCleanUpJobImage = "openebs/linux-utils:3.9"
 )
 
 // getCleanUpImage gets the image to be used for the cleanup job

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	// defaultCleanUpJobImage is the default job container image
-	defaultCleanUpJobImage = "openebs/linux-utils:3.9"
+	defaultCleanUpJobImage = "quay.io/openebs/linux-utils:3.9"
 )
 
 // getCleanUpImage gets the image to be used for the cleanup job

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -76,10 +76,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 		// wipefs erases the filesystem signature from the block
 		// -a    wipe all magic strings
 		// -f    force erasure
-		wipeCommand := BlockCleanerCommand + " -af " + bd.Spec.Path
-
-		jobContainer.Command = []string{"/bin/sh", "-c"}
-		jobContainer.Args = []string{wipeCommand}
+		jobContainer.Command = getCommand(BlockCleanerCommand, "-af", bd.Spec.Path)
 
 		// in case of sparse disk, need to mount the sparse file directory
 		// and clear the sparse file


### PR DESCRIPTION
Fixed high cpu/io utilization of cleanup job. Using `dd` caused heavy load on the CPU, and prevented other pods from getting scheduled on the node. It also caused kube-api server crash at times. By using `wipefs` instead of `dd` only the file-system signatures will be erased. This process is much faster than writing zeros, since we are only working with certain block(superblocks).

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>