### PR TITLE
fix(operator, upgrade): handle CRD upgrade from operator

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -187,6 +187,8 @@ metadata:
   name: node-disk-operator
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       name: node-disk-operator

--- a/pkg/setup/create_crd.go
+++ b/pkg/setup/create_crd.go
@@ -47,10 +47,10 @@ func (sc Config) createCRD(crd *apiext.CustomResourceDefinition) error {
 			// This will also handle the upgrades of CRDs
 			patch, err := json.Marshal(crd)
 			if err != nil {
-				return fmt.Errorf("could not marshal new customResourceDefintion: %v", err)
+				return fmt.Errorf("could not marshal new customResourceDefintion for %s : %v", crd.Name, err)
 			}
 			if _, err := sc.apiExtClient.ApiextensionsV1beta1().CustomResourceDefinitions().Patch(crd.Name, types.MergePatchType, patch); err != nil {
-				return fmt.Errorf("could not update customResourceDefinition: %v", err)
+				return fmt.Errorf("could not update customResourceDefinition for %s : %v", crd.Name, err)
 			}
 		} else {
 			return err


### PR DESCRIPTION
This PR handles the upgrade scenarios of CRDs (disk, bd and bdc). When a new change is seen in the CRD object, operator will create a json patch and update the CRD object with the patch.  