### PR TITLE
fix(seachest, travis): use latest release of seachest  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   # we need openSeaChest repo to build node-disk-manager
   - pushd .
   - cd ..
-  - git clone --recursive --branch Hotfix-Makefile_fix https://github.com/Seagate/openSeaChest.git
+  - git clone --recursive --branch Hotfix-Makefile_fix https://github.com/openebs/openSeaChest.git
   - cd openSeaChest/Make/gcc 
   - make release
   - cd ../../

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   # we need openSeaChest repo to build node-disk-manager
   - pushd .
   - cd ..
+  # Hotfix-Makefile_fix is the Release-19.06 with certain fixes in Makefile
   - git clone --recursive --branch Hotfix-Makefile_fix https://github.com/openebs/openSeaChest.git
   - cd openSeaChest/Make/gcc 
   - make release

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ install:
   # we need openSeaChest repo to build node-disk-manager
   - pushd .
   - cd ..
-  - git clone --recursive --branch Release-18.10 https://github.com/openebs/openSeaChest.git
+  - git clone --recursive --branch Hotfix-Makefile_fix https://github.com/Seagate/openSeaChest.git
   - cd openSeaChest/Make/gcc 
   - make release
   - cd ../../

--- a/pkg/seachest/seachest.go
+++ b/pkg/seachest/seachest.go
@@ -16,7 +16,7 @@ limitations under the License.
 package seachest
 
 /*
-#cgo LDFLAGS: -lopensea-operations -lopensea-transport -lopensea-common
+#cgo LDFLAGS: -lopensea-operations -lopensea-transport -lopensea-common -lm
 #cgo CFLAGS: -I../../../openSeaChest/include -I../../../openSeaChest/opensea-common/include -I../../../openSeaChest/opensea-operations/include -I../../../openSeaChest/opensea-transport/include
 #include "common.h"
 #include "openseachest_util_options.h"


### PR DESCRIPTION
use latest seachest release for building NDM. The `Release-19.06` fixes stack corruption issue and initial code for support for NVMe devices.