### PR TITLE
cherry-pick(333) : Fixes device detection for KVM-based virtualization

### DIFF
--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -121,6 +121,7 @@ func (device *UdevDevice) GetUid() string {
 	localDiskModels := make([]string, 0)
 	localDiskModels = append(localDiskModels, "EphemeralDisk")
 	localDiskModels = append(localDiskModels, "Virtual_disk")
+	localDiskModels = append(localDiskModels, "QEMU_HARDDISK")
 	if len(idtype) == 0 || util.Contains(localDiskModels, model) {
 		// as hostNetwork is true, os.Hostname will give you the node's Hostname
 		host, _ := os.Hostname()


### PR DESCRIPTION
cherry-pick #333 for fixing disk identification issues on KVM host.

Signed-off-by: Aurelien Guillaume <aurelien@iwi.me>