### PR TITLE
feat(apis, controller, manager): include node attributes to disk/BD

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -108,6 +108,7 @@ func (di *DeviceInfo) getStatus() apis.DeviceStatus {
 // It is used to populate data of BlockDevice struct of blockdevice CR.
 func (di *DeviceInfo) getDeviceSpec() apis.DeviceSpec {
 	deviceSpec := apis.DeviceSpec{}
+	deviceSpec.NodeAttributes.NodeName = di.NodeAttributes[NDMNodeKey]
 	deviceSpec.Path = di.getPath()
 	deviceSpec.Details = di.getDeviceDetails()
 	deviceSpec.Capacity = di.getDeviceCapacity()

--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -73,7 +73,8 @@ func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
 		Name:      di.UUID,
 		Namespace: Namespace,
 	}
-	objectMeta.Labels[NDMHostKey] = di.NodeAttributes[NDMHostKey]
+	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
+	objectMeta.Labels[kubernetesHostNameKey] = di.NodeAttributes[HostNameKey]
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta
@@ -108,7 +109,7 @@ func (di *DeviceInfo) getStatus() apis.DeviceStatus {
 // It is used to populate data of BlockDevice struct of blockdevice CR.
 func (di *DeviceInfo) getDeviceSpec() apis.DeviceSpec {
 	deviceSpec := apis.DeviceSpec{}
-	deviceSpec.NodeAttributes.NodeName = di.NodeAttributes[NDMNodeKey]
+	deviceSpec.NodeAttributes.NodeName = di.NodeAttributes[NodeNameKey]
 	deviceSpec.Path = di.getPath()
 	deviceSpec.Details = di.getDeviceDetails()
 	deviceSpec.Capacity = di.getDeviceCapacity()

--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -26,7 +26,9 @@ import (
 // future). At the end it is converted to BlockDevice struct which will be pushed to
 // etcd as a CR of that blockdevice.
 type DeviceInfo struct {
-	HostName           string   // Node's name to which backing disk is attached.
+	// NodeAttributes is the attributes of the node to which this block device is attached,
+	// like hostname, nodename
+	NodeAttributes     NodeAttribute
 	UUID               string   // UUID of backing disk
 	Capacity           uint64   // Capacity of blockdevice
 	Model              string   // Do blockdevice have model ??
@@ -71,7 +73,7 @@ func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
 		Name:      di.UUID,
 		Namespace: Namespace,
 	}
-	objectMeta.Labels[NDMHostKey] = di.HostName
+	objectMeta.Labels[NDMHostKey] = di.NodeAttributes[NDMHostKey]
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta

--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -73,8 +73,7 @@ func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
 		Name:      di.UUID,
 		Namespace: Namespace,
 	}
-	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
-	objectMeta.Labels[kubernetesHostNameKey] = di.NodeAttributes[HostNameKey]
+	objectMeta.Labels[KubernetesHostNameLabel] = di.NodeAttributes[HostNameKey]
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -154,7 +154,7 @@ func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
 		},
 	}
 
-	filter := NDMHostKey + "=" + c.HostName
+	filter := NDMHostKey + "=" + c.NodeAttributes[NDMHostKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
@@ -179,7 +179,7 @@ func (c *Controller) GetExistingBlockDeviceResource(blockDeviceList *apis.BlockD
 // list of active resources. Active resource which is present in etcd not in
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
-	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.HostName)...)
+	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.NodeAttributes[NDMHostKey])...)
 	blockDeviceList, err := c.ListBlockDeviceResource()
 	if err != nil {
 		glog.Error(err)
@@ -197,7 +197,6 @@ func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
 // else it creates new blockdevice resource in etcd
 func (c *Controller) PushBlockDeviceResource(oldBlockDevice *apis.BlockDevice,
 	deviceDetails *DeviceInfo) {
-	deviceDetails.HostName = c.HostName
 	deviceAPI := deviceDetails.ToDevice()
 	if oldBlockDevice != nil {
 		c.UpdateBlockDevice(deviceAPI, oldBlockDevice)

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -153,8 +153,7 @@ func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
 			APIVersion: "openebs.io/v1alpha1",
 		},
 	}
-	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
-	filter := kubernetesHostNameKey + "=" + c.NodeAttributes[HostNameKey]
+	filter := KubernetesHostNameLabel + "=" + c.NodeAttributes[HostNameKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
@@ -197,6 +196,7 @@ func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
 // else it creates new blockdevice resource in etcd
 func (c *Controller) PushBlockDeviceResource(oldBlockDevice *apis.BlockDevice,
 	deviceDetails *DeviceInfo) {
+	deviceDetails.NodeAttributes = c.NodeAttributes
 	deviceAPI := deviceDetails.ToDevice()
 	if oldBlockDevice != nil {
 		c.UpdateBlockDevice(deviceAPI, oldBlockDevice)

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -153,8 +153,8 @@ func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
 			APIVersion: "openebs.io/v1alpha1",
 		},
 	}
-
-	filter := NDMHostKey + "=" + c.NodeAttributes[NDMHostKey]
+	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
+	filter := kubernetesHostNameKey + "=" + c.NodeAttributes[HostNameKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
@@ -179,7 +179,7 @@ func (c *Controller) GetExistingBlockDeviceResource(blockDeviceList *apis.BlockD
 // list of active resources. Active resource which is present in etcd not in
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
-	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.NodeAttributes[NDMHostKey])...)
+	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.NodeAttributes[HostNameKey])...)
 	blockDeviceList, err := c.ListBlockDeviceResource()
 	if err != nil {
 		glog.Error(err)

--- a/cmd/ndm_daemonset/controller/blockdevicestore_test.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore_test.go
@@ -22,7 +22,6 @@ import (
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 // mockEmptyDeviceCr returns BlockDevice object with minimum attributes it is used in unit test cases.
@@ -56,16 +55,16 @@ func mockEmptyDeviceCr() apis.BlockDevice {
 
 func TestCreateDevice(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create blockdevice resource devR1
 	devR1 := fakeDevice
-	devR1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	devR1.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	devR1.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(devR1)
 
@@ -74,7 +73,7 @@ func TestCreateDevice(t *testing.T) {
 
 	// Create resource which is already present, it should update
 	devR2 := fakeDevice
-	devR2.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	devR2.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	devR2.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(devR2)
 
@@ -83,7 +82,7 @@ func TestCreateDevice(t *testing.T) {
 
 	// Create blockdevice resource devR3
 	devR3 := newFakeDevice
-	devR3.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	devR3.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	devR3.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(devR3)
 
@@ -110,16 +109,16 @@ func TestCreateDevice(t *testing.T) {
 
 func TestUpdateDevice(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Update a resource which is not present
 	devR := fakeDevice
-	devR.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	devR.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	devR.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	err := fakeController.UpdateBlockDevice(devR, nil)
 	if err == nil {
@@ -179,16 +178,16 @@ func TestUpdateDevice(t *testing.T) {
 
 func TestDeactivateDevice(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create one resource and deactivate it.
 	dr := fakeDevice
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 	fakeController.DeactivateBlockDevice(dr)
@@ -198,13 +197,13 @@ func TestDeactivateDevice(t *testing.T) {
 
 	// Deactivate one resource which is not present it should return error
 	dr1 := newFakeDevice
-	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr1.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr1.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.DeactivateBlockDevice(dr1)
 
 	// Create another resource and deactivate it.
 	newDr := newFakeDevice
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 	fakeController.DeactivateBlockDevice(newDr)
@@ -232,16 +231,16 @@ func TestDeactivateDevice(t *testing.T) {
 
 func TestDeleteDevice(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create one resource and delete it
 	dr := fakeDevice
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 	fakeController.DeleteBlockDevice(fakeDeviceUID)
@@ -254,7 +253,7 @@ func TestDeleteDevice(t *testing.T) {
 
 	// Create another resource and delete it
 	newDr := newFakeDevice
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 	fakeController.DeleteBlockDevice(newFakeDeviceUID)
@@ -282,22 +281,22 @@ func TestDeleteDevice(t *testing.T) {
 
 func TestListDeviceResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create blockdevice resource dr
 	dr := fakeDevice
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 
 	// Create blockdevice resource newDr
 	newDr := newFakeDevice
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 	listDevice, err := fakeController.ListBlockDeviceResource()
@@ -332,22 +331,22 @@ func TestListDeviceResource(t *testing.T) {
 
 func TestGetExistingDeviceResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create blockdevice resource dr
 	dr := fakeDevice
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 
 	// Create blockdevice resource newDr
 	newDr := newFakeDevice
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 
@@ -380,20 +379,21 @@ func TestGetExistingDeviceResource(t *testing.T) {
  */
 func TestPushDeviceResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create one DeviceInfo struct with mock uuid
 	deviceDetails := &DeviceInfo{}
+	deviceDetails.NodeAttributes = make(map[string]string)
 	deviceDetails.UUID = fakeDeviceUID
 
 	// Create one fake BlockDevice struct
 	fakeDr := mockEmptyDeviceCr()
-	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	fakeDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 
@@ -428,22 +428,22 @@ func TestPushDeviceResource(t *testing.T) {
 
 func TestDeactivateStaleDeviceResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create blockdevice resource dr
 	dr := fakeDevice
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 
 	// Create blockdevice resource newDr
 	newDr := newFakeDevice
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 
@@ -478,15 +478,15 @@ func TestDeactivateStaleDeviceResource(t *testing.T) {
 
 func TestMarkDeviceStatusToUnknown(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	dr := mockEmptyDeviceCr()
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(dr)
 

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -52,6 +52,8 @@ const (
 	HostNameKey = "hostname"
 	// NodeNameKey is the node name label prefix
 	NodeNameKey = "nodename"
+	// KubernetesHostNameLabel is the hostname label used by k8s
+	KubernetesHostNameLabel = KubernetesLabelPrefix + HostNameKey
 	// NDMVersion is the CR version.
 	NDMVersion = OpenEBSLabelPrefix + "v1alpha1"
 	// NDMNotPartitioned is used to say blockdevice does not have any partition.

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -44,9 +44,9 @@ const (
 	NDMDiskKind = "Disk"
 	// NDMBlockDeviceKind is the Device kind CR.
 	NDMBlockDeviceKind = "BlockDevice"
-	// Kubernetes label prefix
+	// KubernetesLabelPrefix is the prefix for k8s labels
 	KubernetesLabelPrefix = "kubernetes.io/"
-	// OpenEBS label prefix
+	// OpenEBSLabelPrefix is the label prefix for openebs labels
 	OpenEBSLabelPrefix = "openebs.io/"
 	// HostNameKey is the key for hostname
 	HostNameKey = "hostname"

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -134,6 +134,7 @@ func NewController(kubeconfig string) (*Controller, error) {
 	controller.SetNDMConfig()
 	controller.Filters = make([]*Filter, 0)
 	controller.Probes = make([]*Probe, 0)
+	controller.NodeAttributes = make(map[string]string, 0)
 	controller.Mutex = &sync.Mutex{}
 
 	// get the namespace in which NDM is installed

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -44,12 +44,16 @@ const (
 	NDMDiskKind = "Disk"
 	// NDMBlockDeviceKind is the Device kind CR.
 	NDMBlockDeviceKind = "BlockDevice"
+	// Kubernetes label prefix
+	KubernetesLabelPrefix = "kubernetes.io/"
+	// OpenEBS label prefix
+	OpenEBSLabelPrefix = "openebs.io/"
+	// HostNameKey is the key for hostname
+	HostNameKey = "hostname"
+	// NodeNameKey is the node name label prefix
+	NodeNameKey = "nodename"
 	// NDMVersion is the CR version.
-	NDMVersion = "openebs.io/v1alpha1"
-	// NDMHostKey is host name label prefix.
-	NDMHostKey = "kubernetes.io/hostname"
-	// NDMNodeKey is the node name label prefix
-	NDMNodeKey = "openebs.io/nodename"
+	NDMVersion = OpenEBSLabelPrefix + "v1alpha1"
 	// NDMNotPartitioned is used to say blockdevice does not have any partition.
 	NDMNotPartitioned = "No"
 	// NDMPartitioned is used to say blockdevice has some partitions.
@@ -181,7 +185,7 @@ func (c *Controller) setNodeAttributes() error {
 	if err != nil {
 		return fmt.Errorf("unable to set node attributes: %v", err)
 	}
-	c.NodeAttributes[NDMNodeKey] = nodeName
+	c.NodeAttributes[NodeNameKey] = nodeName
 
 	// set the hostname label
 	if err = c.setHostName(); err != nil {
@@ -193,7 +197,7 @@ func (c *Controller) setNodeAttributes() error {
 // setHostName set NodeAttribute field in Controller struct
 // from the labels in node object
 func (c *Controller) setHostName() error {
-	nodeName := c.NodeAttributes[NDMNodeKey]
+	nodeName := c.NodeAttributes[NodeNameKey]
 	// get the node object and fetch the hostname label from the
 	// node object
 	node := &v1.Node{}
@@ -204,10 +208,10 @@ func (c *Controller) setHostName() error {
 
 	// if the label is not present, or hostname is an empty string,
 	// use nodename as hostname
-	if hostName, ok := node.Labels[NDMHostKey]; !ok || hostName == "" {
-		c.NodeAttributes[NDMHostKey] = nodeName
+	if hostName, ok := node.Labels[HostNameKey]; !ok || hostName == "" {
+		c.NodeAttributes[HostNameKey] = nodeName
 	} else {
-		c.NodeAttributes[NDMHostKey] = hostName
+		c.NodeAttributes[HostNameKey] = hostName
 	}
 	return nil
 }

--- a/cmd/ndm_daemonset/controller/disk.go
+++ b/cmd/ndm_daemonset/controller/disk.go
@@ -102,7 +102,10 @@ type FSInfo struct {
 // be field by different probes each probe will responsible for
 // populate some specific fields of DiskInfo struct.
 func NewDiskInfo() *DiskInfo {
-	diskInfo := &DiskInfo{}
+	nodeAttribute := make(NodeAttribute)
+	diskInfo := &DiskInfo{
+		NodeAttributes: nodeAttribute,
+	}
 	diskInfo.DiskType = NDMDefaultDiskType
 	return diskInfo
 }
@@ -136,8 +139,7 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 		Labels: make(map[string]string),
 		Name:   di.Uuid,
 	}
-	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
-	objectMeta.Labels[kubernetesHostNameKey] = di.NodeAttributes[HostNameKey]
+	objectMeta.Labels[KubernetesHostNameLabel] = di.NodeAttributes[HostNameKey]
 	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta

--- a/cmd/ndm_daemonset/controller/disk.go
+++ b/cmd/ndm_daemonset/controller/disk.go
@@ -30,7 +30,7 @@ import (
 // etcd as a CR of that disk.
 type DiskInfo struct {
 	ProbeIdentifiers      ProbeIdentifier // ProbeIdentifiers contains some keys to uniquely identify each disk by probe
-	HostName              string          // HostName contains the node's hostname in which this disk is attached.
+	NodeAttributes        NodeAttribute   // NodeAttribute contains the node's attributes like hostname and nodename
 	Uuid                  string          // Uuid is the unique id given by ndm
 	Capacity              uint64          // Capacity is capacity of a disk
 	Model                 string          // Model is model no of a disk
@@ -64,6 +64,8 @@ type DiskInfo struct {
 		LowestTemperature    int16 //lifetime measured lowest
 	}
 }
+
+type NodeAttribute map[string]string
 
 // ProbeIdentifier contains some keys to enable probes to uniquely identify each disk.
 // These keys are defined here in order to denote the identifier that a particular probe
@@ -134,7 +136,7 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 		Labels: make(map[string]string),
 		Name:   di.Uuid,
 	}
-	objectMeta.Labels[NDMHostKey] = di.HostName
+	objectMeta.Labels[NDMHostKey] = di.NodeAttributes[NDMHostKey]
 	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta

--- a/cmd/ndm_daemonset/controller/disk.go
+++ b/cmd/ndm_daemonset/controller/disk.go
@@ -65,6 +65,8 @@ type DiskInfo struct {
 	}
 }
 
+// NodeAttribute is a map of string, which stores various attributes like hostname, node name, failure domain
+// etc of a node
 type NodeAttribute map[string]string
 
 // ProbeIdentifier contains some keys to enable probes to uniquely identify each disk.

--- a/cmd/ndm_daemonset/controller/disk.go
+++ b/cmd/ndm_daemonset/controller/disk.go
@@ -136,7 +136,8 @@ func (di *DiskInfo) getObjectMeta() metav1.ObjectMeta {
 		Labels: make(map[string]string),
 		Name:   di.Uuid,
 	}
-	objectMeta.Labels[NDMHostKey] = di.NodeAttributes[NDMHostKey]
+	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
+	objectMeta.Labels[kubernetesHostNameKey] = di.NodeAttributes[HostNameKey]
 	objectMeta.Labels[NDMDiskTypeKey] = di.DiskType
 	objectMeta.Labels[NDMManagedKey] = TrueString
 	return objectMeta

--- a/cmd/ndm_daemonset/controller/disk_test.go
+++ b/cmd/ndm_daemonset/controller/disk_test.go
@@ -140,14 +140,14 @@ func TestGetObjectMeta(t *testing.T) {
 	// add mock fields in diskInfo struct
 	fakeDiskInfo := NewDiskInfo()
 	fakeDiskInfo.Uuid = diskUid
-	fakeDiskInfo.HostName = hostName
+	fakeDiskInfo.NodeAttributes[HostNameKey] = hostName
 
 	//create fakeObjectMeta using mock data
 	fakeObjectMeta := metav1.ObjectMeta{
 		Labels: make(map[string]string),
 		Name:   diskUid,
 	}
-	fakeObjectMeta.Labels[NDMHostKey] = hostName
+	fakeObjectMeta.Labels[KubernetesHostNameLabel] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeObjectMeta.Labels[NDMManagedKey] = TrueString
 
@@ -239,11 +239,12 @@ and get Disk value from ToDisk() and compare them
 func TestToDisk(t *testing.T) {
 	diskUid := "disk-uuid"
 	hostName := "host-name"
+
 	fakeDevLinks := make([]apis.DiskDevLink, 0)
 	// add mock fields in diskInfo struct
 	fakeDiskInfo := NewDiskInfo()
 	fakeDiskInfo.Uuid = diskUid
-	fakeDiskInfo.HostName = hostName
+	fakeDiskInfo.NodeAttributes[HostNameKey] = hostName
 
 	// Creating one Disk struct using mock value
 	expectedDisk := apis.Disk{}
@@ -256,7 +257,7 @@ func TestToDisk(t *testing.T) {
 		Labels: make(map[string]string),
 		Name:   diskUid,
 	}
-	fakeObjectMeta.Labels[NDMHostKey] = hostName
+	fakeObjectMeta.Labels[KubernetesHostNameLabel] = hostName
 	fakeObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeObjectMeta.Labels[NDMManagedKey] = TrueString
 	expectedDisk.ObjectMeta = fakeObjectMeta

--- a/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
+++ b/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
@@ -25,7 +25,7 @@ func (c *Controller) NewDeviceInfoFromDiskInfo(diskDetails *DiskInfo) *DeviceInf
 
 	deviceDetails := NewDeviceInfo()
 
-	deviceDetails.HostName = c.HostName
+	deviceDetails.NodeAttributes = diskDetails.NodeAttributes
 	deviceDetails.UUID = c.DiskToDeviceUUID(diskDetails.ProbeIdentifiers.Uuid)
 	deviceDetails.Capacity = diskDetails.Capacity
 	deviceDetails.Model = diskDetails.Model

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -138,8 +138,7 @@ func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 		},
 	}
 
-	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
-	filter := kubernetesHostNameKey + "=" + c.NodeAttributes[HostNameKey]
+	filter := KubernetesHostNameLabel + "=" + c.NodeAttributes[HostNameKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
@@ -180,6 +179,7 @@ func (c *Controller) DeactivateStaleDiskResource(disks []string) {
 // else it creates one new disk resource in etcd
 func (c *Controller) PushDiskResource(oldDr *apis.Disk, diskDetails *DiskInfo) {
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
+	diskDetails.NodeAttributes = c.NodeAttributes
 	diskApi := diskDetails.ToDisk()
 	if oldDr != nil {
 		c.UpdateDisk(diskApi, oldDr)

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -138,7 +138,8 @@ func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 		},
 	}
 
-	filter := NDMHostKey + "=" + c.NodeAttributes[NDMHostKey]
+	kubernetesHostNameKey := KubernetesLabelPrefix + HostNameKey
+	filter := kubernetesHostNameKey + "=" + c.NodeAttributes[HostNameKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -138,7 +138,7 @@ func (c *Controller) ListDiskResource() (*apis.DiskList, error) {
 		},
 	}
 
-	filter := NDMHostKey + "=" + c.HostName
+	filter := NDMHostKey + "=" + c.NodeAttributes[NDMHostKey]
 	filter = filter + "," + NDMManagedKey + "!=" + FalseString
 	opts := &client.ListOptions{}
 	opts.SetLabelSelector(filter)
@@ -178,7 +178,6 @@ func (c *Controller) DeactivateStaleDiskResource(disks []string) {
 // present or not. If it presents in etcd then it updates the resource
 // else it creates one new disk resource in etcd
 func (c *Controller) PushDiskResource(oldDr *apis.Disk, diskDetails *DiskInfo) {
-	diskDetails.HostName = c.HostName
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
 	diskApi := diskDetails.ToDisk()
 	if oldDr != nil {

--- a/cmd/ndm_daemonset/controller/diskstore_test.go
+++ b/cmd/ndm_daemonset/controller/diskstore_test.go
@@ -22,7 +22,6 @@ import (
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 // mockEmptyDiskCr returns Disk object with minimum attributes it is used in unit test cases.
@@ -45,16 +44,17 @@ func mockEmptyDiskCr() apis.Disk {
 
 func TestCreateDisk(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create disk resource dr1
 	dr1 := fakeDr
-	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr1.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr1.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr1)
@@ -64,7 +64,7 @@ func TestCreateDisk(t *testing.T) {
 
 	// Create resource which is already present, it should update
 	dr2 := fakeDr
-	dr2.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr2.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr2.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr2.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr2)
@@ -74,7 +74,7 @@ func TestCreateDisk(t *testing.T) {
 
 	// Create disk resource dr3
 	dr3 := newFakeDr
-	dr3.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr3.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr3.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr3.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr3)
@@ -102,16 +102,17 @@ func TestCreateDisk(t *testing.T) {
 
 func TestUpdateDisk(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Update a resource which is not present
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	err := fakeController.UpdateDisk(dr, nil)
@@ -172,16 +173,16 @@ func TestUpdateDisk(t *testing.T) {
 
 func TestDeactivateDisk(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create one resource and deactivate it.
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
@@ -192,14 +193,14 @@ func TestDeactivateDisk(t *testing.T) {
 
 	// Deactivate one resource which is not present it should return error
 	dr1 := newFakeDr
-	dr1.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr1.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr1.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr1.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.DeactivateDisk(dr1)
 
 	// Create another resource and deactivate it.
 	newDr := newFakeDr
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
@@ -228,16 +229,17 @@ func TestDeactivateDisk(t *testing.T) {
 
 func TestDeleteDisk(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create one resource and delete it
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
@@ -251,7 +253,7 @@ func TestDeleteDisk(t *testing.T) {
 
 	// Create another resource and delete it
 	newDr := newFakeDr
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
@@ -280,16 +282,17 @@ func TestDeleteDisk(t *testing.T) {
 
 func TestListDiskResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create disk resource dr
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
@@ -300,7 +303,7 @@ func TestListDiskResource(t *testing.T) {
 
 	// Create disk resource newDr
 	newDr := newFakeDr
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
@@ -336,23 +339,24 @@ func TestListDiskResource(t *testing.T) {
 
 func TestGetExistingDiskResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create disk resource dr
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 
 	// Create disk resource newDr
 	newDr := newFakeDr
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
@@ -386,11 +390,12 @@ func TestGetExistingDiskResource(t *testing.T) {
  */
 func TestPushDiskResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// create one DiskInfo struct with mock uuid
@@ -400,7 +405,7 @@ func TestPushDiskResource(t *testing.T) {
 
 	// Create one fake Disk struct
 	fakeDr := mockEmptyDiskCr()
-	fakeDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	fakeDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	fakeDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	fakeDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 
@@ -435,23 +440,24 @@ func TestPushDiskResource(t *testing.T) {
 
 func TestDeactivateStaleDiskResource(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	// Create disk resource dr
 	dr := fakeDr
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)
 
 	// Create disk resource newDr
 	newDr := newFakeDr
-	newDr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	newDr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(newDr)
@@ -487,14 +493,15 @@ func TestDeactivateStaleDiskResource(t *testing.T) {
 
 func TestMarkDiskStatusToUnknown(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
+
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 	dr := mockEmptyDiskCr()
-	dr.ObjectMeta.Labels[NDMHostKey] = fakeController.HostName
+	dr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	dr.ObjectMeta.Labels[NDMDiskTypeKey] = NDMDefaultDiskType
 	dr.ObjectMeta.Labels[NDMManagedKey] = TrueString
 	fakeController.CreateDisk(dr)

--- a/cmd/ndm_daemonset/controller/probe.go
+++ b/cmd/ndm_daemonset/controller/probe.go
@@ -98,7 +98,8 @@ func (c *Controller) ListProbe() []*Probe {
 
 // FillDiskDetails lists registered probes and fills details from each probe
 func (c *Controller) FillDiskDetails(diskDetails *DiskInfo) {
-	diskDetails.HostName = c.HostName
+	diskDetails.NodeAttributes[NDMHostKey] = c.NodeAttributes[NDMHostKey]
+	diskDetails.NodeAttributes[NDMNodeKey] = c.NodeAttributes[NDMNodeKey]
 	diskDetails.DiskType = NDMDefaultDiskType
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
 	probes := c.ListProbe()

--- a/cmd/ndm_daemonset/controller/probe.go
+++ b/cmd/ndm_daemonset/controller/probe.go
@@ -98,8 +98,7 @@ func (c *Controller) ListProbe() []*Probe {
 
 // FillDiskDetails lists registered probes and fills details from each probe
 func (c *Controller) FillDiskDetails(diskDetails *DiskInfo) {
-	diskDetails.NodeAttributes[NDMHostKey] = c.NodeAttributes[NDMHostKey]
-	diskDetails.NodeAttributes[NDMNodeKey] = c.NodeAttributes[NDMNodeKey]
+	diskDetails.NodeAttributes = c.NodeAttributes
 	diskDetails.DiskType = NDMDefaultDiskType
 	diskDetails.Uuid = diskDetails.ProbeIdentifiers.Uuid
 	probes := c.ListProbe()

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -204,8 +204,9 @@ func GetActiveSparseBlockDevicesUUID(hostname string) []string {
 func (c *Controller) MarkSparseBlockDeviceStateActive(sparseFile string, sparseFileSize int64) {
 	// Fill in the details of the sparse disk
 	BlockDeviceDetails := NewDeviceInfo()
-	BlockDeviceDetails.UUID = GetSparseBlockDeviceUUID(c.HostName, sparseFile)
-	BlockDeviceDetails.HostName = c.HostName
+	BlockDeviceDetails.UUID = GetSparseBlockDeviceUUID(c.NodeAttributes[NDMHostKey], sparseFile)
+	BlockDeviceDetails.NodeAttributes[NDMHostKey] = c.NodeAttributes[NDMHostKey]
+	BlockDeviceDetails.NodeAttributes[NDMNodeKey] = c.NodeAttributes[NDMNodeKey]
 
 	BlockDeviceDetails.DeviceType = SparseBlockDeviceType
 	BlockDeviceDetails.Path = sparseFile

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator.go
@@ -204,9 +204,8 @@ func GetActiveSparseBlockDevicesUUID(hostname string) []string {
 func (c *Controller) MarkSparseBlockDeviceStateActive(sparseFile string, sparseFileSize int64) {
 	// Fill in the details of the sparse disk
 	BlockDeviceDetails := NewDeviceInfo()
-	BlockDeviceDetails.UUID = GetSparseBlockDeviceUUID(c.NodeAttributes[NDMHostKey], sparseFile)
-	BlockDeviceDetails.NodeAttributes[NDMHostKey] = c.NodeAttributes[NDMHostKey]
-	BlockDeviceDetails.NodeAttributes[NDMNodeKey] = c.NodeAttributes[NDMNodeKey]
+	BlockDeviceDetails.UUID = GetSparseBlockDeviceUUID(c.NodeAttributes[HostNameKey], sparseFile)
+	BlockDeviceDetails.NodeAttributes = c.NodeAttributes
 
 	BlockDeviceDetails.DeviceType = SparseBlockDeviceType
 	BlockDeviceDetails.Path = sparseFile

--- a/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
+++ b/cmd/ndm_daemonset/controller/sparsefilegenerator_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 // TestGetSparseFileDir verifies that a valid sparse file directory
@@ -173,11 +172,11 @@ func TestGetActiveSparseBlockDevicesUUID(t *testing.T) {
 
 func TestInitializeSparseFile(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 
 	sparseFileDir := "/tmp"
@@ -210,11 +209,11 @@ func TestInitializeSparseFile(t *testing.T) {
 
 func TestMarkSparseBlockDeviceStateActive(t *testing.T) {
 	fakeNdmClient := CreateFakeClient(t)
-	fakeKubeClient := fake.NewSimpleClientset()
+	nodeAttributes := make(map[string]string, 0)
+	nodeAttributes[HostNameKey] = fakeHostName
 	fakeController := &Controller{
-		HostName:      fakeHostName,
-		KubeClientset: fakeKubeClient,
-		Clientset:     fakeNdmClient,
+		NodeAttributes: nodeAttributes,
+		Clientset:      fakeNdmClient,
 	}
 	sparseFile := "/tmp/0-ndm-sparse.img"
 	sparseUUID := "sparse-11063db4a4bfd3d0443d0b9d98391707"

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -106,9 +106,9 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 		glog.Infof("Path:%s filled by seachest.", d.Path)
 	}
 
-	if d.HostName == "" {
-		d.HostName = seachestProbe.SeachestIdentifier.GetHostName(driveInfo)
-		glog.Infof("Disk: %s HostName:%s filled by seachest.", d.Path, d.HostName)
+	if d.NodeAttributes[controller.NDMHostKey] == "" {
+		d.NodeAttributes[controller.NDMHostKey] = seachestProbe.SeachestIdentifier.GetHostName(driveInfo)
+		glog.Infof("Disk: %s NodeAttribute:%s filled by seachest.", d.Path, d.NodeAttributes[controller.NDMHostKey])
 	}
 
 	if d.Model == "" {

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -106,9 +106,9 @@ func (scp *seachestProbe) FillDiskDetails(d *controller.DiskInfo) {
 		glog.Infof("Path:%s filled by seachest.", d.Path)
 	}
 
-	if d.NodeAttributes[controller.NDMHostKey] == "" {
-		d.NodeAttributes[controller.NDMHostKey] = seachestProbe.SeachestIdentifier.GetHostName(driveInfo)
-		glog.Infof("Disk: %s NodeAttribute:%s filled by seachest.", d.Path, d.NodeAttributes[controller.NDMHostKey])
+	if d.NodeAttributes[controller.HostNameKey] == "" {
+		d.NodeAttributes[controller.HostNameKey] = seachestProbe.SeachestIdentifier.GetHostName(driveInfo)
+		glog.Infof("Disk: %s NodeAttribute:%s filled by seachest.", d.Path, d.NodeAttributes[controller.HostNameKey])
 	}
 
 	if d.Model == "" {

--- a/deploy/crds/openebs_v1alpha1_blockdevice_cr.yaml
+++ b/deploy/crds/openebs_v1alpha1_blockdevice_cr.yaml
@@ -26,6 +26,8 @@ spec:
     - <link2> # like /dev/disk/by-id/google-disk-2
   - kind: by-path
     links:
-    - <link1> # like /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:2:0 
-  Partitioned: # Yes or No
+    - <link1> # like /dev/disk/by-path/virtio-pci-0000:00:03.0-scsi-0:0:2:0
+  nodeAttributes:
+    nodeName: <node name> # output of `kubectl get nodes` can be used
+  partitioned: # Yes or No
   path: <devpath> # like /dev/sdb

--- a/pkg/apis/openebs/v1alpha1/blockdevice_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdevice_types.go
@@ -29,6 +29,8 @@ import (
 
 // DeviceSpec defines the desired state of BlockDevice
 type DeviceSpec struct {
+	// NodeAttributes has the details of the node in which this BD is attached
+	NodeAttributes  NodeAttribute       `json:"nodeAttributes"`
 	Path            string              `json:"path"`                      //Path contain devpath (e.g. /dev/sdb)
 	Capacity        DeviceCapacity      `json:"capacity"`                  //Capacity
 	Details         DeviceDetails       `json:"details"`                   //Details contains static attributes (model, serial ..)
@@ -38,6 +40,12 @@ type DeviceSpec struct {
 	Partitioned     string              `json:"partitioned"`               //BlockDevice has partions or not (YES/NO)
 	ParentDevice    string              `json:"parentDevice,omitempty"`    //ParentDevice has the UUID of the parent device
 	AggregateDevice string              `json:"aggregateDevice,omitempty"` //AggregateDevice has the UUID of the aggregate device created from this device
+}
+
+// NodeAttribute defines the various attributes of the node
+type NodeAttribute struct {
+	// NodeName is the name of the node in which the device is attached
+	NodeName string `json:"nodeName"`
 }
 
 // DeviceCapacity defines the physical and logical size of the block device

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -58,7 +58,7 @@ type jobController struct {
 // NewCleanupJob creates a new cleanup job in the  namespace. It returns a Job object which can be used to
 // start the job
 func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace string) (*batchv1.Job, error) {
-	nodeName := bd.Labels[controller.NDMHostKey]
+	nodeName := bd.Labels[controller.KubernetesHostNameLabel]
 
 	priv := true
 	jobContainer := v1.Container{
@@ -97,14 +97,14 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 
 	podSpec.ServiceAccountName = getServiceAccount()
 	podSpec.Containers = []v1.Container{jobContainer}
-	podSpec.NodeSelector = map[string]string{controller.NDMHostKey: nodeName}
+	podSpec.NodeSelector = map[string]string{controller.KubernetesHostNameLabel: nodeName}
 
 	podTemplate := v1.Pod{}
 	podTemplate.Spec = podSpec
 
 	labels := map[string]string{
-		controller.NDMHostKey: nodeName,
-		BDLabel:               bd.Name,
+		controller.KubernetesLabelPrefix: nodeName,
+		BDLabel:                          bd.Name,
 	}
 
 	podTemplate.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/controller/blockdevice/blockdevice_controller_test.go
+++ b/pkg/controller/blockdevice/blockdevice_controller_test.go
@@ -191,7 +191,7 @@ func GetFakeDiskObject() *openebsv1alpha1.Disk {
 			State: ndm.NDMActive,
 		},
 	}
-	disk.ObjectMeta.Labels[ndm.NDMHostKey] = fakeHostName
+	disk.ObjectMeta.Labels[ndm.KubernetesHostNameLabel] = fakeHostName
 	return disk
 }
 

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -342,7 +342,7 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(hostName string, ManualSele
 	// blockdevices are listed.
 	// TODO for manual selection, instead of listing all BDs, only get the BD with given name
 	if !ManualSelection {
-		filter := ndm.NDMHostKey + "=" + hostName
+		filter := ndm.KubernetesHostNameLabel + "=" + hostName
 		opts.SetLabelSelector(filter)
 	}
 

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
@@ -352,7 +352,7 @@ func GetFakeDiskObject() *openebsv1alpha1.Disk {
 			State: ndm.NDMActive,
 		},
 	}
-	disk.ObjectMeta.Labels[ndm.NDMHostKey] = fakeHostName
+	disk.ObjectMeta.Labels[ndm.KubernetesHostNameLabel] = fakeHostName
 	return disk
 }
 

--- a/pkg/controller/disk/disk_controller_test.go
+++ b/pkg/controller/disk/disk_controller_test.go
@@ -140,6 +140,6 @@ func GetFakeDiskObject() *openebsv1alpha1.Disk {
 			State: ndm.NDMActive,
 		},
 	}
-	disk.ObjectMeta.Labels[ndm.NDMHostKey] = fakeHostName
+	disk.ObjectMeta.Labels[ndm.KubernetesHostNameLabel] = fakeHostName
 	return disk
 }


### PR DESCRIPTION
Currently only hostname was included as part of the device information. This has been refactored to include nodename and hostname along with provision for multiple other fields which can be used for geolocating a node and its associated disks and BDs.

**Note for Reviewer**: Most of the test cases in daemonset controller and probes has been refactored in this PR with labelling changes.