### PR TITLE
fix(filter): fix os-filter to ignore empty exclude paths

### DIFF
--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -114,7 +114,7 @@ func (odf *oSDiskExcludeFilter) Include(d *controller.DiskInfo) bool {
 	return true
 }
 
-// Exclude returns true if disk devpath matches with excludeDevPath
+// Exclude returns true if disk devpath does not match with excludeDevPath
 func (odf *oSDiskExcludeFilter) Exclude(d *controller.DiskInfo) bool {
 	// The partitionRegex is chosen depending on whether the device uses
 	// the p[0-9] partition naming structure or not.

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -126,6 +126,7 @@ func (odf *oSDiskExcludeFilter) Exclude(d *controller.DiskInfo) bool {
 		// matches sda, sda1
 		partitionRegex = "[0-9]*$"
 	}
-	glog.Infof("applying os-fiter regex %s on %s", odf.excludeDevPath+partitionRegex, d.Path)
-	return !util.IsMatchRegex(odf.excludeDevPath+partitionRegex, d.Path)
+	regex := "^" + odf.excludeDevPath + partitionRegex
+	glog.Infof("applying os-fiter regex %s on %s", regex, d.Path)
+	return !util.IsMatchRegex(regex, d.Path)
 }

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter_test.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter_test.go
@@ -118,6 +118,11 @@ func TestOsDiskExcludeFilterExclude(t *testing.T) {
 			disk:     &controller.DiskInfo{Path: "/dev/vg0-lv0"},
 			expected: false,
 		},
+		"exclude path is empty and device path is /dev/sda": {
+			filter:   oSDiskExcludeFilter{excludeDevPath: ""},
+			disk:     &controller.DiskInfo{Path: "/dev/sda"},
+			expected: true,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
If `os-disk-filter` failed to find the device in which os is installed, the os-filter should not match with any devices. But currently if the filter failed to initialize, all devices on that node were getting excluded. A change has been introduced in the regex to fix this bug. 

Related Issues: [#2727](https://github.com/openebs/openebs/issues/2727)