### PR TITLE
logs formatted for easy parsing for sending alerts based on logs

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -35,13 +35,15 @@ func (c *Controller) CreateBlockDevice(blockDevice apis.BlockDevice) {
 	blockDeviceCopy := blockDevice.DeepCopy()
 	err := c.Clientset.Create(context.TODO(), blockDeviceCopy)
 	if err == nil {
-		klog.Info("Created blockdevice object in etcd: ",
-			blockDeviceCopy.ObjectMeta.Name)
+		klog.Info("eventcode=ndm.blockdevice.create.success",
+			"msg=Created blockdevice object in etcd", "rname=", blockDeviceCopy.ObjectMeta.Name)
 		return
 	}
 
 	if !errors.IsAlreadyExists(err) {
-		klog.Error("Creation of blockdevice object failed: ", err)
+		klog.Error("eventcode=ndm.blockdevice.create.failure",
+			"msg=Creation of blockdevice object failed: ", err,
+			"rname=", blockDeviceCopy.ObjectMeta.Name)
 		return
 	}
 
@@ -82,7 +84,9 @@ func (c *Controller) UpdateBlockDevice(blockDevice apis.BlockDevice, oldBlockDev
 			Namespace: oldBlockDevice.Namespace,
 			Name:      oldBlockDevice.Name}, oldBlockDevice)
 		if err != nil {
-			klog.Errorf("Unable to get blockdevice object:%v, err:%v", oldBlockDevice.ObjectMeta.Name, err)
+			klog.Errorf("eventcode=%s msg=%s reason=Unable to get blockdevice object:%v, err:%v rname=%s",
+				"ndm.blockdevice.update.failure", "Failed to update block device",
+				oldBlockDevice.ObjectMeta.Name, err, blockDeviceCopy.ObjectMeta.Name)
 			return err
 		}
 	}
@@ -92,10 +96,12 @@ func (c *Controller) UpdateBlockDevice(blockDevice apis.BlockDevice, oldBlockDev
 	blockDeviceCopy.Status.ClaimState = oldBlockDevice.Status.ClaimState
 	err = c.Clientset.Update(context.TODO(), blockDeviceCopy)
 	if err != nil {
-		klog.Error("Unable to update blockdevice object : ", err)
+		klog.Error("eventcode=ndm.blockdevice.update.failure",
+			"msg=Unable to update blockdevice object : ", err, "rname=", blockDeviceCopy.ObjectMeta.Name)
 		return err
 	}
-	klog.Info("Updated blockdevice object : ", blockDeviceCopy.ObjectMeta.Name)
+	klog.Info("eventcode=ndm.blockdevice.update.success",
+		"msg=Updated blockdevice object", "rname=", blockDeviceCopy.ObjectMeta.Name)
 	return nil
 }
 
@@ -106,10 +112,12 @@ func (c *Controller) DeactivateBlockDevice(blockDevice apis.BlockDevice) {
 	blockDeviceCopy.Status.State = NDMInactive
 	err := c.Clientset.Update(context.TODO(), blockDeviceCopy)
 	if err != nil {
-		klog.Error("Unable to deactivate blockdevice: ", err)
+		klog.Error("eventcode=ndm.blockdevice.deactivate.failure",
+			"msg=Unable to deactivate blockdevice: ", err, "rname=", blockDeviceCopy.ObjectMeta.Name)
 		return
 	}
-	klog.Info("Deactivated blockdevice: ", blockDeviceCopy.ObjectMeta.Name)
+	klog.Info("eventcode=ndm.blockdevice.deactivate.success",
+		"msg=Deactivated blockdevice", "rname=", blockDeviceCopy.ObjectMeta.Name)
 }
 
 // GetBlockDevice get Disk resource from etcd
@@ -137,10 +145,12 @@ func (c *Controller) DeleteBlockDevice(name string) {
 
 	err := c.Clientset.Delete(context.TODO(), blockDevice)
 	if err != nil {
-		klog.Error("Unable to delete blockdevice object : ", err)
+		klog.Error("eventcode=ndm.blockdevice.delete.failure",
+			"msg=Unable to delete blockdevice object : ", err, "rname=", name)
 		return
 	}
-	klog.Info("Deleted blockdevice object : ", name)
+	klog.Info("eventcode=ndm.blockdevice.delete.success",
+		"msg=Deleted blockdevice object", "rname=", name)
 }
 
 // ListBlockDeviceResource queries the etcd for the devices for the host/node

--- a/cmd/ndm_daemonset/controller/diskstore.go
+++ b/cmd/ndm_daemonset/controller/diskstore.go
@@ -31,7 +31,8 @@ func (c *Controller) CreateDisk(dr apis.Disk) {
 	drCopy := dr.DeepCopy()
 	err := c.Clientset.Create(context.TODO(), drCopy)
 	if err == nil {
-		klog.Info("Created disk object in etcd : ", drCopy.ObjectMeta.Name)
+		klog.Info("eventcode=ndm.disk.create.success", "msg=Created disk object in etcd",
+			"rname=", drCopy.ObjectMeta.Name)
 		return
 	}
 	/*
@@ -70,7 +71,8 @@ func (c *Controller) UpdateDisk(dr apis.Disk, oldDr *apis.Disk) error {
 			Namespace: oldDr.Namespace,
 			Name:      oldDr.Name}, oldDr)
 		if err != nil {
-			klog.Errorf("Unable to get disk object:%v, err:%v", oldDr.ObjectMeta.Name, err)
+			klog.Errorf("eventcode=%s msg=Unable to get disk object:%v, err:%v rname=%v",
+				"ndm.disk.update.failure", oldDr.ObjectMeta.Name, err, drCopy.ObjectMeta.Name)
 			return err
 		}
 	}
@@ -78,10 +80,12 @@ func (c *Controller) UpdateDisk(dr apis.Disk, oldDr *apis.Disk) error {
 	drCopy.ObjectMeta.ResourceVersion = oldDr.ObjectMeta.ResourceVersion
 	err := c.Clientset.Update(context.TODO(), drCopy)
 	if err != nil {
-		klog.Errorf("Unable to update disk object:%v, err:%v", drCopy.ObjectMeta.Name, err)
+		klog.Errorf("eventcode=%s msg=Unable to update disk object, err:%v rname=%v",
+			"ndm.disk.update.failure", err, drCopy.ObjectMeta.Name)
 		return err
 	}
-	klog.Infof("Updated disk object::%v successfully", drCopy.ObjectMeta.Name)
+	klog.Infof("eventcode=%s msg=Updated disk object successfully rname=%v",
+		"ndm.disk.update.success", drCopy.ObjectMeta.Name)
 	return nil
 }
 
@@ -91,10 +95,12 @@ func (c *Controller) DeactivateDisk(dr apis.Disk) {
 	drCopy.Status.State = NDMInactive
 	err := c.Clientset.Update(context.TODO(), drCopy)
 	if err != nil {
-		klog.Error("Unable to deactivate disk object : ", err)
+		klog.Error("eventcode=ndm.disk.deactivate.failure",
+			"msg=Unable to deactivate disk object : ", err, "rname=", drCopy.ObjectMeta.Name)
 		return
 	}
-	klog.Info("deactivate the disk object : ", drCopy.ObjectMeta.Name)
+	klog.Info("eventcode=ndm.disk.deactivate.success", "msg=Deactivated the disk object",
+		"rname=", drCopy.ObjectMeta.Name)
 }
 
 // GetDisk get Disk resource from etcd
@@ -122,10 +128,12 @@ func (c *Controller) DeleteDisk(name string) {
 
 	err := c.Clientset.Delete(context.TODO(), dr)
 	if err != nil {
-		klog.Error("Unable to delete disk object : ", err)
+		klog.Error("eventcode=ndm.disk.delete.failure",
+			"msg=Unable to delete disk object : ", err, "rname=", name)
 		return
 	}
-	klog.Info("Deleted disk object : ", name)
+	klog.Info("eventcode=ndm.disk.delete.success", "msg=Deleted disk object",
+		"rname=", name)
 }
 
 // ListDiskResource queries the etcd for the devices for the host/node


### PR DESCRIPTION
moved to klog

The purpose of this change is to help with generating alerts based on the log messages from all openebs components through elasticsearch and elastalert. It is easy to parse the logs and generate alerts if the log messages are all formatted in a predefined way.

Signed-off-by: moteesh <moteesh@gmail.com>