### PR TITLE
feat(build, version): add version and commit to builds

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -88,8 +88,15 @@ cd "$DIR"
 # Get the git commit
 GIT_COMMIT=$(getGitCommit)
 
-# Get the version details
-VERSION="beta"
+# Get the version details. By default set as ci.
+VERSION="ci"
+
+if [ -n "${TRAVIS_TAG}" ] ;
+then
+  # When github is tagged with a release, then Travis will
+  # set the release tag in env TRAVIS_TAG
+  VERSION="${TRAVIS_TAG}"
+fi;
 
 
 # Determine the arch/os combos we're building for

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openebs/node-disk-manager/pkg/upgrade"
 	"github.com/openebs/node-disk-manager/pkg/upgrade/v040_041"
 	"github.com/openebs/node-disk-manager/pkg/upgrade/v041_042"
+	"github.com/openebs/node-disk-manager/pkg/version"
 	"os"
 	"runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,6 +52,8 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	log.Info(fmt.Sprintf("Version Tag: %s", version.GetVersion()))
+	log.Info(fmt.Sprintf("Git Commit: %s", version.GetGitCommit()))
 }
 
 func main() {

--- a/cmd/ndm-exporter/cmd/root.go
+++ b/cmd/ndm-exporter/cmd/root.go
@@ -19,11 +19,9 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
-	"github.com/openebs/node-disk-manager/pkg/util"
-	"github.com/openebs/node-disk-manager/pkg/version"
+	ndm_exporter "github.com/openebs/node-disk-manager/ndm-exporter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 	"os"
 )
 
@@ -32,7 +30,7 @@ var rootCmd = &cobra.Command{
 	Use:   "exporter",
 	Short: "exporter can be used to expose block device metrics",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		util.CheckErr(RunNodeDiskExporter(cmd), util.Fatal)
+		ndm_exporter.RunNodeDiskExporter()
 	},
 }
 
@@ -43,14 +41,6 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-// RunNodeDiskExporter logs the starting of NDM exporter
-func RunNodeDiskExporter(cmd *cobra.Command) error {
-	klog.Infof("Starting NDM Exporter...")
-	klog.Infof("Version Tag : %v", version.GetVersion())
-	klog.Infof("GitCommit : %v", version.GetGitCommit())
-	return nil
 }
 
 func init() {

--- a/cmd/ndm-exporter/cmd/root.go
+++ b/cmd/ndm-exporter/cmd/root.go
@@ -19,8 +19,11 @@ package cmd
 import (
 	goflag "flag"
 	"fmt"
+	"github.com/openebs/node-disk-manager/pkg/util"
+	"github.com/openebs/node-disk-manager/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 	"os"
 )
 
@@ -28,6 +31,9 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "exporter",
 	Short: "exporter can be used to expose block device metrics",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		util.CheckErr(RunNodeDiskExporter(cmd), util.Fatal)
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -37,6 +43,14 @@ func Execute() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+// RunNodeDiskExporter logs the starting of NDM exporter
+func RunNodeDiskExporter(cmd *cobra.Command) error {
+	klog.Infof("Starting NDM Exporter...")
+	klog.Infof("Version Tag : %v", version.GetVersion())
+	klog.Infof("GitCommit : %v", version.GetGitCommit())
+	return nil
 }
 
 func init() {

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -18,11 +18,12 @@ package command
 
 import (
 	goflag "flag"
+	"github.com/openebs/node-disk-manager/pkg/version"
 
-	"k8s.io/klog"
 	"github.com/openebs/node-disk-manager/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 )
 
 // NewNodeDiskManager creates a new ndm.
@@ -31,7 +32,7 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "ndm",
 		Short: "ndm controls the Node-Disk-Manager ",
-		Run: func(cmd *cobra.Command, args []string) {
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(RunNodeDiskManager(cmd), util.Fatal)
 		},
 	}
@@ -47,9 +48,10 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 	return cmd, nil
 }
 
-// RunNodeDiskManager starts ndm process
+// RunNodeDiskManager logs the starting of NDM daemon
 func RunNodeDiskManager(cmd *cobra.Command) error {
-	klog.Infof("Starting node disk manager ...")
-
+	klog.Infof("Starting Node Device Manager Daemon...")
+	klog.Infof("Version Tag : %v", version.GetVersion())
+	klog.Infof("GitCommit : %v", version.GetGitCommit())
 	return nil
 }

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -51,7 +51,7 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 // RunNodeDiskManager logs the starting of NDM daemon
 func RunNodeDiskManager(cmd *cobra.Command) error {
 	klog.Infof("Starting Node Device Manager Daemon...")
-	klog.Infof("Version Tag : %v", version.GetVersion())
-	klog.Infof("GitCommit : %v", version.GetGitCommit())
+	klog.Infof("Version Tag : %s", version.GetVersion())
+	klog.Infof("GitCommit : %s", version.GetGitCommit())
 	return nil
 }

--- a/ndm-exporter/exporter.go
+++ b/ndm-exporter/exporter.go
@@ -51,8 +51,8 @@ const (
 // RunNodeDiskExporter logs the starting of NDM exporter
 func RunNodeDiskExporter() {
 	klog.Infof("Starting NDM Exporter...")
-	klog.Infof("Version Tag : %v", version.GetVersion())
-	klog.Infof("GitCommit : %v", version.GetGitCommit())
+	klog.Infof("Version Tag : %s", version.GetVersion())
+	klog.Infof("GitCommit : %s", version.GetGitCommit())
 }
 
 // Run starts the exporter, depending on the mode of startup of the exporter

--- a/ndm-exporter/exporter.go
+++ b/ndm-exporter/exporter.go
@@ -22,8 +22,10 @@ import (
 	"github.com/openebs/node-disk-manager/db/kubernetes"
 	"github.com/openebs/node-disk-manager/ndm-exporter/collector"
 	"github.com/openebs/node-disk-manager/pkg/server"
+	"github.com/openebs/node-disk-manager/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -45,6 +47,13 @@ const (
 	// MetricsPath is the endpoint at which metrics will be available
 	MetricsPath = "/metrics"
 )
+
+// RunNodeDiskExporter logs the starting of NDM exporter
+func RunNodeDiskExporter() {
+	klog.Infof("Starting NDM Exporter...")
+	klog.Infof("Version Tag : %v", version.GetVersion())
+	klog.Infof("GitCommit : %v", version.GetGitCommit())
+}
 
 // Run starts the exporter, depending on the mode of startup of the exporter
 func (e *Exporter) Run() error {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+package version
+
+var (
+	// Version is the version filled in by the compiler
+	Version string
+	// GitCommit is the git commit filled in by the compiler
+	GitCommit string
+)
+
+// GetVersion returns the version of NDM
+func GetVersion() string {
+	return Version
+}
+
+// GetGitCommit returns commit from which this version is compiled
+func GetGitCommit() string {
+	return GitCommit
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package version
 
 var (


### PR DESCRIPTION
`Version` and `GitCommit` is now added as part of NDM build. This will enable the binaries to log commit from which the build was generated and also the version of NDM. 
By default `ci` will be the version used. For releases and RC builds the tags will be used as version.