### PR TITLE
feat(upgrade): perform upgrade from NDM operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ header:
 	@echo
 
 integration-test:
-	go test -v -timeout 15m github.com/openebs/node-disk-manager/integration_tests/sanity
+	go test -v -timeout 20m github.com/openebs/node-disk-manager/integration_tests/sanity
 
 ndm:
 	@echo '--> Building node-disk-manager binary...'

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -110,6 +110,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Info("Registering Components")
+
+	// Setup Scheme for all resources
+	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
 	// Upgrade the components if required
 	k8sClient, err := client.New(cfg, client.Options{})
 	if err != nil {
@@ -117,16 +125,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	log.Info("Performing upgrade operation")
 	err = performUpgrade(k8sClient)
 	if err != nil {
 		log.Error(err, "Upgrade failed")
-	}
-
-	log.Info("Registering Components")
-
-	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "")
 		os.Exit(1)
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -125,7 +125,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Performing upgrade operation")
+	log.Info("Check if CR has to be upgraded, and perform upgrade")
 	err = performUpgrade(k8sClient)
 	if err != nil {
 		log.Error(err, "Upgrade failed")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"github.com/openebs/node-disk-manager/pkg/setup"
 	"github.com/openebs/node-disk-manager/pkg/upgrade"
-	"github.com/openebs/node-disk-manager/pkg/upgrade/preupgrade"
 	"os"
 	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -150,6 +149,6 @@ func main() {
 // performUpgrade performs the upgrade operations
 func performUpgrade(client client.Client) error {
 	//TODO: this task should be named for release, not for upgrade steps
-	preUpgradeTask := preupgrade.NewPreUpgradeTask("1.0", "1.1", client)
+	preUpgradeTask := upgrade.NewPreUpgradeTask("1.0", "1.1", client)
 	return upgrade.RunUpgrade(preUpgradeTask)
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -147,6 +147,7 @@ func main() {
 	}
 }
 
+// performUpgrade performs the upgrade operations
 func performUpgrade(client client.Client) error {
 	//TODO: this task should be named for release, not for upgrade steps
 	preUpgradeTask := preupgrade.NewPreUpgradeTask("1.0", "1.1", client)

--- a/integration_tests/k8s/k8sapi.go
+++ b/integration_tests/k8s/k8sapi.go
@@ -19,6 +19,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
@@ -116,6 +117,20 @@ func (c k8sClient) ListBlockDeviceClaims() (*apis.BlockDeviceClaimList, error) {
 		return nil, fmt.Errorf("cannot list block device claims. Error :%v", err)
 	}
 	return bdcList, nil
+}
+
+// RestartPod the given pod
+func (c k8sClient) RestartPod(name string) error {
+	pods, err := c.ListPodStatus()
+	if err != nil {
+		return nil
+	}
+	for pod, _ := range pods {
+		if strings.Contains(pod, name) {
+			return c.ClientSet.CoreV1().Pods(namespace).Delete(pod, &metav1.DeleteOptions{})
+		}
+	}
+	return fmt.Errorf("could not find given pod")
 }
 
 // NewBDC creates a sample device claim which can be used for

--- a/integration_tests/k8s/k8sapi.go
+++ b/integration_tests/k8s/k8sapi.go
@@ -125,7 +125,7 @@ func (c k8sClient) RestartPod(name string) error {
 	if err != nil {
 		return nil
 	}
-	for pod, _ := range pods {
+	for pod := range pods {
 		if strings.Contains(pod, name) {
 			return c.ClientSet.CoreV1().Pods(namespace).Delete(pod, &metav1.DeleteOptions{})
 		}

--- a/integration_tests/k8s/k8sndmresources.go
+++ b/integration_tests/k8s/k8sndmresources.go
@@ -87,22 +87,6 @@ func (c k8sClient) DeleteNDMYAML() error {
 		return err
 	}
 
-	// deleting disk crd
-	err = c.DeleteNDMDiskCRD()
-	if err != nil {
-		return err
-	}
-	// deleting device crd
-	err = c.DeleteNDMDeviceCRD()
-	if err != nil {
-		return err
-	}
-	// deleting device request crd
-	err = c.DeleteNDMDeviceRequestCRD()
-	if err != nil {
-		return err
-	}
-
 	// deleting ndm daemon-set
 	err = c.DeleteNDMDaemonSet()
 	if err != nil {

--- a/integration_tests/sanity/deviceclaim_test.go
+++ b/integration_tests/sanity/deviceclaim_test.go
@@ -33,6 +33,8 @@ const (
 	HostName = "minikube"
 	// FakeHostName is a generated fake hostname
 	FakeHostName = "fake-minikube"
+	// FakeBlockDevice is a generated fake block device name
+	FakeBlockDevice = "fake-BD"
 )
 
 var (

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Pre upgrade tests", func() {
 			// list BDC and check for new finalizer
 			bdcList, err := k8sClient.ListBlockDeviceClaims()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(bdcList.Items).To(Equal(1))
+			Expect(len(bdcList.Items)).To(Equal(1))
 
 			for _, bdc := range bdcList.Items {
 				Expect(bdc.Finalizers).To(Equal(newBDCFinalizer))

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -40,10 +40,17 @@ var _ = Describe("Pre upgrade tests", func() {
 			blockDeviceClaim.Finalizers = append(blockDeviceClaim.ObjectMeta.Finalizers, oldBDCFinalizer)
 			blockDeviceClaim.Spec.BlockDeviceName = FakeBlockDevice
 
+			// create the BDC with old finalizer
 			err := k8sClient.CreateBlockDeviceClaim(blockDeviceClaim)
 			Expect(err).NotTo(HaveOccurred())
 			k8s.WaitForReconcilation()
 
+			// restart the ndm operator pod
+			err = k8sClient.RestartPod("node-disk-operator")
+			Expect(err).NotTo(HaveOccurred())
+			k8s.WaitForStateChange()
+
+			// list BDC and check for new finalizer
 			bdcList, err := k8sClient.ListBlockDeviceClaims()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bdcList.Items).To(Equal(1))

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Pre upgrade tests", func() {
 		})
 		It("has only the old BDC finalizer", func() {
 			blockDeviceClaim.Finalizers = append(blockDeviceClaim.ObjectMeta.Finalizers, oldBDCFinalizer)
+			blockDeviceClaim.Namespace = DefaultNamespace
 			blockDeviceClaim.Spec.BlockDeviceName = FakeBlockDevice
 
 			// create the BDC with old finalizer

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Pre upgrade tests", func() {
 			Expect(len(bdcList.Items)).To(Equal(1))
 
 			for _, bdc := range bdcList.Items {
-				Expect(bdc.Finalizers).To(Equal(newBDCFinalizer))
+				Expect(bdc.Finalizers).To(ContainElement(newBDCFinalizer))
 			}
 
 		})

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -1,0 +1,58 @@
+package sanity
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openebs/node-disk-manager/integration_tests/k8s"
+	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+)
+
+const (
+	// oldBDCFinalizer is the old string from which BDC should be updated
+	oldBDCFinalizer = "blockdeviceclaim.finalizer"
+	// newBDCFinalizer is the new string to which BDC to be updated
+	newBDCFinalizer = "openebs.io/bdc-protection"
+	//
+)
+
+var _ = Describe("Pre upgrade tests", func() {
+
+	k8sClient, _ := k8s.GetClientSet()
+
+	BeforeEach(func() {
+		err := k8sClient.CreateNDMYAML()
+		Expect(err).NotTo(HaveOccurred())
+		k8s.WaitForStateChange()
+		k8sClient, _ = k8s.GetClientSet()
+	})
+	AfterEach(func() {
+		err := k8sClient.DeleteNDMYAML()
+		Expect(err).NotTo(HaveOccurred())
+		k8s.WaitForStateChange()
+	})
+	Context("BDC with old finalizer", func() {
+		bdcName1 := "test-bdc1"
+		var blockDeviceClaim *apis.BlockDeviceClaim
+		BeforeEach(func() {
+			blockDeviceClaim = k8s.NewBDC(bdcName1)
+		})
+		It("has only the old BDC finalizer", func() {
+			blockDeviceClaim.Finalizers = append(blockDeviceClaim.ObjectMeta.Finalizers, oldBDCFinalizer)
+			blockDeviceClaim.Spec.BlockDeviceName = FakeBlockDevice
+
+			err := k8sClient.CreateBlockDeviceClaim(blockDeviceClaim)
+			Expect(err).NotTo(HaveOccurred())
+			k8s.WaitForReconcilation()
+
+			bdcList, err := k8sClient.ListBlockDeviceClaims()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bdcList.Items).To(Equal(1))
+
+			for _, bdc := range bdcList.Items {
+				Expect(bdc.Finalizers).To(Equal(newBDCFinalizer))
+			}
+
+		})
+
+	})
+})

--- a/integration_tests/sanity/upgrade_test.go
+++ b/integration_tests/sanity/upgrade_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package sanity
 
 import (

--- a/pkg/upgrade/preupgrade.go
+++ b/pkg/upgrade/preupgrade.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package preupgrade
+package upgrade
 
 import (
 	"context"

--- a/pkg/upgrade/preupgrade/preupgrade.go
+++ b/pkg/upgrade/preupgrade/preupgrade.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package preupgrade
 
 import (
@@ -8,10 +24,14 @@ import (
 )
 
 const (
+	// oldBDCFinalizer is the old string from which BDC should be updated
 	oldBDCFinalizer = "blockdeviceclaim.finalizer"
+	// newBDCFinalizer is the new string to which BDC to be updated
 	newBDCFinalizer = "openebs.io/bdc-protection"
 )
 
+// PreUpgrade is the struct which implements the UpgradeTask interface
+// which can be used to perform the upgrade
 type PreUpgrade struct {
 	from   string
 	to     string
@@ -19,18 +39,24 @@ type PreUpgrade struct {
 	err    error
 }
 
+// NewPreUpgradeTask creates a new preupgrade with given client
+// and specified `from` and `to` version
 func NewPreUpgradeTask(from, to string, c client.Client) *PreUpgrade {
 	return &PreUpgrade{from: from, to: to, client: c}
 }
 
+// FromVersion returns the version from which the components need to be updated
 func (p *PreUpgrade) FromVersion() string {
 	return p.from
 }
 
+// ToVersion returns the version to which components will be updated. This should be
+// the current version
 func (p *PreUpgrade) ToVersion() string {
 	return p.to
 }
 
+// PreUpgrade runs the preupgrade tasks and returns whether it succeeded or not
 func (p *PreUpgrade) PreUpgrade() bool {
 	var err error
 	bdcList := &apis.BlockDeviceClaimList{}
@@ -51,6 +77,7 @@ func (p *PreUpgrade) PreUpgrade() bool {
 	return true
 }
 
+// Upgrade runs the main upgrade tasks and returns whether it succeeded or not
 func (p *PreUpgrade) Upgrade() bool {
 	if p.err != nil {
 		return false
@@ -58,6 +85,8 @@ func (p *PreUpgrade) Upgrade() bool {
 	return true
 }
 
+// PostUpgrade runs the tasks that need to be performed after upgrade and returns
+// whether the tasks where success or not
 func (p *PreUpgrade) PostUpgrade() bool {
 	if p.err != nil {
 		return false
@@ -65,10 +94,13 @@ func (p *PreUpgrade) PostUpgrade() bool {
 	return true
 }
 
+// IsSuccess returns error if the upgrade failed, at any step. Else nil will
+// be returned
 func (p *PreUpgrade) IsSuccess() error {
 	return p.err
 }
 
+// renameFinalizer renames the finalizer from old to new in BDC
 func (p *PreUpgrade) renameFinalizer(claim *apis.BlockDeviceClaim) error {
 	if util.Contains(claim.Finalizers, oldBDCFinalizer) {
 		claim.Finalizers = util.RemoveString(claim.Finalizers, oldBDCFinalizer)

--- a/pkg/upgrade/preupgrade/preupgrade.go
+++ b/pkg/upgrade/preupgrade/preupgrade.go
@@ -1,0 +1,79 @@
+package preupgrade
+
+import (
+	"context"
+	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	"github.com/openebs/node-disk-manager/pkg/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	oldBDCFinalizer = "blockdeviceclaim.finalizer"
+	newBDCFinalizer = "openebs.io/bdc-protection"
+)
+
+type PreUpgrade struct {
+	from   string
+	to     string
+	client client.Client
+	err    error
+}
+
+func NewPreUpgradeTask(from, to string, c client.Client) *PreUpgrade {
+	return &PreUpgrade{from: from, to: to, client: c}
+}
+
+func (p *PreUpgrade) FromVersion() string {
+	return p.from
+}
+
+func (p *PreUpgrade) ToVersion() string {
+	return p.to
+}
+
+func (p *PreUpgrade) PreUpgrade() bool {
+	var err error
+	bdcList := &apis.BlockDeviceClaimList{}
+	opts := &client.ListOptions{}
+	err = p.client.List(context.TODO(), opts, bdcList)
+	if err != nil {
+		p.err = err
+		return false
+	}
+
+	for _, bdc := range bdcList.Items {
+		err = p.renameFinalizer(&bdc)
+		if err != nil {
+			p.err = err
+			return false
+		}
+	}
+	return true
+}
+
+func (p *PreUpgrade) Upgrade() bool {
+	if p.err != nil {
+		return false
+	}
+	return true
+}
+
+func (p *PreUpgrade) PostUpgrade() bool {
+	if p.err != nil {
+		return false
+	}
+	return true
+}
+
+func (p *PreUpgrade) IsSuccess() error {
+	return p.err
+}
+
+func (p *PreUpgrade) renameFinalizer(claim *apis.BlockDeviceClaim) error {
+	if util.Contains(claim.Finalizers, oldBDCFinalizer) {
+		claim.Finalizers = util.RemoveString(claim.Finalizers, oldBDCFinalizer)
+		claim.Finalizers = append(claim.Finalizers, newBDCFinalizer)
+		return p.client.Update(context.TODO(), claim)
+	}
+	return nil
+}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package upgrade
 
 // UpgradeTask interfaces gives a set of methods to be implemented

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -1,0 +1,23 @@
+package upgrade
+
+// UpgradeTask interfaces gives a set of methods to be implemented
+// for performing an upgrade
+type UpgradeTask interface {
+	FromVersion() string
+	ToVersion() string
+	IsSuccess() error
+	PreUpgrade() bool
+	Upgrade() bool
+	PostUpgrade() bool
+}
+
+// RunUpgrade runs all the upgrade tasks required
+func RunUpgrade(tasks ...UpgradeTask) error {
+	for _, task := range tasks {
+		_ = task.PreUpgrade() && task.Upgrade() && task.PostUpgrade()
+		if err := task.IsSuccess(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package upgrade
 
-// UpgradeTask interfaces gives a set of methods to be implemented
+// Task interfaces gives a set of methods to be implemented
 // for performing an upgrade
-type UpgradeTask interface {
+type Task interface {
 	FromVersion() string
 	ToVersion() string
 	IsSuccess() error
@@ -28,7 +28,7 @@ type UpgradeTask interface {
 }
 
 // RunUpgrade runs all the upgrade tasks required
-func RunUpgrade(tasks ...UpgradeTask) error {
+func RunUpgrade(tasks ...Task) error {
 	for _, task := range tasks {
 		_ = task.PreUpgrade() && task.Upgrade() && task.PostUpgrade()
 		if err := task.IsSuccess(); err != nil {


### PR DESCRIPTION
This PR adds a new pkg to perform upgrade operations. Preupgrade -> upgrade -> postupgrade tasks all can be performed using the package. It is also possible to handle upgrade for multiple release versions.

Currently, only the preupgrade script is being executed. It handles renaming finalizer in BDC.