### PR TITLE
fix(installer): add node name to printer column of CRD

### DIFF
--- a/pkg/setup/build_crd.go
+++ b/pkg/setup/build_crd.go
@@ -50,6 +50,7 @@ func buildBlockDeviceCRD() (*apiext.CustomResourceDefinition, error) {
 		WithListKind(apis.BlockDeviceResourceListKind).
 		WithPlural(apis.BlockDeviceResourcePlural).
 		WithShortNames([]string{apis.BlockDeviceResourceShort}).
+		WithPrinterColumns("NodeName", "string", ".spec.nodeAttributes.nodeName").
 		WithPrinterColumns("Size", "string", ".spec.capacity.storage").
 		WithPrinterColumns("ClaimState", "string", ".status.claimState").
 		WithPrinterColumns("Status", "string", ".status.state").


### PR DESCRIPTION
add node name to printer column of BlockDevice CRD. This will result in `kubectl get bd` also list the name of the node to which the BD is attached
```
user@host:/$ kubectl get bd
NAME                                           NODENAME                                   SIZE           CLAIMSTATE   STATUS   AGE
blockdevice-4833f3d01155d26a61cb0a92e6b122fc   gke-akhil-ndm-default-pool-b62186cd-85fn   402653184000   Unclaimed    Active   30m
sparse-b60e173560072794680c46d75b33490b        gke-akhil-ndm-default-pool-b62186cd-85fn   1073741824     Unclaimed    Active   30m
```

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>