### PR TITLE
feat(apis, selector): add node name filter

### DIFF
--- a/deploy/crds/openebs_v1alpha1_blockdeviceclaim_cr.yaml
+++ b/deploy/crds/openebs_v1alpha1_blockdeviceclaim_cr.yaml
@@ -4,6 +4,8 @@ metadata:
   name: example-blockdeviceclaim
 spec:
   hostName: "" # hostname of the node from which you want to get a BD
+  nodeAttributes:
+    nodeName: "" # node name of the k8s node. Output from `kubectl get nodes`
   blockDeviceName: "" # BD name, if you want to claim a specific block device
   resources:
     requests:

--- a/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
@@ -34,6 +34,9 @@ type DeviceClaimSpec struct {
 	HostName        string               `json:"hostName"`                     // Node name from where blockdevice has to be claimed.
 	Details         DeviceClaimDetails   `json:"deviceClaimDetails,omitempty"` // Details of the device to be claimed
 	BlockDeviceName string               `json:"blockDeviceName,omitempty"`    // BlockDeviceName is the reference to the block-device backing this claim
+	// NodeAttributes is the attributes on the node from which a BD should
+	// be selected for this claim. It can include nodename, failure domain etc.
+	NodeAttributes NodeAttribute `json:"nodeAttributes,omitempty"`
 }
 
 // DeviceClaimStatus defines the observed state of BlockDeviceClaim

--- a/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
@@ -34,9 +34,9 @@ type DeviceClaimSpec struct {
 	HostName        string               `json:"hostName"`                     // Node name from where blockdevice has to be claimed.
 	Details         DeviceClaimDetails   `json:"deviceClaimDetails,omitempty"` // Details of the device to be claimed
 	BlockDeviceName string               `json:"blockDeviceName,omitempty"`    // BlockDeviceName is the reference to the block-device backing this claim
-	// NodeAttributes is the attributes on the node from which a BD should
+	// BlockDeviceNodeAttributes is the attributes on the node from which a BD should
 	// be selected for this claim. It can include nodename, failure domain etc.
-	NodeAttributes NodeAttribute `json:"nodeAttributes,omitempty"`
+	BlockDeviceNodeAttributes BlockDeviceNodeAttributes `json:"blockDeviceNodeAttributes,omitempty"`
 }
 
 // DeviceClaimStatus defines the observed state of BlockDeviceClaim
@@ -98,6 +98,13 @@ const (
 	// VolumeModeFileSystem specifies that block device will be used with a filesystem already existing
 	VolumeModeFileSystem BlockDeviceVolumeMode = "FileSystem"
 )
+
+// BlockDeviceNodeAttributes contains the attributes of the node from which the BD should
+// be selected for claiming
+type BlockDeviceNodeAttributes struct {
+	NodeName string `json:"nodeName,omitempty"`
+	HostName string `json:"hostName,omitempty"`
+}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -19,6 +19,7 @@ package blockdeviceclaim
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	ndm "github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/select/blockdevice"
@@ -163,7 +164,12 @@ func (r *ReconcileBlockDeviceClaim) claimDeviceForBlockDeviceClaim(
 	}
 
 	//select block device from list of devices.
-	bdList, err := r.getListofDevices(instance.Spec.HostName, config.ManualSelection)
+	labelFilter := make([]string, 0)
+	if len(instance.Spec.HostName) != 0 {
+		labelFilter = append(labelFilter, ndm.NDMHostKey+"="+instance.Spec.HostName)
+	}
+
+	bdList, err := r.getListofDevices(labelFilter...)
 	if err != nil {
 		return err
 	}
@@ -262,13 +268,8 @@ func (r *ReconcileBlockDeviceClaim) releaseClaimedBlockDevice(
 
 	reqLogger.Info("Deleting external dependencies for CR:" + instance.Name)
 
-	manualSelection := false
-	if instance.Spec.BlockDeviceName != "" {
-		manualSelection = true
-	}
-
-	//Get BlockDevice list for particular host
-	listDVR, err := r.getListofDevices(instance.Spec.HostName, manualSelection)
+	//Get BlockDevice list for
+	listDVR, err := r.getListofDevices()
 	if err != nil {
 		return err
 	}
@@ -326,7 +327,7 @@ func (r *ReconcileBlockDeviceClaim) GetBlockDevice(name string) (*apis.BlockDevi
 // TODO:
 //  ListBlockDeviceResource in package cmd/ndm_daemonset/controller has the same functionality.
 //  Need to merge these 2 functions.
-func (r *ReconcileBlockDeviceClaim) getListofDevices(hostName string, ManualSelection bool) (*apis.BlockDeviceList, error) {
+func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.BlockDeviceList, error) {
 
 	//Initialize a deviceList object.
 	listBlockDevice := &apis.BlockDeviceList{
@@ -337,13 +338,10 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(hostName string, ManualSele
 	}
 
 	opts := &client.ListOptions{}
-	// Set filter option, in our case we are filtering based on hostname/node
-	// Filter is only applied when its auto selection. In Manual selection, all
-	// blockdevices are listed.
-	// TODO for manual selection, instead of listing all BDs, only get the BD with given name
-	if !ManualSelection {
-		filter := ndm.KubernetesHostNameLabel + "=" + hostName
-		opts.SetLabelSelector(filter)
+
+	// if filter strings are present, apply them before querying etcd
+	if len(filters) != 0 {
+		opts.SetLabelSelector(strings.Join(filters, ","))
 	}
 
 	//Fetch deviceList with matching criteria

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -268,7 +268,7 @@ func (r *ReconcileBlockDeviceClaim) releaseClaimedBlockDevice(
 
 	reqLogger.Info("Deleting external dependencies for CR:" + instance.Name)
 
-	//Get BlockDevice list for
+	//Get BlockDevice list on all nodes
 	listDVR, err := r.getListofDevices()
 	if err != nil {
 		return err

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -165,8 +165,18 @@ func (r *ReconcileBlockDeviceClaim) claimDeviceForBlockDeviceClaim(
 
 	//select block device from list of devices.
 	labelFilter := make([]string, 0)
+	var hostName string
 	if len(instance.Spec.HostName) != 0 {
-		labelFilter = append(labelFilter, ndm.NDMHostKey+"="+instance.Spec.HostName)
+		hostName = instance.Spec.HostName
+	}
+	// the hostname in NodeAttribute will override the hostname in spec, since spec.hostName
+	// will be deprecated shortly
+	if len(instance.Spec.BlockDeviceNodeAttributes.HostName) != 0 {
+		hostName = instance.Spec.BlockDeviceNodeAttributes.HostName
+	}
+	// only if any hostname is provided create the filter
+	if len(hostName) != 0 {
+		labelFilter = append(labelFilter, ndm.KubernetesHostNameLabel+"="+hostName)
 	}
 
 	bdList, err := r.getListofDevices(labelFilter...)

--- a/pkg/select/blockdevice/filters.go
+++ b/pkg/select/blockdevice/filters.go
@@ -39,6 +39,8 @@ const (
 	FilterResourceStorage = "filterResourceStorage"
 	// FilterOutSparseBlockDevices is used to filter out sparse BDs
 	FilterOutSparseBlockDevices = "filterSparseBlockDevice"
+	// FilterNodeName is used to filter based on nodename
+	FilterNodeName = "filterNodeName"
 )
 
 // filterFunc is the func type for the filter functions
@@ -52,6 +54,7 @@ var filterFuncMap = map[string]filterFunc{
 	FilterBlockDeviceName:       filterBlockDeviceName,
 	FilterResourceStorage:       filterResourceStorage,
 	FilterOutSparseBlockDevices: filterOutSparseBlockDevice,
+	FilterNodeName:              filterNodeName,
 }
 
 // ApplyFilters apply the filter specified in the filterkeys on the given BD List,
@@ -214,6 +217,28 @@ func filterOutSparseBlockDevice(originalBD *apis.BlockDeviceList, spec *apis.Dev
 
 	for _, bd := range originalBD.Items {
 		if bd.Spec.Details.DeviceType != controller.SparseBlockDeviceType {
+			filteredBDList.Items = append(filteredBDList.Items, bd)
+		}
+	}
+	return filteredBDList
+}
+
+func filterNodeName(originalBD *apis.BlockDeviceList, spec *apis.DeviceClaimSpec) *apis.BlockDeviceList {
+
+	// if node name is not given in BDC, this filter will not work
+	if len(spec.NodeAttributes.NodeName) == 0 {
+		return originalBD
+	}
+
+	filteredBDList := &apis.BlockDeviceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "BlockDevice",
+			APIVersion: "openebs.io/v1alpha1",
+		},
+	}
+
+	for _, bd := range originalBD.Items {
+		if bd.Spec.NodeAttributes.NodeName == spec.NodeAttributes.NodeName {
 			filteredBDList.Items = append(filteredBDList.Items, bd)
 		}
 	}

--- a/pkg/select/blockdevice/filters.go
+++ b/pkg/select/blockdevice/filters.go
@@ -226,7 +226,7 @@ func filterOutSparseBlockDevice(originalBD *apis.BlockDeviceList, spec *apis.Dev
 func filterNodeName(originalBD *apis.BlockDeviceList, spec *apis.DeviceClaimSpec) *apis.BlockDeviceList {
 
 	// if node name is not given in BDC, this filter will not work
-	if len(spec.NodeAttributes.NodeName) == 0 {
+	if len(spec.BlockDeviceNodeAttributes.NodeName) == 0 {
 		return originalBD
 	}
 
@@ -238,7 +238,7 @@ func filterNodeName(originalBD *apis.BlockDeviceList, spec *apis.DeviceClaimSpec
 	}
 
 	for _, bd := range originalBD.Items {
-		if bd.Spec.NodeAttributes.NodeName == spec.NodeAttributes.NodeName {
+		if bd.Spec.NodeAttributes.NodeName == spec.BlockDeviceNodeAttributes.NodeName {
 			filteredBDList.Items = append(filteredBDList.Items, bd)
 		}
 	}

--- a/pkg/select/blockdevice/select.go
+++ b/pkg/select/blockdevice/select.go
@@ -54,6 +54,7 @@ func (c *Config) getCandidateDevices(bdList *apis.BlockDeviceList) (*apis.BlockD
 			FilterOutSparseBlockDevices,
 			FilterDeviceType,
 			FilterVolumeMode,
+			FilterNodeName,
 		)
 	}
 


### PR DESCRIPTION
Added node name filter to BDC.
Use case:
1. If hostname is only given, matching BDs on the host will be used for selection
2. If nodename is only given, matching BDs on the node will be used for selection
3. If both hostname and nodename are provided, BDs with matching hostname and nodename will be used for selection
4. If no node selection value is provided, all BDs will be used for selection