### PR TITLE
fix(daemon, controller): change nodeName to hostname in disk and BD

### DIFF
--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -187,8 +187,8 @@ func (c *Controller) newClientSet() (client.Client, error) {
 	return clientSet, nil
 }
 
-// getNodeName set HostName field in Controller struct
-// if it gets from env else it returns error
+// setHostName set HostName field in Controller struct
+// from the labels in node object
 func (c *Controller) setHostName() error {
 	nodeName, err := getNodeName()
 	if err != nil {
@@ -205,6 +205,8 @@ func (c *Controller) setHostName() error {
 	return nil
 }
 
+// getNodeName gets the node name from env, else
+// returns an error
 func getNodeName() (string, error) {
 	nodeName, ok := os.LookupEnv("NODE_NAME")
 	if !ok {

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -201,7 +201,14 @@ func (c *Controller) setHostName() error {
 	if err != nil {
 		return err
 	}
-	c.HostName = node.Labels[NDMHostKey]
+
+	// if the label is not present, or hostname is an empty string,
+	// use nodename as hostname
+	if hostName, ok := node.Labels[NDMHostKey]; !ok || hostName == "" {
+		c.HostName = nodeName
+	} else {
+		c.HostName = hostName
+	}
 	return nil
 }
 

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -17,7 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"sync"
 	"time"
@@ -28,9 +31,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/openebs/node-disk-manager/pkg/apis"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 const (
@@ -108,20 +111,6 @@ func NewController(kubeconfig string) (*Controller, error) {
 		return nil, err
 	}
 
-	if err := controller.setNodeName(); err != nil {
-		return nil, err
-	}
-	controller.SetNDMConfig()
-	controller.Filters = make([]*Filter, 0)
-	controller.Probes = make([]*Probe, 0)
-	controller.Mutex = &sync.Mutex{}
-
-	// get the namespace in which NDM is installed
-	Namespace, err = getNamespace()
-	if err != nil {
-		return controller, err
-	}
-
 	controller.mgr, err = manager.New(controller.config, manager.Options{Namespace: Namespace})
 	if err != nil {
 		return controller, err
@@ -135,6 +124,21 @@ func NewController(kubeconfig string) (*Controller, error) {
 	_, err = controller.newClientSet()
 	if err != nil {
 		return controller, err
+	}
+
+	controller.SetNDMConfig()
+	controller.Filters = make([]*Filter, 0)
+	controller.Probes = make([]*Probe, 0)
+	controller.Mutex = &sync.Mutex{}
+
+	// get the namespace in which NDM is installed
+	Namespace, err = getNamespace()
+	if err != nil {
+		return controller, err
+	}
+
+	if err := controller.setHostName(); err != nil {
+		return nil, err
 	}
 
 	controller.WaitForDiskCRD()
@@ -183,15 +187,30 @@ func (c *Controller) newClientSet() (client.Client, error) {
 	return clientSet, nil
 }
 
-// setNodeName set HostName field in Controller struct
+// getNodeName set HostName field in Controller struct
 // if it gets from env else it returns error
-func (c *Controller) setNodeName() error {
-	host, ret := os.LookupEnv("NODE_NAME")
-	if ret != true {
-		return errors.New("error building hostname")
+func (c *Controller) setHostName() error {
+	nodeName, err := getNodeName()
+	if err != nil {
+		return fmt.Errorf("unable to get hostname: %v", err)
 	}
-	c.HostName = host
+	// get the node object and fetch the hostname label from the
+	// node object
+	node := &v1.Node{}
+	err = c.Clientset.Get(context.TODO(), client.ObjectKey{Namespace: "", Name: nodeName}, node)
+	if err != nil {
+		return err
+	}
+	c.HostName = node.Labels[NDMHostKey]
 	return nil
+}
+
+func getNodeName() (string, error) {
+	nodeName, ok := os.LookupEnv("NODE_NAME")
+	if !ok {
+		return "", errors.New("error getting node name")
+	}
+	return nodeName, nil
 }
 
 // getNamespace get Namespace from env, else it returns error

--- a/cmd/ndm_daemonset/controller/controller_test.go
+++ b/cmd/ndm_daemonset/controller/controller_test.go
@@ -25,29 +25,27 @@ import (
 )
 
 /*
-	set environment variable "NODE_NAME" with some value and setNodeName
-	unset environment variable "NODE_NAME" with some value and setNodeName
+	set environment variable "NODE_NAME" with some value and getNodeName
+	unset environment variable "NODE_NAME" with some value and getNodeName
 */
-func TestSetNodeName(t *testing.T) {
+func TestGetNodeName(t *testing.T) {
 	fakeNodeName := "fake-node-name"
-	ctrl1 := &Controller{}
-	ctrl2 := &Controller{}
-	err1 := ctrl1.setNodeName()
+	nodeName1, err1 := getNodeName()
 	os.Setenv("NODE_NAME", fakeNodeName)
-	err2 := ctrl2.setNodeName()
-	expectedErr2 := errors.New("error building hostname")
+	nodeName2, err2 := getNodeName()
+	expectedErr2 := errors.New("error getting node name")
 	tests := map[string]struct {
-		actualController *Controller
-		expectedHostName string
+		actualNodeName   string
+		expectedNodeName string
 		actualError      error
 		expectedError    error
 	}{
-		"call setNodeName when env variable not present": {actualController: ctrl1, actualError: err1, expectedHostName: "", expectedError: expectedErr2},
-		"call setNodeName when env variable present":     {actualController: ctrl2, actualError: err2, expectedHostName: fakeNodeName, expectedError: nil},
+		"call getNodeName when env variable not present": {actualNodeName: nodeName1, actualError: err1, expectedNodeName: "", expectedError: expectedErr2},
+		"call getNodeName when env variable present":     {actualNodeName: nodeName2, actualError: err2, expectedNodeName: fakeNodeName, expectedError: nil},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expectedHostName, test.actualController.HostName)
+			assert.Equal(t, test.expectedNodeName, test.actualNodeName)
 			assert.Equal(t, test.expectedError, test.actualError)
 		})
 	}

--- a/integration_tests/yamls/clusterrole.yaml
+++ b/integration_tests/yamls/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: openebs-ndm-operator
 rules:
   - apiGroups: ["*"]
-    resources: ["pods", "services", "endpoints", "events", "configmaps", "secrets", "jobs"]
+    resources: ["nodes", "pods", "services", "endpoints", "events", "configmaps", "secrets", "jobs"]
     verbs:
       - '*'
   - apiGroups: ["apiextensions.k8s.io"]

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -61,7 +61,7 @@ metadata:
   name: openebs-ndm-operator
 rules:
 - apiGroups: ["*"]
-  resources: ["disks", "blockdevices", "blockdeviceclaims", "pods", "services", "endpoints", "events", "configmaps", "secrets", "jobs"]
+  resources: ["nodes", "pods", "services", "endpoints", "events", "configmaps", "secrets", "jobs"]
   verbs:
   - '*'
 - apiGroups: ["apiextensions.k8s.io"]
@@ -71,7 +71,7 @@ rules:
 - apiGroups:
   - openebs.io
   resources:
-  - '*'
+  - disks
   - blockdevices
   - blockdeviceclaims
   verbs:


### PR DESCRIPTION
earlier node name was used as `kubernetes.io/hostname`, in disk and blockdevices. But in some cloud providers like AWS, node name and hostname are not same. Therefore, now we fetch the nodename using downward API, and then get the hostname label set on that node.