### PR TITLE
refact(client): refact kubernetes client 

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -42,28 +42,24 @@ type BlockDevice struct {
 
 // NodeAttribute is the representing the various attributes of the machine
 // on which this block device is present
-type NodeAttribute map[NodeAttributeKey]string
-
-// NodeAttributeKey is a typed string for representing the keys in the
-// node attribute map
-type NodeAttributeKey string
+type NodeAttribute map[string]string
 
 const (
 	// HostName is the hostname of the system on which this BD is present
-	HostName NodeAttributeKey = "hostname"
+	HostName string = "hostname"
 
 	// NodeName is the nodename (may be FQDN) on which this BD is present
-	NodeName NodeAttributeKey = "nodename"
+	NodeName string = "nodename"
 
 	// ZoneName is the zone in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	ZoneName NodeAttributeKey = "zone"
+	ZoneName string = "zone"
 
 	// RegionName is the region in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	RegionName NodeAttributeKey = "region"
+	RegionName string = "region"
 )
 
 const (

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -36,6 +36,9 @@ type BlockDevice struct {
 	// BlockDevice if it exists
 	FSInfo FileSystemInformation
 
+	// DeviceType is the type of the blockdevice. can be sparse/disk/partition etc
+	DeviceType string
+
 	// Status contains the state of the blockdevice
 	Status Status
 }

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -36,34 +36,36 @@ type BlockDevice struct {
 	// BlockDevice if it exists
 	FSInfo FileSystemInformation
 
+	// DeviceType is the type of the blockdevice. can be sparse/disk/partition etc
+	DeviceType string
+
+	// DriveType is the type of the backing drive. can be HDD/SSD etc
+	DriveType string
+
 	// Status contains the state of the blockdevice
 	Status Status
 }
 
 // NodeAttribute is the representing the various attributes of the machine
 // on which this block device is present
-type NodeAttribute map[NodeAttributeKey]string
-
-// NodeAttributeKey is a typed string for representing the keys in the
-// node attribute map
-type NodeAttributeKey string
+type NodeAttribute map[string]string
 
 const (
 	// HostName is the hostname of the system on which this BD is present
-	HostName NodeAttributeKey = "hostname"
+	HostName string = "hostname"
 
 	// NodeName is the nodename (may be FQDN) on which this BD is present
-	NodeName NodeAttributeKey = "nodename"
+	NodeName string = "nodename"
 
 	// ZoneName is the zone in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	ZoneName NodeAttributeKey = "zone"
+	ZoneName string = "zone"
 
 	// RegionName is the region in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	RegionName NodeAttributeKey = "region"
+	RegionName string = "region"
 )
 
 const (

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -36,36 +36,34 @@ type BlockDevice struct {
 	// BlockDevice if it exists
 	FSInfo FileSystemInformation
 
-	// DeviceType is the type of the blockdevice. can be sparse/disk/partition etc
-	DeviceType string
-
-	// DriveType is the type of the backing drive. can be HDD/SSD etc
-	DriveType string
-
 	// Status contains the state of the blockdevice
 	Status Status
 }
 
 // NodeAttribute is the representing the various attributes of the machine
 // on which this block device is present
-type NodeAttribute map[string]string
+type NodeAttribute map[NodeAttributeKey]string
+
+// NodeAttributeKey is a typed string for representing the keys in the
+// node attribute map
+type NodeAttributeKey string
 
 const (
 	// HostName is the hostname of the system on which this BD is present
-	HostName string = "hostname"
+	HostName NodeAttributeKey = "hostname"
 
 	// NodeName is the nodename (may be FQDN) on which this BD is present
-	NodeName string = "nodename"
+	NodeName NodeAttributeKey = "nodename"
 
 	// ZoneName is the zone in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	ZoneName string = "zone"
+	ZoneName NodeAttributeKey = "zone"
 
 	// RegionName is the region in which the system is present.
 	//
 	// NOTE: Valid only for cloud providers
-	RegionName string = "region"
+	RegionName NodeAttributeKey = "region"
 )
 
 const (

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -98,4 +98,13 @@ const (
 	Inactive string = "Inactive"
 	// Unknown means the state cannot be determined at this point of time
 	Unknown string = "Unknown"
+
+	// Claimed means the blockdevice is in use
+	Claimed string = "Claimed"
+	// Released means the blockdevice is not in use, but cannot be claimed,
+	// because of some pending cleanup tasks
+	Released string = "Released"
+	// Unclaimed means the blockdevice is free and is availbale for
+	// claiming
+	Unclaimed string = "Unclaimed"
 )

--- a/cmd/ndm-exporter/cmd/root.go
+++ b/cmd/ndm-exporter/cmd/root.go
@@ -22,7 +22,6 @@ import (
 	ndm_exporter "github.com/openebs/node-disk-manager/ndm-exporter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 	"os"
 )
 

--- a/cmd/ndm-exporter/cmd/root.go
+++ b/cmd/ndm-exporter/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	ndm_exporter "github.com/openebs/node-disk-manager/ndm-exporter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 	"os"
 )
 

--- a/db/kubernetes/client.go
+++ b/db/kubernetes/client.go
@@ -64,7 +64,7 @@ func New() (Client, error) {
 
 	c.cfg = cfg
 
-	klog.V(2).Info("Client cfg created.")
+	klog.V(2).Info("Client config created.")
 
 	err = c.setNamespace()
 	if err != nil {
@@ -72,7 +72,7 @@ func New() (Client, error) {
 		return c, err
 	}
 
-	klog.V(2).Info("Namespace set for the client")
+	klog.V(2).Infof("Namespace \"%s\" set for the client", c.namespace)
 
 	err = c.InitClient()
 	if err != nil {

--- a/db/kubernetes/client.go
+++ b/db/kubernetes/client.go
@@ -32,6 +32,11 @@ import (
 	"strings"
 )
 
+const (
+	// NamespaceENV is the name of environment variable to get the namespace
+	NamespaceENV = "NAMESPACE"
+)
+
 // Client is the wrapper over the k8s client that will be used by
 // NDM to interface with etcd
 type Client struct {
@@ -108,7 +113,7 @@ func (cl *Client) RegisterAPI() error {
 
 // setNamespace sets the namespace in which NDM is running
 func (cl *Client) setNamespace() error {
-	ns, ok := os.LookupEnv("NAMESPACE")
+	ns, ok := os.LookupEnv(NamespaceENV)
 	if !ok {
 		return fmt.Errorf("error getting namespace from ENV variable")
 	}
@@ -147,7 +152,7 @@ func (cl *Client) ListBlockDevice(filters ...string) ([]blockdevice.BlockDevice,
 		return blockDeviceList, err
 	}
 
-	klog.V(4).Infof("no of blockdevices listed :", len(blockDeviceList))
+	klog.V(4).Infof("no of blockdevices listed : %d", len(blockDeviceList))
 
 	return blockDeviceList, nil
 }

--- a/db/kubernetes/client.go
+++ b/db/kubernetes/client.go
@@ -35,6 +35,9 @@ import (
 type Client struct {
 	cfg    *rest.Config
 	client client.Client
+
+	// namespace in which this client is operating
+	namespace string
 }
 
 // New creates a new client object using the default config
@@ -85,7 +88,7 @@ func (cl *Client) SetClient(client2 client.Client) {
 // RegisterAPI registers the API scheme in the client using the manager.
 // This function needs to be called only once a client object
 func (cl *Client) RegisterAPI() error {
-	mgr, err := manager.New(cl.cfg, manager.Options{})
+	mgr, err := manager.New(cl.cfg, manager.Options{Namespace: cl.namespace})
 	if err != nil {
 		return err
 	}
@@ -107,7 +110,7 @@ func (cl *Client) ListBlockDevice(filters ...string) ([]blockdevice.BlockDevice,
 		},
 	}
 
-	listOptions := &client.ListOptions{}
+	listOptions := &client.ListOptions{Namespace: cl.namespace}
 
 	// apply the filter only if any filters are provided
 	if len(filters) != 0 {

--- a/db/kubernetes/client.go
+++ b/db/kubernetes/client.go
@@ -63,13 +63,6 @@ func New() (Client, error) {
 	return c, nil
 }
 
-/*
-3 functions should be there.
-1. Create a new client, with no args. New() Clinet, err
-2. Initialize the client from available config. InitClient() err
-3. sets the given client without using config. SetClient(Client) err
-*/
-
 // InitClient sets the client using the config
 func (cl *Client) InitClient() error {
 	c, err := client.New(cl.cfg, client.Options{})

--- a/db/kubernetes/client.go
+++ b/db/kubernetes/client.go
@@ -19,17 +19,18 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/pkg/apis"
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"strings"
 )
 
 const (

--- a/db/kubernetes/client_test.go
+++ b/db/kubernetes/client_test.go
@@ -1,0 +1,91 @@
+package kubernetes
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestClientListBlockDevice(t *testing.T) {
+	type fields struct {
+		cfg       *rest.Config
+		client    client.Client
+		namespace string
+	}
+	type args struct {
+		filters []string
+	}
+	tests := map[string]struct {
+		fields  fields
+		args    args
+		want    []blockdevice.BlockDevice
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cl := &Client{
+				cfg:       test.fields.cfg,
+				client:    test.fields.client,
+				namespace: test.fields.namespace,
+			}
+			got, err := cl.ListBlockDevice(test.args.filters...)
+			if (err != nil) != test.wantErr {
+				t.Errorf("ListBlockDevice() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("ListBlockDevice() got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestClientsetNamespace(t *testing.T) {
+
+	fakeNamespace := "openebs"
+	cl := &Client{}
+
+	// setting namespace in client when env is not available
+	err1 := cl.setNamespace()
+	ns1 := cl.namespace
+
+	//setting namespace environment variable
+	_ = os.Setenv(NamespaceENV, fakeNamespace)
+
+	// setting namespace in client when env is available
+	err2 := cl.setNamespace()
+	ns2 := cl.namespace
+
+	tests := map[string]struct {
+		wantNamespace string
+		gotNamespace  string
+		wantErr       bool
+		gotErr        error
+	}{
+		"when NAMESPACE env is not available": {
+			ns1,
+			"",
+			true,
+			err1,
+		},
+		"when NAMESPACE env is available": {
+			ns2,
+			fakeNamespace,
+			false,
+			err2,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.wantNamespace, test.gotNamespace)
+			assert.Equal(t, test.wantErr, test.gotErr != nil)
+		})
+	}
+}

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -49,7 +49,7 @@ func convert_BlockDeviceAPI_To_BlockDevice(in *api.BlockDevice, out *blockdevice
 	// currently only the first mount point is filled in. When API is changed, multiple mount points
 	// will be added.
 	out.FSInfo.MountPoint = make([]string, 0)
-	out.FSInfo.MountPoint[0] = in.Spec.FileSystem.Mountpoint
+	out.FSInfo.MountPoint = append(out.FSInfo.MountPoint, in.Spec.FileSystem.Mountpoint)
 	out.DeviceType = in.Spec.Details.DeviceType
 
 	//status

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -48,7 +48,6 @@ func convert_BlockDeviceAPI_To_BlockDevice(in *api.BlockDevice, out *blockdevice
 
 	// currently only the first mount point is filled in. When API is changed, multiple mount points
 	// will be added.
-	out.FSInfo.MountPoint = make([]string, 0)
 	out.FSInfo.MountPoint = append(out.FSInfo.MountPoint, in.Spec.FileSystem.Mountpoint)
 	out.DeviceType = in.Spec.Details.DeviceType
 

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -2,10 +2,10 @@ package kubernetes
 
 import (
 	"github.com/openebs/node-disk-manager/blockdevice"
-	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	api "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 )
 
-func convert_BlockDeviceAPIList_To_BlockDeviceList(in *v1alpha1.BlockDeviceList, out *[]blockdevice.BlockDevice) error {
+func convert_BlockDeviceAPIList_To_BlockDeviceList(in *api.BlockDeviceList, out *[]blockdevice.BlockDevice) error {
 	var err error
 	var bd blockdevice.BlockDevice
 
@@ -19,7 +19,7 @@ func convert_BlockDeviceAPIList_To_BlockDeviceList(in *v1alpha1.BlockDeviceList,
 	return nil
 }
 
-func convert_BlockDeviceAPI_To_BlockDevice(in *v1alpha1.BlockDevice, out *blockdevice.BlockDevice) error {
+func convert_BlockDeviceAPI_To_BlockDevice(in *api.BlockDevice, out *blockdevice.BlockDevice) error {
 	out.UUID = in.Name
 
 	//labels
@@ -29,7 +29,6 @@ func convert_BlockDeviceAPI_To_BlockDevice(in *v1alpha1.BlockDevice, out *blockd
 	//spec
 	out.Path = in.Spec.Path
 	out.FSInfo.FileSystem = in.Spec.FileSystem.Type
-	out.DeviceType = in.Spec.Details.DeviceType
 
 	// currently only the first mount point is filled in. When API is changed, multiple mount points
 	// will be added.

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -1,0 +1,44 @@
+package kubernetes
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+)
+
+func convert_BlockDeviceAPIList_To_BlockDeviceList(in *v1alpha1.BlockDeviceList, out *[]blockdevice.BlockDevice) error {
+	var err error
+	var bd blockdevice.BlockDevice
+
+	for _, bdAPI := range in.Items {
+		err = convert_BlockDeviceAPI_To_BlockDevice(&bdAPI, &bd)
+		if err != nil {
+			return err
+		}
+		*out = append(*out, bd)
+	}
+	return nil
+}
+
+func convert_BlockDeviceAPI_To_BlockDevice(in *v1alpha1.BlockDevice, out *blockdevice.BlockDevice) error {
+	out.UUID = in.Name
+
+	//labels
+	out.NodeAttributes = make(blockdevice.NodeAttribute)
+	out.NodeAttributes[blockdevice.HostName] = in.Labels[KubernetesHostNameLabel]
+
+	//spec
+	out.Path = in.Spec.Path
+	out.FSInfo.FileSystem = in.Spec.FileSystem.Type
+	out.DeviceType = in.Spec.Details.DeviceType
+
+	// currently only the first mount point is filled in. When API is changed, multiple mount points
+	// will be added.
+	out.FSInfo.MountPoint = make([]string, 0)
+	out.FSInfo.MountPoint[0] = in.Spec.FileSystem.Mountpoint
+
+	//status
+	out.Status.State = string(in.Status.State)
+	out.Status.ClaimPhase = string(in.Status.ClaimState)
+
+	return nil
+}

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -34,6 +34,7 @@ func convert_BlockDeviceAPI_To_BlockDevice(in *api.BlockDevice, out *blockdevice
 	// will be added.
 	out.FSInfo.MountPoint = make([]string, 0)
 	out.FSInfo.MountPoint[0] = in.Spec.FileSystem.Mountpoint
+	out.DeviceType = in.Spec.Details.DeviceType
 
 	//status
 	out.Status.State = string(in.Status.State)

--- a/db/kubernetes/convert_test.go
+++ b/db/kubernetes/convert_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openebs/node-disk-manager/blockdevice"
+	api "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_convert_BlockDeviceAPI_To_BlockDevice(t *testing.T) {
+	type args struct {
+		in      *api.BlockDevice
+		wantOut *blockdevice.BlockDevice
+	}
+
+	fakeBDName := "my-fake-bd"
+	fakeHostName := "fake-hostname"
+	fakeDevicePath := "/dev/sdf1"
+	fileSystem := "ext4"
+	mountPoint := "/mnt/media"
+	deviceType := blockdevice.SparseBlockDeviceType
+
+	// building the blockdevice API object
+	in1 := createFakeBlockDeviceAPI(fakeBDName)
+	in1.Labels[KubernetesHostNameLabel] = fakeHostName
+	in1.Spec.Path = fakeDevicePath
+	in1.Spec.FileSystem.Type = fileSystem
+	in1.Spec.FileSystem.Mountpoint = mountPoint
+	in1.Spec.Details.DeviceType = deviceType
+	in1.Status.State = api.BlockDeviceState(blockdevice.Active)
+	in1.Status.ClaimState = api.DeviceClaimState(blockdevice.Claimed)
+
+	// building the core blockdevice object
+	out1 := createFakeBlockDevice(fakeBDName)
+	out1.NodeAttributes[blockdevice.HostName] = fakeHostName
+	out1.Path = fakeDevicePath
+	out1.FSInfo.FileSystem = fileSystem
+	out1.FSInfo.MountPoint = append(out1.FSInfo.MountPoint, mountPoint)
+	out1.DeviceType = blockdevice.SparseBlockDeviceType
+	out1.Status.State = blockdevice.Active
+	out1.Status.ClaimPhase = blockdevice.Claimed
+
+	tests := map[string]struct {
+		args    args
+		wantErr bool
+	}{
+		"converting block device k8s resource to BlockDevice": {
+			args: args{
+				in:      in1,
+				wantOut: out1,
+			},
+			wantErr: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gotOut := &blockdevice.BlockDevice{}
+			err := convert_BlockDeviceAPI_To_BlockDevice(test.args.in, gotOut)
+			assert.Equal(t, test.wantErr, err != nil)
+
+			assert.Equal(t, test.args.wantOut.UUID, gotOut.UUID)
+			// compare the Node attribute map
+			assert.Equal(t, true, reflect.DeepEqual(test.args.wantOut.NodeAttributes, gotOut.NodeAttributes))
+			assert.Equal(t, test.args.wantOut.Path, gotOut.Path)
+			assert.Equal(t, test.args.wantOut.FSInfo.FileSystem, gotOut.FSInfo.FileSystem)
+
+			// comparing the first element of slice for now.
+			// TODO change to range and compare all elements when NDM supports multiple mountpoints
+			assert.Equal(t, test.args.wantOut.FSInfo.MountPoint, gotOut.FSInfo.MountPoint)
+
+			assert.Equal(t, test.args.wantOut.Status.State, gotOut.Status.State)
+			assert.Equal(t, test.args.wantOut.Status.ClaimPhase, gotOut.Status.ClaimPhase)
+		})
+	}
+}

--- a/db/kubernetes/convert_test.go
+++ b/db/kubernetes/convert_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package kubernetes
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/openebs/node-disk-manager/blockdevice"
@@ -74,20 +73,8 @@ func Test_convert_BlockDeviceAPI_To_BlockDevice(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			gotOut := &blockdevice.BlockDevice{}
 			err := convert_BlockDeviceAPI_To_BlockDevice(test.args.in, gotOut)
+			assert.Equal(t, test.args.wantOut, gotOut)
 			assert.Equal(t, test.wantErr, err != nil)
-
-			assert.Equal(t, test.args.wantOut.UUID, gotOut.UUID)
-			// compare the Node attribute map
-			assert.Equal(t, true, reflect.DeepEqual(test.args.wantOut.NodeAttributes, gotOut.NodeAttributes))
-			assert.Equal(t, test.args.wantOut.Path, gotOut.Path)
-			assert.Equal(t, test.args.wantOut.FSInfo.FileSystem, gotOut.FSInfo.FileSystem)
-
-			// comparing the first element of slice for now.
-			// TODO change to range and compare all elements when NDM supports multiple mountpoints
-			assert.Equal(t, test.args.wantOut.FSInfo.MountPoint, gotOut.FSInfo.MountPoint)
-
-			assert.Equal(t, test.args.wantOut.Status.State, gotOut.Status.State)
-			assert.Equal(t, test.args.wantOut.Status.ClaimPhase, gotOut.Status.ClaimPhase)
 		})
 	}
 }

--- a/db/kubernetes/fake_test.go
+++ b/db/kubernetes/fake_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	api "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+)
+
+func createFakeBlockDevice(uuid string) *blockdevice.BlockDevice {
+	mountPoints := make([]string, 0)
+
+	bd := &blockdevice.BlockDevice{
+		UUID: uuid,
+	}
+	// init all fields which require memory
+	bd.NodeAttributes = make(map[string]string)
+	bd.FSInfo = blockdevice.FileSystemInformation{
+		MountPoint: mountPoints,
+	}
+	return bd
+}
+
+func createFakeBlockDeviceAPI(name string) *api.BlockDevice {
+	bdAPI := &api.BlockDevice{}
+	bdAPI.Name = name
+	bdAPI.Labels = make(map[string]string)
+	return bdAPI
+}

--- a/db/kubernetes/fake_test.go
+++ b/db/kubernetes/fake_test.go
@@ -22,16 +22,12 @@ import (
 )
 
 func createFakeBlockDevice(uuid string) *blockdevice.BlockDevice {
-	mountPoints := make([]string, 0)
 
 	bd := &blockdevice.BlockDevice{
 		UUID: uuid,
 	}
 	// init all fields which require memory
 	bd.NodeAttributes = make(map[string]string)
-	bd.FSInfo = blockdevice.FileSystemInformation{
-		MountPoint: mountPoints,
-	}
 	return bd
 }
 

--- a/db/kubernetes/filter.go
+++ b/db/kubernetes/filter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import "github.com/openebs/node-disk-manager/blockdevice"

--- a/db/kubernetes/filter.go
+++ b/db/kubernetes/filter.go
@@ -1,0 +1,18 @@
+package kubernetes
+
+import "github.com/openebs/node-disk-manager/blockdevice"
+
+const (
+	kubernetesLabelPrefix   = "kubernetes.io/"
+	KubernetesHostNameLabel = kubernetesLabelPrefix + blockdevice.HostName
+)
+
+func GenerateFilter(key, value string) string {
+	var filterKey string
+	if key == blockdevice.HostName {
+		filterKey = KubernetesHostNameLabel
+	}
+
+	filterString := filterKey + "=" + value
+	return filterString
+}

--- a/db/kubernetes/filter.go
+++ b/db/kubernetes/filter.go
@@ -7,10 +7,23 @@ const (
 	KubernetesHostNameLabel = kubernetesLabelPrefix + blockdevice.HostName
 )
 
-func GenerateFilter(key, value string) string {
+// GenerateLabelFilter is used to generate a label filter that can be used
+// while listing resources
+func GenerateLabelFilter(key, value string) string {
 	var filterKey string
-	if key == blockdevice.HostName {
+
+	// if key or value is empty, filter will be empty string
+	if len(key) == 0 ||
+		len(value) == 0 {
+		return ""
+	}
+
+	// depending on the key, the filter key will be different
+	switch key {
+	case blockdevice.HostName:
 		filterKey = KubernetesHostNameLabel
+	default:
+		filterKey = key
 	}
 
 	filterString := filterKey + "=" + value

--- a/db/kubernetes/filter.go
+++ b/db/kubernetes/filter.go
@@ -3,7 +3,10 @@ package kubernetes
 import "github.com/openebs/node-disk-manager/blockdevice"
 
 const (
-	kubernetesLabelPrefix   = "kubernetes.io/"
+	// kubernetesLabelPrefix is the label prefix for kubernetes
+	kubernetesLabelPrefix = "kubernetes.io/"
+
+	// KubernetesHostNameLabel is the kubernetes hostname label
 	KubernetesHostNameLabel = kubernetesLabelPrefix + blockdevice.HostName
 )
 

--- a/db/kubernetes/filter_test.go
+++ b/db/kubernetes/filter_test.go
@@ -1,0 +1,60 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateLabelFilter(t *testing.T) {
+	type args struct {
+		key   string
+		value string
+	}
+	tests := map[string]struct {
+		args args
+		want string
+	}{
+		"when key is empty": {
+			args: args{
+				key:   "",
+				value: "machine1",
+			},
+			want: "",
+		},
+		"when value is empty": {
+			args: args{
+				key:   "hostname",
+				value: "",
+			},
+			want: "",
+		},
+		"when both key and value are empty": {
+			args: args{
+				key:   "",
+				value: "",
+			},
+			want: "",
+		},
+		"when valid key and value is given": {
+			args: args{
+				key:   "ndm.io/managed",
+				value: "false",
+			},
+			want: "ndm.io/managed=false",
+		},
+		"when a valid hostname key is present": {
+			args: args{
+				key:   "hostname",
+				value: "machine1",
+			},
+			want: "kubernetes.io/hostname=machine1",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := GenerateLabelFilter(test.args.key, test.args.value)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/db/kubernetes/filter_test.go
+++ b/db/kubernetes/filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (

--- a/ndm-exporter/collector/static.go
+++ b/ndm-exporter/collector/static.go
@@ -17,11 +17,12 @@ limitations under the License.
 package collector
 
 import (
+	"sync"
+
 	"github.com/openebs/node-disk-manager/db/kubernetes"
 	"github.com/openebs/node-disk-manager/pkg/metrics/static"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog"
-	"sync"
 )
 
 // StaticMetricCollector contains the metrics, concurrency handler and client to get the

--- a/ndm-exporter/collector/static.go
+++ b/ndm-exporter/collector/static.go
@@ -17,7 +17,6 @@ limitations under the License.
 package collector
 
 import (
-	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/db/kubernetes"
 	"github.com/openebs/node-disk-manager/pkg/metrics/static"
 	"github.com/prometheus/client_golang/prometheus"

--- a/ndm-exporter/collector/static.go
+++ b/ndm-exporter/collector/static.go
@@ -18,7 +18,6 @@ package collector
 
 import (
 	"github.com/openebs/node-disk-manager/blockdevice"
-	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/db/kubernetes"
 	"github.com/openebs/node-disk-manager/pkg/metrics/static"
 	"github.com/prometheus/client_golang/prometheus"
@@ -88,15 +87,15 @@ func (mc *StaticMetricCollector) Collect(ch chan<- prometheus.Metric) {
 	klog.V(4).Info("Setting client for this request.")
 
 	// set the client each time
-	if err := mc.Client.Set(); err != nil {
+	if err := mc.Client.InitClient(); err != nil {
 		klog.Errorf("error setting client. %v", err)
 		mc.metrics.IncErrorRequestCounter()
 		mc.collectErrors(ch)
 		return
 	}
 
-	// get required metric data from etcd
-	blockDevices, err := mc.getMetricData()
+	// get list of blockdevices from etcd
+	blockDevices, err := mc.Client.ListBlockDevice()
 	if err != nil {
 		mc.metrics.IncErrorRequestCounter()
 		mc.collectErrors(ch)
@@ -114,39 +113,6 @@ func (mc *StaticMetricCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, col := range mc.metrics.Collectors() {
 		col.Collect(ch)
 	}
-}
-
-// getMetricData is used to get the metric data from the source
-func (mc *StaticMetricCollector) getMetricData() ([]blockdevice.BlockDevice, error) {
-	bdList, err := mc.Client.ListBlockDevice()
-	if err != nil {
-		klog.Error("error listing BDs for metrics collection. ", err)
-		return nil, err
-	}
-
-	klog.V(4).Infof("No. of BlockDevices fetched from etcd: %d", len(bdList))
-
-	// convert the BD api to BlockDevice struct used by NDM internally
-	blockDevices := make([]blockdevice.BlockDevice, 0)
-	for _, bd := range bdList {
-		// metrics will not be exposed for sparse block devices
-		if bd.Spec.Details.DeviceType == blockdevice.SparseBlockDeviceType {
-			continue
-		}
-		blockDevice := blockdevice.BlockDevice{
-			NodeAttributes: make(blockdevice.NodeAttribute, 0),
-		}
-		// copy values from api to BlockDevice struct
-		blockDevice.UUID = bd.Name
-		blockDevice.NodeAttributes[blockdevice.HostName] = bd.Labels[controller.KubernetesHostNameLabel]
-		blockDevice.NodeAttributes[blockdevice.NodeName] = bd.Spec.NodeAttributes.NodeName
-		blockDevice.Path = bd.Spec.Path
-		// setting the block device status
-		blockDevice.Status.State = string(bd.Status.State)
-		blockDevices = append(blockDevices, blockDevice)
-		klog.V(4).Infof("BlockDevice %+v processed", blockDevice)
-	}
-	return blockDevices, nil
 }
 
 // collectErrors collects only the error metrics and set it on the channel

--- a/ndm-exporter/exporter.go
+++ b/ndm-exporter/exporter.go
@@ -18,6 +18,7 @@ package ndm_exporter
 
 import (
 	"fmt"
+
 	"github.com/openebs/node-disk-manager/db/kubernetes"
 	"github.com/openebs/node-disk-manager/ndm-exporter/collector"
 	"github.com/openebs/node-disk-manager/pkg/server"

--- a/ndm-exporter/exporter.go
+++ b/ndm-exporter/exporter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 // Exporter contains the options for starting the exporter along with
@@ -63,17 +62,8 @@ func (e *Exporter) Run() error {
 		return fmt.Errorf("unknown mode '%s' selected for starting exporter", e.Mode)
 	}
 
-	// get the kube config
-	cfg, err := config.GetConfig()
-	if err != nil {
-		klog.Errorf("error getting config. %v", err)
-		return err
-	}
-
-	klog.V(2).Info("Client config created.")
-
 	// generate a new client object
-	e.Client, err = kubernetes.New(cfg)
+	e.Client, err = kubernetes.New()
 	if err != nil {
 		klog.Errorf("error creating client from config. %v", err)
 		return err

--- a/pkg/metrics/static/metrics.go
+++ b/pkg/metrics/static/metrics.go
@@ -108,6 +108,10 @@ func (m *Metrics) withErrorRequest() *Metrics {
 // SetMetrics is used to set the prometheus metrics to resepective fields
 func (m *Metrics) SetMetrics(blockDevices []bd.BlockDevice) {
 	for _, blockDevice := range blockDevices {
+		// do not report metrics for sparse devices
+		if blockDevice.DeviceType == bd.SparseBlockDeviceType {
+			continue
+		}
 		// remove /dev from the device path so that the device path is similar to the
 		// path given by node exporter
 		path := strings.ReplaceAll(blockDevice.Path, "/dev/", "")

--- a/pkg/metrics/static/metrics.go
+++ b/pkg/metrics/static/metrics.go
@@ -17,9 +17,10 @@ limitations under the License.
 package static
 
 import (
+	"strings"
+
 	bd "github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/prometheus/client_golang/prometheus"
-	"strings"
 )
 
 const (


### PR DESCRIPTION
refactor the kubernetes client code:
- add functions to convert from k8s API to core BlockDevice struct
- add methods to generate filter specific to kubernetes
- make namespace a part of the k8s client