### PR TITLE
feat(reconcile, controller): disable reconciliation on custom resources

### DIFF
--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -57,6 +57,10 @@ const (
 	KubernetesHostNameLabel = kubernetesLabelPrefix + HostNameKey
 	// NDMVersion is the CR version.
 	NDMVersion = openEBSLabelPrefix + "v1alpha1"
+	// reconcileKey is the key used for enable/disable of reconcilation
+	reconcileKey = "reconcile"
+	// OpenEBSReconcile is used in annotation to check whether CR is to be reconciled or not
+	OpenEBSReconcile = openEBSLabelPrefix + reconcileKey
 	// NDMNotPartitioned is used to say blockdevice does not have any partition.
 	NDMNotPartitioned = "No"
 	// NDMPartitioned is used to say blockdevice has some partitions.

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -108,7 +108,7 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	// check if the resource needs to be reconciled
+	// check if the this block device need to reconciled
 	if IsReconcileDisabled(instance) {
 		return reconcile.Result{}, nil
 	}
@@ -208,7 +208,7 @@ func (r *ReconcileBlockDevice) updateBDStatus(state openebsv1alpha1.DeviceClaimS
 }
 
 // IsReconcileDisabled is used to check if reconcilation is disabled for
-// BlockDeviceClaim
+// BlockDevice
 func IsReconcileDisabled(bd *openebsv1alpha1.BlockDevice) bool {
 	return bd.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -108,6 +108,11 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	// check if the resource needs to be reconciled
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	switch instance.Status.ClaimState {
 	case openebsv1alpha1.BlockDeviceReleased:
 		jobController := cleaner.NewJobController(r.client, request.Namespace)
@@ -200,4 +205,10 @@ func (r *ReconcileBlockDevice) updateBDStatus(state openebsv1alpha1.DeviceClaimS
 		return err
 	}
 	return nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// BlockDeviceClaim
+func IsReconcileDisabled(bd *openebsv1alpha1.BlockDevice) bool {
+	return bd.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -110,6 +110,11 @@ func (r *ReconcileBlockDeviceClaim) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
+	// check if the resource needs to be reconciled
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	switch instance.Status.Phase {
 	case apis.BlockDeviceClaimStatusPending:
 		fallthrough
@@ -361,4 +366,10 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.B
 	}
 
 	return listBlockDevice, nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// BlockDeviceClaim
+func IsReconcileDisabled(bdc *apis.BlockDeviceClaim) bool {
+	return bdc.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -110,7 +110,7 @@ func (r *ReconcileBlockDeviceClaim) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
-	// check if the resource needs to be reconciled
+	// check if reconcilation is disabled for this resource
 	if IsReconcileDisabled(instance) {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/disk/disk_controller.go
+++ b/pkg/controller/disk/disk_controller.go
@@ -105,7 +105,7 @@ func (r *ReconcileDisk) Reconcile(request reconcile.Request) (reconcile.Result, 
 		return reconcile.Result{}, err
 	}
 
-	// check if the resource needs to be reconciled
+	// check if reconciliation is disabled on this disk resource
 	if IsReconcileDisabled(instance) {
 		return reconcile.Result{}, nil
 	}
@@ -114,7 +114,7 @@ func (r *ReconcileDisk) Reconcile(request reconcile.Request) (reconcile.Result, 
 }
 
 // IsReconcileDisabled is used to check if reconcilation is disabled for
-// BlockDeviceClaim
+// Disk resource
 func IsReconcileDisabled(disk *openebsv1alpha1.Disk) bool {
 	return disk.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/disk/disk_controller.go
+++ b/pkg/controller/disk/disk_controller.go
@@ -18,6 +18,8 @@ package disk
 
 import (
 	"context"
+	ndm "github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+
 	//"fmt"
 
 	openebsv1alpha1 "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
@@ -102,5 +104,17 @@ func (r *ReconcileDisk) Reconcile(request reconcile.Request) (reconcile.Result, 
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	// check if the resource needs to be reconciled
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	return reconcile.Result{}, nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// BlockDeviceClaim
+func IsReconcileDisabled(disk *openebsv1alpha1.Disk) bool {
+	return disk.Annotations[ndm.OpenEBSReconcile] == "false"
 }


### PR DESCRIPTION
`openebs.io/reconcile: "false"` annotation can be set on BlockDevice, Disk and BlockDeviceClaim custom resources to stop reconciliation of those resources.

Disabling reconciliation is useful while handling upgrades. No updates will be done on the Disk, BDs, BDCs etc if the reconciliation is disabled. This means that both the NDM operator and the NDM daemon will not be updating the Disk and BlockDevice resource when the reconcile annotation is set.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>