### PR TITLE
[WIP] Adding builds for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: xenial
 language: go
 
+os:
+  - linux
+  - linux-ppc64le
+
 go:
   - 1.12.7
 
@@ -44,13 +48,13 @@ install:
   - popd 
 
 before_script:
-  - sudo minikube start --vm-driver=none --cpus=1 --memory=1024
-  - sudo minikube update-context
+  - if [ "$ARCH" = "amd64" ]; then sudo minikube start --vm-driver=none --cpus=1 --memory=1024; fi
+  - if [ "$ARCH" = "amd64" ]; then sudo minikube update-context; fi
   # By default root is the owner of the .minikube directory. This is changed to $USER so that
   # from the integration tests which run as a non-root user can access the files and connect
   # to the minikube cluster
-  - sudo chown -R $USER $HOME/.minikube
-  - sudo chown -R $USER $HOME/.kube
+  - if [ "$ARCH" = "amd64" ]; then sudo chown -R $USER $HOME/.minikube; fi
+  - if [ "$ARCH" = "amd64" ]; then sudo chown -R $USER $HOME/.kube; fi
 
 script:
   - make

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,14 @@ golint:
 
 # shellcheck target for checking shell scripts linting
 shellcheck: getshellcheck
+ifeq ($(XC_ARCH), amd64)
 	find . -type f -name "*.sh" | grep -v "./vendor/*" | xargs /tmp/shellcheck-latest/shellcheck
+endif
 
 getshellcheck:
+ifeq ($(XC_ARCH), amd64)
 	wget -c 'https://goo.gl/ZzKHFv' -O - | tar -xvJ -C /tmp/
+endif
 
 version:
 	@echo $(VERSION)

--- a/build/build.sh
+++ b/build/build.sh
@@ -92,7 +92,7 @@ VERSION="beta"
 
 
 # Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"amd64"}
+XC_ARCH=${XC_ARCH:-"$(go env GOARCH)"}
 XC_OS=${XC_OS:-"linux"}
 
 XC_ARCHS=("${XC_ARCH// / }")


### PR DESCRIPTION
Hi,

This is first in a series of PR to enable OpenEBS for ppc64le arch. I have marked it as WIP as some changes require discussion.

1) I have disabled `shellcheck` for ppc64le. It can be added back once it is supported for ppc64le.
2) Added `linux-ppc64le` in .travis.yml to enable builds for ppc64le arch on travis.
3) minikube doesn't provide binaries for any arch other than amd64. Hence, I have disabled some of the steps for ppc64le that could have broken the build before running the actual script i.e. the make command. Is it possible to use `kubeadm` instead of `minikube` as the former one already has multi-arch support?
4) If it is decided to not use `kubeadm`, would it be possible to run tests without `minikube`?
5) build script now builds for native archs, as cross building would require cgo cross dependencies for to be installed on the host.

Please let me know if I need to open an issue to discuss above points? Thanks.

cc: @kmova @harshvkarn  