### PR TITLE
refactor(upgrade): remove duplicated code in upgrade

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -21,23 +21,16 @@ import "fmt"
 // Task interfaces gives a set of methods to be implemented
 // for performing an upgrade
 type Task interface {
-	FromVersion() string
-	ToVersion() string
-	IsSuccess() error
 	PreUpgrade() bool
-	Upgrade() bool
-	PostUpgrade() bool
+	IsSuccess() error
 }
 
 // RunUpgrade runs all the upgrade tasks required
 func RunUpgrade(tasks ...Task) error {
 	for _, task := range tasks {
-		_ = task.PreUpgrade() && task.Upgrade() && task.PostUpgrade()
+		_ = task.PreUpgrade()
 		if err := task.IsSuccess(); err != nil {
-			return fmt.Errorf("upgrade from %s to %s failed. Error : %v",
-				task.FromVersion(),
-				task.ToVersion(),
-				err)
+			return fmt.Errorf("upgrade failed. Error : %v", err)
 		}
 	}
 	return nil

--- a/pkg/upgrade/v040_041/preupgrade.go
+++ b/pkg/upgrade/v040_041/preupgrade.go
@@ -18,7 +18,6 @@ package v040_041
 
 import (
 	"context"
-	"fmt"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -70,7 +69,7 @@ func (p *UpgradeTask) PreUpgrade() bool {
 // IsSuccess returns error if the upgrade failed, at any step. Else nil will
 // be returned
 func (p *UpgradeTask) IsSuccess() error {
-	return fmt.Errorf("from : %s - to : %s. err : %v", p.from, p.to, p.err)
+	return p.err
 }
 
 // renameFinalizer renames the finalizer from old to new in BDC

--- a/pkg/upgrade/v040_041/preupgrade.go
+++ b/pkg/upgrade/v040_041/preupgrade.go
@@ -18,6 +18,7 @@ package v040_041
 
 import (
 	"context"
+	"fmt"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,16 +46,6 @@ func NewUpgradeTask(from, to string, c client.Client) *UpgradeTask {
 	return &UpgradeTask{from: from, to: to, client: c}
 }
 
-// FromVersion returns the version from which the components need to be updated
-func (p *UpgradeTask) FromVersion() string {
-	return p.from
-}
-
-// ToVersion returns the version to which components will be updated.
-func (p *UpgradeTask) ToVersion() string {
-	return p.to
-}
-
 // PreUpgrade runs the preupgrade tasks and returns whether it succeeded or not
 func (p *UpgradeTask) PreUpgrade() bool {
 	var err error
@@ -76,27 +67,10 @@ func (p *UpgradeTask) PreUpgrade() bool {
 	return true
 }
 
-// Upgrade runs the main upgrade tasks and returns whether it succeeded or not
-func (p *UpgradeTask) Upgrade() bool {
-	if p.err != nil {
-		return false
-	}
-	return true
-}
-
-// PostUpgrade runs the tasks that need to be performed after upgrade and returns
-// whether the tasks where success or not
-func (p *UpgradeTask) PostUpgrade() bool {
-	if p.err != nil {
-		return false
-	}
-	return true
-}
-
 // IsSuccess returns error if the upgrade failed, at any step. Else nil will
 // be returned
 func (p *UpgradeTask) IsSuccess() error {
-	return p.err
+	return fmt.Errorf("from : %s - to : %s. err : %v", p.from, p.to, p.err)
 }
 
 // renameFinalizer renames the finalizer from old to new in BDC

--- a/pkg/upgrade/v041_042/preupgrade.go
+++ b/pkg/upgrade/v041_042/preupgrade.go
@@ -18,7 +18,6 @@ package v041_042
 
 import (
 	"context"
-	"fmt"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -62,7 +61,7 @@ func (p *UpgradeTask) PreUpgrade() bool {
 // IsSuccess returns error if the upgrade failed, at any step. Else nil will
 // be returned
 func (p *UpgradeTask) IsSuccess() error {
-	return fmt.Errorf("from : %s - to : %s. err : %v", p.from, p.to, p.err)
+	return p.err
 }
 
 // copyHostName will copy the hostname string from .spec.hostName to

--- a/pkg/upgrade/v041_042/preupgrade.go
+++ b/pkg/upgrade/v041_042/preupgrade.go
@@ -18,6 +18,7 @@ package v041_042
 
 import (
 	"context"
+	"fmt"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -35,17 +36,6 @@ type UpgradeTask struct {
 // and specified `from` and `to` version
 func NewUpgradeTask(from, to string, c client.Client) *UpgradeTask {
 	return &UpgradeTask{from: from, to: to, client: c}
-}
-
-// FromVersion returns the version from which the components need to be updated
-func (p *UpgradeTask) FromVersion() string {
-	return p.from
-}
-
-// ToVersion returns the version to which components will be updated. This should be
-// the current version
-func (p *UpgradeTask) ToVersion() string {
-	return p.to
 }
 
 // PreUpgrade runs the preupgrade tasks and returns whether it succeeded or not
@@ -69,27 +59,10 @@ func (p *UpgradeTask) PreUpgrade() bool {
 	return true
 }
 
-// Upgrade runs the main upgrade tasks and returns whether it succeeded or not
-func (p *UpgradeTask) Upgrade() bool {
-	if p.err != nil {
-		return false
-	}
-	return true
-}
-
-// PostUpgrade runs the tasks that need to be performed after upgrade and returns
-// whether the tasks where success or not
-func (p *UpgradeTask) PostUpgrade() bool {
-	if p.err != nil {
-		return false
-	}
-	return true
-}
-
 // IsSuccess returns error if the upgrade failed, at any step. Else nil will
 // be returned
 func (p *UpgradeTask) IsSuccess() error {
-	return p.err
+	return fmt.Errorf("from : %s - to : %s. err : %v", p.from, p.to, p.err)
 }
 
 // copyHostName will copy the hostname string from .spec.hostName to


### PR DESCRIPTION
This PR removes duplicated code in upgrade pkg. The interface definition for upgrade task has been changed so that only required functions need to be written, reducing the amount of boilerplate