### PR TITLE
fix(travis): upgrade seachest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pushd .
   - cd ..
   # Hotfix-Makefile_fix is the Release-19.06 with certain fixes in Makefile
-  - git clone --recursive --branch Hotfix-Makefile_fix https://github.com/openebs/openSeaChest.git
+  - git clone --recursive --branch Release-19.06.02 https://github.com/openebs/openSeaChest.git
   - cd openSeaChest/Make/gcc 
   - make release
   - cd ../../


### PR DESCRIPTION
upgrade seachest version to `Release-19.06.02`. This fixes issue of seachest crashing with NVMe devices, in which write cache is supported.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>