### PR TITLE
fix(mount): fix parent disk detection for nvme devices.

### DIFF
--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -126,16 +126,21 @@ func getParentBlockDevice(sysPath string) (string, bool) {
 	nvmeSubsystem := "nvme"
 	parts := strings.Split(sysPath, "/")
 
-	// checking in block subsystem
+	// checking for block subsystem, return the next part after subsystem only
+	// if the length is greater. This check is to avoid an index out of range panic.
 	for i, part := range parts {
-		if part == blockSubsystem {
+		if part == blockSubsystem &&
+			len(parts)-1 >= i+1 {
 			return parts[i+1], true
 		}
 	}
 
-	// checking in nvme subsystem
+	// checking for nvme subsystem, return the 2nd item in hierarchy, which will be the
+	// nvme namespace. Length checking is to avoid index out of range in case of malformed
+	// links (extremely rare case)
 	for i, part := range parts {
-		if part == nvmeSubsystem {
+		if part == nvmeSubsystem &&
+			len(parts)-1 >= i+2 {
 			return parts[i+2], true
 		}
 	}

--- a/pkg/mount/mountutil_test.go
+++ b/pkg/mount/mountutil_test.go
@@ -186,3 +186,34 @@ func TestOsDiskPath(t *testing.T) {
 		})
 	}
 }
+
+func TestGetParentBlockDevice(t *testing.T) {
+	tests := map[string]struct {
+		syspath                   string
+		expectedParentBlockDevice string
+	}{
+		"getting parent of a main blockdevice itself": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda",
+			expectedParentBlockDevice: "sda",
+		},
+		"getting parent of a partition": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1",
+			expectedParentBlockDevice: "sda",
+		},
+		"getting parent of main NVMe blockdevice": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0/nvme/nvme0/nvme0n1",
+			expectedParentBlockDevice: "nvme0n1",
+		},
+		"getting parent of partitioned NVMe blockdevice": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0/nvme/nvme0/nvme0n1/nvme0n1p1",
+			expectedParentBlockDevice: "nvme0n1",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			parentBlockDevice := getParentBlockDevice(test.syspath)
+			assert.Equal(t, test.expectedParentBlockDevice, parentBlockDevice)
+		})
+	}
+}

--- a/pkg/mount/mountutil_test.go
+++ b/pkg/mount/mountutil_test.go
@@ -213,6 +213,16 @@ func TestGetParentBlockDevice(t *testing.T) {
 			expectedParentBlockDevice: "nvme0n1",
 			expectedOk:                true,
 		},
+		"getting parent of wrong disk": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0/nvme/nvme0",
+			expectedParentBlockDevice: "",
+			expectedOk:                false,
+		},
+		"giving a wrong syspath": {
+			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0",
+			expectedParentBlockDevice: "",
+			expectedOk:                false,
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/mount/mountutil_test.go
+++ b/pkg/mount/mountutil_test.go
@@ -191,29 +191,35 @@ func TestGetParentBlockDevice(t *testing.T) {
 	tests := map[string]struct {
 		syspath                   string
 		expectedParentBlockDevice string
+		expectedOk                bool
 	}{
 		"getting parent of a main blockdevice itself": {
 			syspath:                   "/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda",
 			expectedParentBlockDevice: "sda",
+			expectedOk:                true,
 		},
 		"getting parent of a partition": {
 			syspath:                   "/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1",
 			expectedParentBlockDevice: "sda",
+			expectedOk:                true,
 		},
 		"getting parent of main NVMe blockdevice": {
 			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0/nvme/nvme0/nvme0n1",
 			expectedParentBlockDevice: "nvme0n1",
+			expectedOk:                true,
 		},
 		"getting parent of partitioned NVMe blockdevice": {
 			syspath:                   "/sys/devices/pci0000:00/0000:00:0e.0/nvme/nvme0/nvme0n1/nvme0n1p1",
 			expectedParentBlockDevice: "nvme0n1",
+			expectedOk:                true,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			parentBlockDevice := getParentBlockDevice(test.syspath)
+			parentBlockDevice, ok := getParentBlockDevice(test.syspath)
 			assert.Equal(t, test.expectedParentBlockDevice, parentBlockDevice)
+			assert.Equal(t, test.expectedOk, ok)
 		})
 	}
 }


### PR DESCRIPTION
nvme devices has a different syspath since it belongs to a different subsystem. Thus the nvme instance name need to be searched instead of the `block` keyword. This will help identify the parent disk.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>