### PR TITLE
fix(cleaner): add service account to cleanup job

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -200,7 +200,6 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
         - name: node-disk-operator
-          # Replace this with the built image name
           image: openebs/node-disk-operator-amd64:ci
           ports:
           - containerPort: 8080
@@ -223,6 +222,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            # the service account of this pod
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -55,7 +55,7 @@ const (
 
 // Cleaner handles BD cleanup
 // For filesystem/mount based block devices, it deletes the contents of the directory
-// For raw block devices, a `dd` command will be issued.
+// For raw block devices, a `wipefs` command will be issued.
 type Cleaner struct {
 	Client        client.Client
 	Namespace     string

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -22,6 +22,9 @@ const (
 	// EnvCleanUpJobImage is the environment variable for getting the
 	// job container image
 	EnvCleanUpJobImage = "CLEANUP_JOB_IMAGE"
+	// ServiceAccountName is the service account in which the operator pod
+	// is running. The cleanup job, pod will be started with this service account
+	ServiceAccountName = "SERVICE_ACCOUNT"
 )
 
 var (
@@ -36,4 +39,10 @@ func getCleanUpImage() string {
 		return defaultCleanUpJobImage
 	}
 	return image
+}
+
+// getServiceAccount gets the service account in which the pod is running
+// TODO move env variable operations to a separate pkg
+func getServiceAccount() string {
+	return os.Getenv(ServiceAccountName)
 }

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -95,6 +95,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 		podSpec.Volumes = []v1.Volume{volume}
 	}
 
+	podSpec.ServiceAccountName = getServiceAccount()
 	podSpec.Containers = []v1.Container{jobContainer}
 	podSpec.NodeSelector = map[string]string{controller.NDMHostKey: nodeName}
 


### PR DESCRIPTION
add service account to cleanup jobs, so that job pods requiring privileged access can be started in openshift cluster.

Fixes [openebs#2698](https://github.com/openebs/openebs/issues/2698)