### PR TITLE
Continous Integration should run Lint, Flow for every PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ script:
   # a particular scsi device, sudo or root permissions are required.
   - sudo -E env "PATH=$PATH" make test
   - make integration-test
-  - kubectl describe pod
 
 after_success:
   - DIMAGE=openebs/node-disk-manager-$ARCH ./hack/push;

--- a/cmd/controller/sparsefilegenerator.go
+++ b/cmd/controller/sparsefilegenerator.go
@@ -122,11 +122,12 @@ func GetSparseFileSize() int64 {
 		return SparseFileDefaultSize
 	}
 
-	sparseFileSize, econv := strconv.ParseInt(sparseFileSizeStr, 10, 64)
+	fileSize, econv := strconv.ParseFloat(sparseFileSizeStr, 64)
 	if econv != nil {
-		glog.Info("Error converting sparse file size:  ", sparseFileSizeStr)
+		glog.Error("Error converting sparse file size:  ", econv)
 		return 0
 	}
+	sparseFileSize := int64(fileSize)
 
 	if sparseFileSize < SparseFileMinSize {
 		glog.Info(fmt.Sprint(sparseFileSizeStr), " is less than minimum required. Setting the size to:  ", fmt.Sprint(SparseFileMinSize))

--- a/cmd/filter/osdiskexcludefilter.go
+++ b/cmd/filter/osdiskexcludefilter.go
@@ -31,7 +31,7 @@ const (
 var (
 	defaultMountFilePath     = "/proc/self/mounts"
 	mountPoints              = []string{"/", "/etc/hosts"}
-	hostMountFilePath        = "/host/mounts"           // hostMountFilePath is the file path mounted inside container
+	hostMountFilePath        = "/host/proc/1/mounts"    // hostMountFilePath is the file path mounted inside container
 	oSDiskExcludeFilterName  = "os disk exclude filter" // filter name
 	oSDiskExcludeFilterState = defaultEnabled           // filter state
 )

--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -162,7 +162,6 @@ func (up *udevProbe) scan() error {
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: diskInfo,
 	}
-	glog.Info("Partition Data to channel: ", eventDetails.Devices[3].PartitionData)
 	udevevent.UdevEventMessageChannel <- eventDetails
 	return nil
 }

--- a/cmd/probe/udevprobe.go
+++ b/cmd/probe/udevprobe.go
@@ -94,20 +94,20 @@ func newUdevProbe(c *controller.Controller) *udevProbe {
 // newUdevProbeForFillDiskDetails returns udevProbe struct which helps populate diskInfo struct.
 // it contains copy of udevDevice struct to populate diskInfo use defer free in caller function
 // to free c pointer memory
-func newUdevProbeForFillDiskDetails(sysPath string) *udevProbe {
+func newUdevProbeForFillDiskDetails(sysPath string) (*udevProbe, error) {
 	udev, err := libudevwrapper.NewUdev()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevDevice, err := udev.NewDeviceFromSysPath(sysPath)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	udevProbe := &udevProbe{
 		udev:       udev,
 		udevDevice: udevDevice,
 	}
-	return udevProbe
+	return udevProbe, nil
 }
 
 // Start setup udev probe listener and make a single scan of system
@@ -168,7 +168,11 @@ func (up *udevProbe) scan() error {
 
 // fillDiskDetails filles details in diskInfo struct using probe information
 func (up *udevProbe) FillDiskDetails(d *controller.DiskInfo) {
-	udevDevice := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	udevDevice, err := newUdevProbeForFillDiskDetails(d.ProbeIdentifiers.UdevIdentifier)
+	if err != nil {
+		glog.Errorf("%s : %s", d.ProbeIdentifiers.UdevIdentifier, err)
+		return
+	}
 	udevDiskDetails := udevDevice.udevDevice.DiskInfoFromLibudev()
 	defer udevDevice.free()
 	d.ProbeIdentifiers.SmartIdentifier = udevDiskDetails.Path

--- a/cmd/probe/udevprobe_test.go
+++ b/cmd/probe/udevprobe_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package probe
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -187,6 +188,46 @@ func TestUdevProbe(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, test.expectedDisk, test.actualDisk)
+			assert.Equal(t, test.expectedError, test.actualError)
+		})
+	}
+}
+
+func TestNewUdevProbeForFillDiskDetails(t *testing.T) {
+	// Creating the actual udev probe struct
+	mockDisk, err := libudevwrapper.MockDiskDetails()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sysPath := mockDisk.SysPath
+	udev, err := libudevwrapper.NewUdev()
+	if err != nil {
+		t.Fatal(err)
+	}
+	actualUdevProbe := &udevProbe{
+		udev: udev,
+	}
+	actualUdevProbe.udevDevice, err = actualUdevProbe.udev.NewDeviceFromSysPath(sysPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	udevProbeError := errors.New("unable to create Udevice object for null struct struct_udev_device")
+
+	// expected cases
+	expectedUdevProbe1, expectedError1 := newUdevProbeForFillDiskDetails(sysPath)
+	expectedUdevProbe2, expectedError2 := newUdevProbeForFillDiskDetails("")
+	tests := map[string]struct {
+		actualUdevProbe   *udevProbe
+		expectedUdevProbe *udevProbe
+		actualError       error
+		expectedError     error
+	}{
+		"udev probe with correct syspath": {actualUdevProbe: actualUdevProbe, expectedUdevProbe: expectedUdevProbe1, actualError: nil, expectedError: expectedError1},
+		"udev probe with empty syspath":   {actualUdevProbe: nil, expectedUdevProbe: expectedUdevProbe2, actualError: udevProbeError, expectedError: expectedError2},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expectedUdevProbe, test.actualUdevProbe)
 			assert.Equal(t, test.expectedError, test.actualError)
 		})
 	}

--- a/hack/entrypoint.sh
+++ b/hack/entrypoint.sh
@@ -4,7 +4,7 @@ export GOTRACEBACK=crash
 
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
-echo "/var/openebs/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+echo "/var/openebs/sparse/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -110,6 +110,8 @@ kind: DaemonSet
 metadata:
   name: node-disk-manager
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -129,7 +131,7 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         # make udev database available inside container

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -143,7 +143,8 @@ spec:
         - name: udev
           mountPath: /run/udev
         - name: procmount
-          mountPath: /host/mounts
+          mountPath: /host/proc
+          readOnly: true
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -174,7 +175,8 @@ spec:
       # mount /proc/1/mounts (mount file of process 1 of host) inside container
       # to read which partition is mounted on / path
         hostPath:
-          path: /proc/1/mounts
+          path: /proc
+          type: Directory
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -145,7 +145,7 @@ spec:
         - name: procmount
           mountPath: /host/mounts
         - name: sparsepath
-          mountPath: /var/openebs
+          mountPath: /var/openebs/sparse
         env:
         # pass hostname as env variable using downward API to the NDM container
         - name: NODE_NAME
@@ -177,4 +177,4 @@ spec:
           path: /proc/1/mounts
       - name: sparsepath
         hostPath:
-          path: /var/openebs
+          path: /var/openebs/sparse

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -155,7 +155,7 @@ spec:
         # specify the directory where the sparse files need to be created.
         # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR
-          value: "/var/openebs"
+          value: "/var/openebs/sparse"
         # Size of the sparse file to be created.
         - name: SPARSE_FILE_SIZE
           value: "1073741824"

--- a/pkg/udev/device.go
+++ b/pkg/udev/device.go
@@ -34,7 +34,7 @@ type UdevDevice struct {
 // it returns nil if the pointer passed is NULL.
 func newUdevDevice(ptr *C.struct_udev_device) (*UdevDevice, error) {
 	if ptr == nil {
-		return nil, errors.New("unable to create Udevice object for for null struct struct_udev_device")
+		return nil, errors.New("unable to create Udevice object for null struct struct_udev_device")
 	}
 	ud := &UdevDevice{
 		udptr: ptr,

--- a/pkg/udev/monitor_test.go
+++ b/pkg/udev/monitor_test.go
@@ -117,6 +117,6 @@ func TestUdevMonitorNewDevice(t *testing.T) {
 	defer udevMonitor.UdevMonitorUnref()
 	_, err = udevMonitor.ReceiveDevice()
 	if err != nil {
-		assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+		assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	}
 }

--- a/pkg/udev/udev_test.go
+++ b/pkg/udev/udev_test.go
@@ -80,7 +80,7 @@ func TestNewDeviceFromSysPath(t *testing.T) {
 	if device1 != nil {
 		t.Fatal("device should be nil for invalid syspath")
 	}
-	assert.Equal(t, errors.New("unable to create Udevice object for for null struct struct_udev_device"), err)
+	assert.Equal(t, errors.New("unable to create Udevice object for null struct struct_udev_device"), err)
 	diskDetails, err := MockDiskDetails()
 	if err != nil {
 		t.Fatal(err)

--- a/samples/node-disk-manager.yaml
+++ b/samples/node-disk-manager.yaml
@@ -20,11 +20,8 @@ spec:
       hostNetwork: true
       containers:
       - name: node-disk-manager
-        command:
-        - /usr/sbin/ndm
-        - start
         image: openebs/node-disk-manager-amd64:ci
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
The package.json defines a check-all script that runs Prettier, Lint, and Flow. This script is intended to be run before commit to help catch inconsistent formatting or type errors. However we are not currently running this check as part of CI.

  To fix this, first create a script that does the following 
Run Prettier and fail if any modifications are made.This means that the committed code isn't formatted correctly.
Run ESLint and fail if there are any errors.
Run Flow and fail if there are any errors.
  Fix all pre-existing errors so the new yarn ci-check task passes in master.
  Hook this new script into CircleCI to run automatically for every PR
