### PR TITLE
refactor(build): for multiple arch compilation using gox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ go:
 
 env:
   global:
-    - TAG="ci"
-    - CODECOV_TOKEN="d1e39bea-f800-45de-8266-3e9b85e2594a"
-  matrix:
-    - XC_ARCH="amd64"
-      BASEIMAGE="ubuntu:16.04"
-    #- XC_ARCH="arm64"
-    #  BASEIMAGE="arm64v8/ubuntu:18.04"
+   - ARCH=$(go env GOARCH)
+   - TAG="ci"
+   - CODECOV_TOKEN="d1e39bea-f800-45de-8266-3e9b85e2594a"
 
 sudo: required
 
@@ -22,8 +18,6 @@ services:
 addons:
   apt:
     update: true
-    packages: 
-      - gcc-multilib
 
 install:
   - make bootstrap
@@ -33,11 +27,9 @@ install:
       mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/openebs;
       cd $GOPATH/src/github.com/openebs/node-disk-manager;
     fi
-  - if [ "$XC_ARCH" == "amd64" ]; then
-      curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64;
-      sudo chmod +x minikube;
-      sudo mv minikube /usr/local/bin/;
-    fi
+  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64
+  - sudo chmod +x minikube
+  - sudo mv minikube /usr/local/bin/
   # we need openSeaChest repo to build node-disk-manager
   - pushd .
   - cd ..
@@ -52,26 +44,24 @@ install:
   - popd 
 
 before_script:
-  - if [ "$XC_ARCH" == "amd64" ]; then
-      sudo minikube start --vm-driver=none --cpus=1 --memory=1024;
-      sudo minikube update-context;
-      sudo chown -R $USER $HOME/.minikube;
-      sudo chown -R $USER $HOME/.kube;
-      make shellcheck;
-    fi
+  - sudo minikube start --vm-driver=none --cpus=1 --memory=1024
+  - sudo minikube update-context
+  # By default root is the owner of the .minikube directory. This is changed to $USER so that
+  # from the integration tests which run as a non-root user can access the files and connect
+  # to the minikube cluster
+  - sudo chown -R $USER $HOME/.minikube
+  - sudo chown -R $USER $HOME/.kube
 
 script:
+  - make shellcheck
   - make
   # Here sudo -E env "PATH=$PATH" make test is required for running tests with
   # sudo permissions since we are making use of scsi device mockdata in smartprobe_test
   # which could be fetched for a SCSI device with sudo permissions only since to access
   # a particular scsi device, sudo or root permissions are required.
-  - if [ "$XC_ARCH" == "amd64" ]; then
-      sudo -E env "PATH=$PATH" make test;
-      make integration-test;
-      bash <(curl -s https://codecov.io/bash);
-    fi
+  - sudo -E env "PATH=$PATH" make test
+  - make integration-test
 
 after_success:
-  - DIMAGE=openebs/node-disk-manager-$XC_ARCH ./build/push;
-  - DIMAGE=openebs/node-disk-operator-$XC_ARCH ./build/push;
+  - make push
+  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ go:
 
 env:
   global:
-   - ARCH=$(go env GOARCH)
-   - TAG="ci"
-   - CODECOV_TOKEN="d1e39bea-f800-45de-8266-3e9b85e2594a"
+    - TAG="ci"
+    - CODECOV_TOKEN="d1e39bea-f800-45de-8266-3e9b85e2594a"
+  matrix:
+    - XC_ARCH="amd64"
+      BASEIMAGE="ubuntu:16.04"
+    #- XC_ARCH="arm64"
+    #  BASEIMAGE="arm64v8/ubuntu:18.04"
 
 sudo: required
 
@@ -18,6 +22,8 @@ services:
 addons:
   apt:
     update: true
+    packages: 
+      - gcc-multilib
 
 install:
   - make bootstrap
@@ -27,9 +33,11 @@ install:
       mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/openebs;
       cd $GOPATH/src/github.com/openebs/node-disk-manager;
     fi
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64
-  - sudo chmod +x minikube
-  - sudo mv minikube /usr/local/bin/
+  - if [ "$XC_ARCH" == "amd64" ]; then
+      curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64;
+      sudo chmod +x minikube;
+      sudo mv minikube /usr/local/bin/;
+    fi
   # we need openSeaChest repo to build node-disk-manager
   - pushd .
   - cd ..
@@ -44,13 +52,13 @@ install:
   - popd 
 
 before_script:
-  - sudo minikube start --vm-driver=none --cpus=1 --memory=1024
-  - sudo minikube update-context
-  # By default root is the owner of the .minikube directory. This is changed to $USER so that
-  # from the integration tests which run as a non-root user can access the files and connect
-  # to the minikube cluster
-  - sudo chown -R $USER $HOME/.minikube
-  - sudo chown -R $USER $HOME/.kube
+  - if [ "$XC_ARCH" == "amd64" ]; then
+      sudo minikube start --vm-driver=none --cpus=1 --memory=1024;
+      sudo minikube update-context;
+      sudo chown -R $USER $HOME/.minikube;
+      sudo chown -R $USER $HOME/.kube;
+      make shellcheck;
+    fi
 
 script:
   - make
@@ -58,10 +66,12 @@ script:
   # sudo permissions since we are making use of scsi device mockdata in smartprobe_test
   # which could be fetched for a SCSI device with sudo permissions only since to access
   # a particular scsi device, sudo or root permissions are required.
-  - sudo -E env "PATH=$PATH" make test
-  - make integration-test
+  - if [ "$XC_ARCH" == "amd64" ]; then
+      sudo -E env "PATH=$PATH" make test;
+      make integration-test;
+      bash <(curl -s https://codecov.io/bash);
+    fi
 
 after_success:
-  - DIMAGE=openebs/node-disk-manager-$ARCH ./build/push;
-  - DIMAGE=openebs/node-disk-operator-$ARCH ./build/push;
-  - bash <(curl -s https://codecov.io/bash)
+  - DIMAGE=openebs/node-disk-manager-$XC_ARCH ./build/push;
+  - DIMAGE=openebs/node-disk-operator-$XC_ARCH ./build/push;

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,76 @@
-# Specify the name for the binaries
-NODE_DISK_MANAGER=ndm
-NODE_DISK_OPERATOR=ndo
+# Copyright 2018-2019 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-# env for specifying that we want to build ndm daemonset
-BUILD_PATH_NDM=ndm_daemonset
+# ==============================================================================
+# Build Options
 
-# env for specifying that we want to build node-disk-operator
-BUILD_PATH_NDO=manager
-
-# Compile binaries and build docker images
-build: clean vet fmt license-check-go version ndm docker_ndm ndo docker_ndo
-
-NODE_DISK_MANAGER?=ndm
-NODE_DISK_OPERATOR?=ndo
-BUILD_PATH_NDM?=ndm_daemonset
-BUILD_PATH_NDO?=manager
+# set the shell to bash in case some environments use sh
+SHELL:=/bin/bash
 
 # VERSION is the version of the binary.
 VERSION:=$(shell git describe --tags --always)
 
+# Determine the arch/os
 ifeq (${XC_OS}, )
   XC_OS:=$(shell go env GOOS)
-  export XC_OS
 endif
+export XC_OS
 
 ifeq (${XC_ARCH}, )
   XC_ARCH:=$(shell go env GOARCH)
-  export XC_ARCH
 endif
+export XC_ARCH
 
-# Determine the arch/os
 ARCH:=${XC_OS}_${XC_ARCH}
-
-# IMAGE is the image name of the node-disk-manager docker image.
-DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
-DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
+export ARCH
 
 ifeq (${BASEIMAGE}, )
+ifeq ($(ARCH),linux_arm64)
+  BASEIMAGE:=arm64v8/ubuntu:18.04
+else
   # The ubuntu:16.04 image is being used as base image.
   BASEIMAGE:=ubuntu:16.04
-  export BASEIMAGE
 endif
+endif
+export BASEIMAGE
+
+
+# Initialize the NDM DaemonSet variables
+# Specify the binary name
+NODE_DISK_MANAGER=ndm
+NODE_DISK_MANAGER?=ndm
+# Specify the path for the main under the ./cmd/
+BUILD_PATH_NDM=ndm_daemonset
+BUILD_PATH_NDM?=ndm_daemonset
+# Name of the docker image
+DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
+
+# Initialize the NDM Operator variables
+NODE_DISK_OPERATOR=ndo
+NODE_DISK_OPERATOR?=ndo
+# env for specifying that we want to build node-disk-operator
+BUILD_PATH_NDO=manager
+BUILD_PATH_NDO?=manager
+# IMAGE is the image name of the node-disk-manager docker image.
+DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
+
+# Compile binaries and build docker images
+.PHONY: build
+build: clean build.common docker.ndm docker.ndo
+
+.PHONY: build.common
+.build.common: license-check-go version
 
 # Tools required for different make targets or for development purposes
 EXTERNAL_TOOLS=\
@@ -48,85 +78,104 @@ EXTERNAL_TOOLS=\
 	github.com/mitchellh/gox \
 	gopkg.in/alecthomas/gometalinter.v1
 
-# -composite: avoid "literal copies lock value from fakePtr"
-vet:
-	go list ./... | grep -v "./vendor/*" | xargs go vet -composites
-
-fmt:
-	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
-
-# Run the bootstrap target once before trying gometalinter in Development environment
-golint:
-	@gometalinter.v1 --install
-	@gometalinter.v1 --vendor --deadline=600s ./...
-
-# shellcheck target for checking shell scripts linting
-shellcheck: getshellcheck
-	find . -type f -name "*.sh" | grep -v "./vendor/*" | xargs /tmp/shellcheck-latest/shellcheck
-
-getshellcheck:
-	wget -c 'https://goo.gl/ZzKHFv' --no-check-certificate -O - | tar -xvJ -C /tmp/
-
-version:
-	@echo $(VERSION)
-
-test: 	vet fmt
-	@echo "--> Running go test";
-	$(PWD)/build/test.sh
-
 # Bootstrap the build by downloading additional tools
+.PHONY: bootstrap
 bootstrap:
 	@for tool in  $(EXTERNAL_TOOLS) ; do \
 		echo "Installing $$tool" ; \
 		go get -u $$tool; \
 	done
 
-Dockerfile.ndm: ./build/ndm-daemonset/Dockerfile.in
-	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@
-
-Dockerfile.ndo: ./build/ndm-operator/Dockerfile.in
-	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@
-
+.PHONY: header
 header:
 	@echo "----------------------------"
 	@echo "--> node-disk-manager       "
 	@echo "----------------------------"
 	@echo
 
+# -composite: avoid "literal copies lock value from fakePtr"
+.PHONY: vet
+vet:
+	go list ./... | grep -v "./vendor/*" | xargs go vet -composites
+
+.PHONY: fmt
+fmt:
+	find . -type f -name "*.go" | grep -v "./vendor/*" | xargs gofmt -s -w -l
+
+# Run the bootstrap target once before trying gometalinter in Development environment
+.PHONY: golint
+golint:
+	@gometalinter.v1 --install
+	@gometalinter.v1 --vendor --deadline=600s ./...
+
+# shellcheck target for checking shell scripts linting
+.PHONY: shellcheck
+shellcheck: getshellcheck
+	find . -type f -name "*.sh" | grep -v "./vendor/*" | xargs /tmp/shellcheck-latest/shellcheck
+
+.PHONY: getshellcheck
+getshellcheck:
+	wget -c 'https://goo.gl/ZzKHFv' --no-check-certificate -O - | tar -xvJ -C /tmp/
+
+.PHONY: version
+version:
+	@echo $(VERSION)
+
+.PHONY: test
+test: 	vet fmt
+	@echo "--> Running go test";
+	$(PWD)/build/test.sh
+
+.PHONY: integration-test
 integration-test:
 	go test -v -timeout 20m github.com/openebs/node-disk-manager/integration_tests/sanity
 
-ndm:
+.PHONY: Dockerfile.ndm
+Dockerfile.ndm: ./build/ndm-daemonset/Dockerfile.in
+	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@
+
+.PHONY: Dockerfile.ndo
+Dockerfile.ndo: ./build/ndm-operator/Dockerfile.in
+	sed -e 's|@BASEIMAGE@|$(BASEIMAGE)|g' $< >$@
+
+.PHONY: build.ndm
+build.ndm:
 	@echo '--> Building node-disk-manager binary...'
 	@pwd
 	@CTLNAME=${NODE_DISK_MANAGER} BUILDPATH=${BUILD_PATH_NDM} sh -c "'$(PWD)/build/build.sh'"
 	@echo '--> Built binary.'
 	@echo
 
-docker_ndm: Dockerfile.ndm 
+.PHONY: docker.ndm
+docker.ndm: build.ndm Dockerfile.ndm 
 	@echo "--> Building docker image for ndm-daemonset..."
 	@sudo docker build -t "$(DOCKER_IMAGE_NDM)" --build-arg ARCH=${ARCH} -f Dockerfile.ndm .
 	@echo "--> Build docker image: $(DOCKER_IMAGE_NDM)"
 	@echo
-ndo:
+
+.PHONY: build.ndo
+build.ndo:
 	@echo '--> Building node-disk-operator binary...'
 	@pwd
 	@CTLNAME=${NODE_DISK_OPERATOR} BUILDPATH=${BUILD_PATH_NDO} sh -c "'$(PWD)/build/build.sh'"
 	@echo '--> Built binary.'
 	@echo
 
-docker_ndo: Dockerfile.ndo 
+.PHONY: build.ndo
+docker.ndo: build.ndo Dockerfile.ndo 
 	@echo "--> Building docker image for ndm-operator..."
 	@sudo docker build -t "$(DOCKER_IMAGE_NDO)" --build-arg ARCH=${ARCH} -f Dockerfile.ndo .
 	@echo "--> Build docker image: $(DOCKER_IMAGE_NDO)"
 	@echo
 
+.PHONY: deps
 deps: header
 	@echo '--> Resolving dependencies...'
 	dep ensure
 	@echo '--> Depedencies resolved.'
 	@echo
 
+.PHONY: clean
 clean: header
 	@echo '--> Cleaning directory...'
 	rm -rf bin
@@ -136,6 +185,7 @@ clean: header
 	@echo '--> Done cleaning.'
 	@echo
 
+.PHONY: license-check-go
 license-check-go:
 	@echo "--> Checking license header..."
 	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ) ; do \
@@ -148,4 +198,7 @@ license-check-go:
 	@echo "--> Done checking license."
 	@echo
 
-.PHONY: build
+.PHONY: push
+push: 
+	DIMAGE=openebs/node-disk-manager-$XC_ARCH ./build/push;
+	DIMAGE=openebs/node-disk-operator-$XC_ARCH ./build/push;

--- a/Makefile
+++ b/Makefile
@@ -49,19 +49,15 @@ export BASEIMAGE
 # Initialize the NDM DaemonSet variables
 # Specify the binary name
 NODE_DISK_MANAGER=ndm
-NODE_DISK_MANAGER?=ndm
 # Specify the path for the main under the ./cmd/
 BUILD_PATH_NDM=ndm_daemonset
-BUILD_PATH_NDM?=ndm_daemonset
 # Name of the docker image
 DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
 
 # Initialize the NDM Operator variables
 NODE_DISK_OPERATOR=ndo
-NODE_DISK_OPERATOR?=ndo
 # env for specifying that we want to build node-disk-operator
 BUILD_PATH_NDO=manager
-BUILD_PATH_NDO?=manager
 # IMAGE is the image name of the node-disk-manager docker image.
 DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
 NODE_DISK_OPERATOR=ndo
 # env for specifying that we want to build node-disk-operator
 BUILD_PATH_NDO=manager
-# IMAGE is the image name of the node-disk-manager docker image.
+# Name of the docker image for ndm operator
 DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
 
 # Compile binaries and build docker images

--- a/Makefile
+++ b/Makefile
@@ -47,18 +47,19 @@ export BASEIMAGE
 
 
 # Initialize the NDM DaemonSet variables
-# Specify the binary name
+# Specify the NDM DaemonSet binary name
 NODE_DISK_MANAGER=ndm
-# Specify the path for the main under the ./cmd/
+# Specify the sub path under ./cmd/ for NDM DaemonSet
 BUILD_PATH_NDM=ndm_daemonset
-# Name of the docker image
+# Name of the image for NDM DaemoneSet
 DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
 
 # Initialize the NDM Operator variables
+# Specify the NDM Operator binary name
 NODE_DISK_OPERATOR=ndo
-# env for specifying that we want to build node-disk-operator
+# Specify the sub path under ./cmd/ for NDM Operator
 BUILD_PATH_NDO=manager
-# Name of the docker image for ndm operator
+# Name of the image for ndm operator
 DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
 
 # Compile binaries and build docker images

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ with one of the below directions:
 * Setup build tools:
   * By default node-disk-manager enables fetching disk attributes using udev. This requires udev develop files. For Ubuntu, `libudev-dev` package should be installed.
   * `make bootstrap` installs the required Go tools.
+  * NDM uses SeaChest to probe for drive details. Use the following to setup the SeaChest libraries:
+    ```
+    pushd .
+    cd ..
+    git clone --recursive --branch Release-19.06.02 https://github.com/openebs/openSeaChest.git
+    cd openSeaChest/Make/gcc 
+    make release
+    cd ../../
+    sudo cp opensea-common/Make/gcc/lib/libopensea-common.a /usr/lib 
+    sudo cp opensea-operations/Make/gcc/lib/libopensea-operations.a /usr/lib 
+    sudo cp opensea-transport/Make/gcc/lib/libopensea-transport.a /usr/lib
+    popd
+    ```
 
 * run `make` in the top directory. It will:
   * Build the binary.

--- a/build/build.sh
+++ b/build/build.sh
@@ -61,11 +61,12 @@ build(){
             if [ "$GOOS" = "windows" ]; then
                 output_name+='.exe'
             fi
-            env GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags \
+            echo "Building for: ${GOOS} ${GOARCH}"
+            gox -cgo -os="$GOOS" -arch="$GOARCH" -ldflags \
                "-X github.com/openebs/node-disk-manager/pkg/version.GitCommit=${GIT_COMMIT} \
                 -X main.CtlName='${CTLNAME}' \
                 -X github.com/openebs/node-disk-manager/pkg/version.Version=${VERSION}" \
-                -o $output_name \
+                -output="$output_name" \
                ./cmd/"$BUILDPATH"
         done
     done
@@ -92,8 +93,8 @@ VERSION="beta"
 
 
 # Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"amd64"}
-XC_OS=${XC_OS:-"linux"}
+#XC_ARCH=${XC_ARCH:-"amd64"}
+#XC_OS=${XC_OS:-"linux"}
 
 XC_ARCHS=("${XC_ARCH// / }")
 XC_OSS=("${XC_OS// / }")


### PR DESCRIPTION
Related to:
- https://github.com/openebs/openebs/issues/1295
- https://github.com/openebs/node-disk-manager/pull/306

This PR refactors the build scripts ( .travis.yaml and Makefile) to allow
for compiling on different platforms like `amd64` and `arm64` without 
having to make changes to the build scripts. 

The following changes have been made: 
- `shellcheck` is triggered as a seperate step from .travis.yaml, as it is only available for amd64
- updated the Makefile to initialize ARCH and BASEIMAGE depending on the platform where builds are initiated. 
- updated the build to make use of gox to allow for cross compilation
- made some cosmetic changes to Makefile for better readability. 
- updated the README with dependency on SeaChest libraries. 

Attempted to automate the building of arm64 builds via cross compiling 
in travis. However, the dependencies on libudev and seachest are non-trivial
to resolve. Will re-attempt to setup automated builds via QEMU based approach
in the upcoming PRs. 

Note: Verified the changes on ARM by manually running the - `make` in a ARM node. 

Signed-off-by: kmova <kiran.mova@mayadata.io>