### PR TITLE
refactor(logs): use formatted log messages with pre-defined keys

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // CreateBlockDevice creates the BlockDevice resource in etcd

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -37,6 +37,11 @@ func (c *Controller) CreateBlockDevice(blockDevice apis.BlockDevice) {
 	if err == nil {
 		glog.Info("Created blockdevice object in etcd: ",
 			blockDeviceCopy.ObjectMeta.Name)
+		alertlog.Logger.Infow("",
+			"eventcode", "ndm.blockdevice.create.success",
+			"msg", "Successfully created block device",
+			"rname", blockDeviceCopy.ObjectMeta.Name,
+		)
 		return
 	}
 
@@ -93,9 +98,19 @@ func (c *Controller) UpdateBlockDevice(blockDevice apis.BlockDevice, oldBlockDev
 	err = c.Clientset.Update(context.TODO(), blockDeviceCopy)
 	if err != nil {
 		glog.Error("Unable to update blockdevice object : ", err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.blockdevice.update.failure",
+			"msg", "Failed to update block device",
+			"rname", blockDeviceCopy.ObjectMeta.Name,
+		)
 		return err
 	}
 	glog.Info("Updated blockdevice object : ", blockDeviceCopy.ObjectMeta.Name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.blockdevice.update.success",
+		"msg", "Successfully updated block device",
+		"rname", blockDeviceCopy.ObjectMeta.Name,
+	)
 	return nil
 }
 
@@ -107,9 +122,19 @@ func (c *Controller) DeactivateBlockDevice(blockDevice apis.BlockDevice) {
 	err := c.Clientset.Update(context.TODO(), blockDeviceCopy)
 	if err != nil {
 		glog.Error("Unable to deactivate blockdevice: ", err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.blockdevice.deactivate.failure",
+			"msg", "Failed to deactivate block device",
+			"rname", blockDeviceCopy.ObjectMeta.Name,
+		)
 		return
 	}
 	glog.Info("Deactivated blockdevice: ", blockDeviceCopy.ObjectMeta.Name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.blockdevice.deactivate.success",
+		"msg", "Successfully deactivated block device",
+		"rname", blockDeviceCopy.ObjectMeta.Name,
+	)
 }
 
 // GetBlockDevice get Disk resource from etcd
@@ -138,9 +163,19 @@ func (c *Controller) DeleteBlockDevice(name string) {
 	err := c.Clientset.Delete(context.TODO(), blockDevice)
 	if err != nil {
 		glog.Error("Unable to delete blockdevice object : ", err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.blockdevice.delete.failure",
+			"msg", "Failed to delete block device",
+			"rname", name,
+		)
 		return
 	}
 	glog.Info("Deleted blockdevice object : ", name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.blockdevice.delete.success",
+		"msg", "Successfully deleted block device",
+		"rname", name,
+	)
 }
 
 // ListBlockDeviceResource queries the etcd for the devices for the host/node

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -20,12 +20,12 @@ import (
 	"context"
 
 	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // CreateBlockDevice creates the BlockDevice resource in etcd

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openebs/node-disk-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // CreateDisk creates the Disk resource in etcd

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/golang/glog"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // CreateDisk creates the Disk resource in etcd

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -32,6 +32,11 @@ func (c *Controller) CreateDisk(dr apis.Disk) {
 	err := c.Clientset.Create(context.TODO(), drCopy)
 	if err == nil {
 		glog.Info("Created disk object in etcd : ", drCopy.ObjectMeta.Name)
+		alertlog.Logger.Infow("",
+			"eventcode", "ndm.disk.create.success",
+			"msg", "Successfully created disk",
+			"rname", drCopy.ObjectMeta.Name,
+		)
 		return
 	}
 	/*
@@ -71,6 +76,11 @@ func (c *Controller) UpdateDisk(dr apis.Disk, oldDr *apis.Disk) error {
 			Name:      oldDr.Name}, oldDr)
 		if err != nil {
 			glog.Errorf("Unable to get disk object:%v, err:%v", oldDr.ObjectMeta.Name, err)
+			alertlog.Logger.Errorw("",
+				"eventcode", "ndm.disk.update.failure",
+				"msg", "Failed to update disk",
+				"rname", drCopy.ObjectMeta.Name,
+			)
 			return err
 		}
 	}
@@ -79,9 +89,19 @@ func (c *Controller) UpdateDisk(dr apis.Disk, oldDr *apis.Disk) error {
 	err := c.Clientset.Update(context.TODO(), drCopy)
 	if err != nil {
 		glog.Errorf("Unable to update disk object:%v, err:%v", drCopy.ObjectMeta.Name, err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.disk.update.failure",
+			"msg", "Failed to update disk",
+			"rname", drCopy.ObjectMeta.Name,
+		)
 		return err
 	}
 	glog.Infof("Updated disk object::%v successfully", drCopy.ObjectMeta.Name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.disk.update.success",
+		"msg", "Successfully updated disk",
+		"rname", drCopy.ObjectMeta.Name,
+	)
 	return nil
 }
 
@@ -92,9 +112,19 @@ func (c *Controller) DeactivateDisk(dr apis.Disk) {
 	err := c.Clientset.Update(context.TODO(), drCopy)
 	if err != nil {
 		glog.Error("Unable to deactivate disk object : ", err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.disk.deactivate.failure",
+			"msg", "Failed to deactivate disk",
+			"rname", drCopy.ObjectMeta.Name,
+		)
 		return
 	}
 	glog.Info("deactivate the disk object : ", drCopy.ObjectMeta.Name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.disk.deactivate.success",
+		"msg", "Successfully deactivated disk",
+		"rname", drCopy.ObjectMeta.Name,
+	)
 }
 
 // GetDisk get Disk resource from etcd
@@ -123,9 +153,19 @@ func (c *Controller) DeleteDisk(name string) {
 	err := c.Clientset.Delete(context.TODO(), dr)
 	if err != nil {
 		glog.Error("Unable to delete disk object : ", err)
+		alertlog.Logger.Errorw("",
+			"eventcode", "ndm.disk.delete.failure",
+			"msg", "Failed to delete disk",
+			"rname", drCopy.ObjectMeta.Name,
+		)
 		return
 	}
 	glog.Info("Deleted disk object : ", name)
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.disk.delete.success",
+		"msg", "Successfully deleted disk",
+		"rname", drCopy.ObjectMeta.Name,
+	)
 }
 
 // ListDiskResource queries the etcd for the devices for the host/node

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -157,7 +157,7 @@ func (c *Controller) DeleteDisk(name string) {
 		alertlog.Logger.Errorw("",
 			"eventcode", "ndm.disk.delete.failure",
 			"msg", "Failed to delete disk",
-			"rname", drCopy.ObjectMeta.Name,
+			"rname", name,
 		)
 		return
 	}
@@ -165,7 +165,7 @@ func (c *Controller) DeleteDisk(name string) {
 	alertlog.Logger.Infow("",
 		"eventcode", "ndm.disk.delete.success",
 		"msg", "Successfully deleted disk",
-		"rname", drCopy.ObjectMeta.Name,
+		"rname", name,
 	)
 }
 

--- a/cmd/ndm_daemonset/main.go
+++ b/cmd/ndm_daemonset/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 	"os"
 
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/app/command"
@@ -25,8 +26,10 @@ import (
 
 func main() {
 	if err := run(); err != nil {
+		alertlog.Logger.Sync()
 		os.Exit(1)
 	}
+	alertlog.Logger.Sync()
 	os.Exit(0)
 }
 

--- a/pkg/alertlog/alertlog.go
+++ b/pkg/alertlog/alertlog.go
@@ -31,15 +31,7 @@ func initLogger() *zap.SugaredLogger {
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}
-	//logger, err := zap.NewProduction()
-	defer logger.Sync() // flushes buffer, if any
+
 	return logger.Sugar()
 }
 
-//sugar.Infow("failed to fetch URL",
-//// Structured context as loosely typed key-value pairs.
-//"url", url,
-//"attempt", 3,
-//"backoff", time.Second,
-//)
-//sugar.Infof("Failed to fetch URL: %s", url)

--- a/pkg/alertlog/alertlog.go
+++ b/pkg/alertlog/alertlog.go
@@ -1,0 +1,30 @@
+package alertlog
+
+import (
+	"go.uber.org/zap"
+	"log"
+)
+
+
+var (
+	// Logger facilitates logging with alert format
+	Logger = initLogger()
+)
+
+func initLogger() *zap.SugaredLogger {
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+	//logger, err := zap.NewProduction()
+	defer logger.Sync() // flushes buffer, if any
+	return logger.Sugar()
+}
+
+//sugar.Infow("failed to fetch URL",
+//// Structured context as loosely typed key-value pairs.
+//"url", url,
+//"attempt", 3,
+//"backoff", time.Second,
+//)
+//sugar.Infof("Failed to fetch URL: %s", url)

--- a/pkg/alertlog/alertlog.go
+++ b/pkg/alertlog/alertlog.go
@@ -1,10 +1,25 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package alertlog
 
 import (
 	"go.uber.org/zap"
 	"log"
 )
-
 
 var (
 	// Logger facilitates logging with alert format

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -33,5 +33,10 @@ func RunUpgrade(tasks ...Task) error {
 			return fmt.Errorf("upgrade failed. Error : %v", err)
 		}
 	}
+	alertlog.Logger.Infow("",
+		"eventcode", "ndm.upgrade.success",
+		"msg", "Successfully upgraded node disk manager",
+		"rname", "NDM",
+	)
 	return nil
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package upgrade
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
+)
 
 // Task interfaces gives a set of methods to be implemented
 // for performing an upgrade

--- a/pkg/upgrade/v040_041/preupgrade.go
+++ b/pkg/upgrade/v040_041/preupgrade.go
@@ -18,10 +18,10 @@ package v040_041
 
 import (
 	"context"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 const (

--- a/pkg/upgrade/v040_041/preupgrade.go
+++ b/pkg/upgrade/v040_041/preupgrade.go
@@ -21,6 +21,7 @@ import (
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 const (

--- a/pkg/upgrade/v040_041/preupgrade.go
+++ b/pkg/upgrade/v040_041/preupgrade.go
@@ -59,6 +59,11 @@ func (p *UpgradeTask) PreUpgrade() bool {
 	for _, bdc := range bdcList.Items {
 		err = p.renameFinalizer(&bdc)
 		if err != nil {
+			alertlog.Logger.Errorw("",
+				"eventcode", "ndm.upgrade.task.failure",
+				"msg", "Failed to upgrade node disk manager",
+				"rname", "v040_041",
+			)
 			p.err = err
 			return false
 		}

--- a/pkg/upgrade/v041_042/preupgrade.go
+++ b/pkg/upgrade/v041_042/preupgrade.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // UpgradeTask is the struct which implements the Task interface

--- a/pkg/upgrade/v041_042/preupgrade.go
+++ b/pkg/upgrade/v041_042/preupgrade.go
@@ -51,6 +51,11 @@ func (p *UpgradeTask) PreUpgrade() bool {
 	for _, bdc := range bdcList.Items {
 		err = p.copyHostName(&bdc)
 		if err != nil {
+			alertlog.Logger.Errorw("",
+				"eventcode", "ndm.upgrade.task.failure",
+				"msg", "Failed to upgrade node disk manager",
+				"rname", "v041_042",
+			)
 			p.err = err
 			return false
 		}

--- a/pkg/upgrade/v041_042/preupgrade.go
+++ b/pkg/upgrade/v041_042/preupgrade.go
@@ -18,9 +18,9 @@ package v041_042
 
 import (
 	"context"
+	"github.com/openebs/node-disk-manager/pkg/alertlog"
 	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"github.com/openebs/node-disk-manager/pkg/alertlog"
 )
 
 // UpgradeTask is the struct which implements the Task interface


### PR DESCRIPTION
The purpose of this change is to help with generating alerts based on the log messages from all openebs components through elasticsearch and elastalert. It is easy to parse the logs and generate alerts if the log messages are all formatted in a predefined way. 

This PR does the following:
* Introduces the usage of uber-zap logger for printing the formatted messages. uber-zap promises to be faster and efficient than its counter parts like glog, logrus etc.
* Initial log message changes are included as examples of how the logs could be be generated. 
