### PR TITLE
fix(cleaner): cancel jobs of inactive blockdevices

### DIFF
--- a/docs/cleanup-design.md
+++ b/docs/cleanup-design.md
@@ -1,0 +1,40 @@
+# Clean-up of released BlockDevices
+
+NDM Operator performs the cleanup of the data on the blockdevice(BD) before it can be claimed by 
+another BlockDeviceClaim(BDC).
+
+The cleanup operation can be of two types depending on the VolumeMode of the BDC. VolumeMode can be
+- Block : a `wipefs` command will be issued on the BD
+- FileSystem : an `rm -rf` command is issued on the mountpoint of the BD
+
+The cleanup is performed by a kubernetes job, that is scheduled to run on a specified node. The
+following cycle of operations is performed for scheduling a cleanup job.
+
+```
++-----------------+         +------------------+         +------------------+         +---------------+             +------------+
+|                 |         |  Check if status |         |  Check if job is |         | Check status  | Completed   |            |
+| Reconcile loop  |         |    is released   |   Yes   |    in progress   |   No    |     of job    +-------------+ Delete job |
+|    of BDx       +-------->+                  +-------->+                  +-------->+               | Successfully|            |
+|                 |         |                  |         |                  |         |               |             |            |
++-----------------+         +------------------+         +--------+---------+         +-------+-------+             +------+-----+
+                                                                  |                           |                            |	
+                                                                  | Yes                       |Not Found                   |	
+                                                                  v                           v                            |	
+                                                          +-------+---------+          +------+-------+                    |	
+                             +-----------------+          |                 |          |              |                    |	
+                             |                 |    No    |  Check if BD is |          |   Check if   |                    |	
+                             | Cancel the job  +<---------+  in active state|          | BD is active |                    |	
+                             |                 |          |                 |          |              |                    |	
+                             |                 |          |                 |          |              |                    |	
+                             +-------+---------+          +-----------------+          +-------+------+                    |	
+                                     |                             |                           |Yes                    	   |	
+                                     |                             |                    +------+-----+                     |	
+                                     |                             |                    |            |                     |	
+                                     |                             | Yes                | start job  |                     |	
+                                     v                             |                    |            |                     |	
+                              +------+---------+                   |                    |            |                     |	
+                              |                |                   |                    +-------+----+                     |	
+                              |    return      |<------------------+----------------------------|--------------------------+ 	
+                              +----------------+                                    		  			 
+                                                                                                            	                 
+```

--- a/integration_tests/sanity/customresources_test.go
+++ b/integration_tests/sanity/customresources_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openebs/node-disk-manager/integration_tests/k8s"
 	"github.com/openebs/node-disk-manager/integration_tests/udev"
+	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"strings"
 )
 
@@ -57,7 +58,7 @@ var _ = Describe("Device Discovery Tests", func() {
 			// Get the no.of sparse block devices from block device list
 			for _, blockDevice := range bdList.Items {
 				if strings.Contains(blockDevice.Name, SparseBlockDeviceName) {
-					Expect(blockDevice.Status.State).To(Equal(ActiveState))
+					Expect(blockDevice.Status.State).To(Equal(v1alpha1.BlockDeviceActive))
 					noOfSparseBlockDevices++
 				}
 			}
@@ -102,7 +103,7 @@ var _ = Describe("Device Discovery Tests", func() {
 				} else if strings.Contains(blockDevice.Name, SparseBlockDeviceName) {
 					noOfSparseBlockDeviceCR++
 				}
-				Expect(blockDevice.Status.State).To(Equal(ActiveState))
+				Expect(blockDevice.Status.State).To(Equal(v1alpha1.BlockDeviceActive))
 			}
 
 			// Get no of physical disk CRs from diskList
@@ -110,7 +111,7 @@ var _ = Describe("Device Discovery Tests", func() {
 				if strings.Contains(disk.Name, DiskName) && disk.Spec.Path == physicalDisk.Name {
 					noOfPhysicalDiskCR++
 				}
-				Expect(disk.Status.State).To(Equal(ActiveState))
+				Expect(disk.Status.State).To(Equal(v1alpha1.BlockDeviceActive))
 			}
 
 			Expect(noOfPhysicalDiskCR).To(Equal(1))
@@ -130,13 +131,13 @@ var _ = Describe("Device Discovery Tests", func() {
 			// the disk CR should be inactive
 			for _, disk := range diskList.Items {
 				if strings.Contains(disk.Name, DiskName) && disk.Spec.Path == physicalDisk.Name {
-					Expect(disk.Status.State).To(Equal(InactiveState))
+					Expect(disk.Status.State).To(Equal(v1alpha1.DiskInactive))
 				}
 			}
 
 			for _, bd := range bdList.Items {
 				if strings.Contains(bd.Name, BlockDeviceName) && bd.Spec.Path == physicalDisk.Name {
-					Expect(bd.Status.State).To(Equal(InactiveState))
+					Expect(bd.Status.State).To(Equal(v1alpha1.DiskInactive))
 				}
 			}
 		})

--- a/integration_tests/sanity/customresources_test.go
+++ b/integration_tests/sanity/customresources_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Device Discovery Tests", func() {
 				if strings.Contains(disk.Name, DiskName) && disk.Spec.Path == physicalDisk.Name {
 					noOfPhysicalDiskCR++
 				}
-				Expect(disk.Status.State).To(Equal(v1alpha1.BlockDeviceActive))
+				Expect(disk.Status.State).To(Equal(v1alpha1.DiskActive))
 			}
 
 			Expect(noOfPhysicalDiskCR).To(Equal(1))
@@ -137,7 +137,7 @@ var _ = Describe("Device Discovery Tests", func() {
 
 			for _, bd := range bdList.Items {
 				if strings.Contains(bd.Name, BlockDeviceName) && bd.Spec.Path == physicalDisk.Name {
-					Expect(bd.Status.State).To(Equal(v1alpha1.DiskInactive))
+					Expect(bd.Status.State).To(Equal(v1alpha1.BlockDeviceInactive))
 				}
 			}
 		})

--- a/integration_tests/sanity/k8s_tests.go
+++ b/integration_tests/sanity/k8s_tests.go
@@ -33,10 +33,6 @@ const (
 	// BlockDeviceName is the name of the blockDevice CRs created corresponding to
 	// physical/virtual disks or blockdevices
 	BlockDeviceName = "blockdevice-"
-	// ActiveState stores the active state of Disk/Device resource
-	ActiveState = "Active"
-	// InactiveState stores the deactivated state of Disk/Device resource
-	InactiveState = "Inactive"
 	// DiskImageSize is the default file size(1GB) used while creating backing image
 	DiskImageSize = 1073741824
 )

--- a/pkg/apis/openebs/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdevice_types.go
@@ -72,10 +72,23 @@ type DeviceDevLink struct {
 // DeviceStatus defines the observed state of BlockDevice
 type DeviceStatus struct {
 	ClaimState DeviceClaimState `json:"claimState"` // claim state of the block device
-	State      string           `json:"state"`      // current state of the blockdevice (Active/Inactive)
+	State      BlockDiskState   `json:"state"`      // current state of the blockdevice (Active/Inactive)
 }
 
-// DeviceClaimState defines the observed state of BlockDevice
+// BlockDeviceState defines the observed state of the disk
+type BlockDiskState string
+
+const (
+	// BlockDeviceActive is the state for a block device that is connected to the node
+	BlockDeviceActive BlockDiskState = "Active"
+	// BlockDeviceInactive is the state for a block device that is disconnected from a node
+	BlockDeviceInactive BlockDiskState = "Inactive"
+	// BlockDeviceUnknown is the state for a block device whose state (attached/detached) cannot
+	// be determined at this time.
+	BlockDeviceUnknown BlockDiskState = "Unknown"
+)
+
+// DeviceClaimState defines the observed claim state of BlockDevice
 type DeviceClaimState string
 
 const (

--- a/pkg/apis/openebs/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdevice_types.go
@@ -72,20 +72,20 @@ type DeviceDevLink struct {
 // DeviceStatus defines the observed state of BlockDevice
 type DeviceStatus struct {
 	ClaimState DeviceClaimState `json:"claimState"` // claim state of the block device
-	State      BlockDiskState   `json:"state"`      // current state of the blockdevice (Active/Inactive)
+	State      BlockDeviceState `json:"state"`      // current state of the blockdevice (Active/Inactive)
 }
 
 // BlockDeviceState defines the observed state of the disk
-type BlockDiskState string
+type BlockDeviceState string
 
 const (
 	// BlockDeviceActive is the state for a block device that is connected to the node
-	BlockDeviceActive BlockDiskState = "Active"
+	BlockDeviceActive BlockDeviceState = "Active"
 	// BlockDeviceInactive is the state for a block device that is disconnected from a node
-	BlockDeviceInactive BlockDiskState = "Inactive"
+	BlockDeviceInactive BlockDeviceState = "Inactive"
 	// BlockDeviceUnknown is the state for a block device whose state (attached/detached) cannot
 	// be determined at this time.
-	BlockDeviceUnknown BlockDiskState = "Unknown"
+	BlockDeviceUnknown BlockDeviceState = "Unknown"
 )
 
 // DeviceClaimState defines the observed claim state of BlockDevice

--- a/pkg/apis/openebs/v1alpha1/disk_types.go
+++ b/pkg/apis/openebs/v1alpha1/disk_types.go
@@ -66,8 +66,21 @@ type Partition struct {
 
 // DiskStatus defines the observed state of Disk
 type DiskStatus struct {
-	State string `json:"state"` //current state of the disk (Active/Inactive)
+	State DiskState `json:"state"` //current state of the disk (Active/Inactive)
 }
+
+// DiskState defines the observed state of the disk
+type DiskState string
+
+const (
+	// DiskActive is the state for a physical disk that is connected to the node
+	DiskActive DiskState = "Active"
+	// DiskInactive is the state for a physical disk that is disconnected from a node
+	DiskInactive DiskState = "Inactive"
+	// DiskUnknown is the state for a physical disk whose state (attached/detached) cannot
+	// be determined at this time.
+	DiskUnknown DiskState = "Unknown"
+)
 
 type Temperature struct {
 	CurrentTemperature int16 `json:"currentTemperature"`

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcileBlockDevice) CheckBackingDiskStatusAndUpdateDeviceCR(
 		return err
 	}
 
-	if strings.Compare(diskInstance.Status.State, ndm.NDMInactive) == 0 {
+	if diskInstance.Status.State == ndm.NDMInactive {
 		dcpyInstance := instance.DeepCopy()
 		dcpyInstance.Status.State = ndm.NDMInactive
 		err := r.client.Update(context.TODO(), dcpyInstance)


### PR DESCRIPTION
This fix makes sure that cleanup jobs are started only on Active BDs. Also, if the BD goes into another state, during cleanup, the job will be cancelled and BD state will remain unchanged. This ensures that stale jobs are not present in the cluster, when corresponding BDs have been removed.