### PR TITLE
 feat(exporter): add collector for fetching metrics using seachest library

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -114,6 +114,9 @@ type BlockDevice struct {
 	// eg: dm-0 is a slave to sda1. Then the list of dm-0 will contain sda1
 	Slaves []string
 
+	// TemperatureInfo stores the temperature information of the drive
+	TemperatureInfo TemperatureInformation
+
 	// Status contains the state of the blockdevice
 	Status Status
 }
@@ -154,6 +157,16 @@ type FileSystemInformation struct {
 
 	// MountPoint is the list of mountpoints at which this blockdevice is mounted
 	MountPoint []string
+}
+
+// TemperatureInformation stores the temperature information of the blockdevice
+type TemperatureInformation struct {
+	// TemperatureDataValid specifies whether the current temperature
+	// data reported is valid or not
+	TemperatureDataValid bool
+
+	// CurrentTemperature is the temperature of the drive in celsius
+	CurrentTemperature int16
 }
 
 // Status is used to represent the status of the blockdevice

--- a/db/kubernetes/convert.go
+++ b/db/kubernetes/convert.go
@@ -41,6 +41,7 @@ func convert_BlockDeviceAPI_To_BlockDevice(in *api.BlockDevice, out *blockdevice
 	//labels
 	out.NodeAttributes = make(blockdevice.NodeAttribute)
 	out.NodeAttributes[blockdevice.HostName] = in.Labels[KubernetesHostNameLabel]
+	out.NodeAttributes[blockdevice.NodeName] = in.Spec.NodeAttributes.NodeName
 
 	//spec
 	out.Path = in.Spec.Path

--- a/db/kubernetes/convert_test.go
+++ b/db/kubernetes/convert_test.go
@@ -32,6 +32,7 @@ func Test_convert_BlockDeviceAPI_To_BlockDevice(t *testing.T) {
 
 	fakeBDName := "my-fake-bd"
 	fakeHostName := "fake-hostname"
+	fakeNodeName := "fake-machine"
 	fakeDevicePath := "/dev/sdf1"
 	fileSystem := "ext4"
 	mountPoint := "/mnt/media"
@@ -40,6 +41,7 @@ func Test_convert_BlockDeviceAPI_To_BlockDevice(t *testing.T) {
 	// building the blockdevice API object
 	in1 := createFakeBlockDeviceAPI(fakeBDName)
 	in1.Labels[KubernetesHostNameLabel] = fakeHostName
+	in1.Spec.NodeAttributes.NodeName = fakeNodeName
 	in1.Spec.Path = fakeDevicePath
 	in1.Spec.FileSystem.Type = fileSystem
 	in1.Spec.FileSystem.Mountpoint = mountPoint
@@ -50,6 +52,7 @@ func Test_convert_BlockDeviceAPI_To_BlockDevice(t *testing.T) {
 	// building the core blockdevice object
 	out1 := createFakeBlockDevice(fakeBDName)
 	out1.NodeAttributes[blockdevice.HostName] = fakeHostName
+	out1.NodeAttributes[blockdevice.NodeName] = fakeNodeName
 	out1.Path = fakeDevicePath
 	out1.FSInfo.FileSystem = fileSystem
 	out1.FSInfo.MountPoint = append(out1.FSInfo.MountPoint, mountPoint)

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package collector
 
 import (

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -143,6 +143,10 @@ func GetMetricData(bds []blockdevice.BlockDevice) error {
 	var err error
 	ok := false
 	for i, bd := range bds {
+		// do not report metrics for sparse devices
+		if bd.DeviceType == blockdevice.SparseBlockDeviceType {
+			continue
+		}
 		sc := SeachestMetricData{
 			SeachestIdentifier: &seachest.Identifier{
 				DevPath: bd.Path,

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -115,7 +115,7 @@ func (sc *SeachestCollector) Collect(ch chan<- prometheus.Metric) {
 
 	klog.V(4).Info("Blockdevices fetched from etcd")
 
-	err = GetMetricData(blockDevices)
+	err = getMetricData(blockDevices)
 	if err != nil {
 		sc.metrics.IncErrorRequestCounter()
 		sc.collectErrors(ch)
@@ -124,7 +124,7 @@ func (sc *SeachestCollector) Collect(ch chan<- prometheus.Metric) {
 
 	klog.V(4).Infof("metrics data obtained from seachest library")
 
-	sc.SetMetricData(blockDevices)
+	sc.setMetricData(blockDevices)
 
 	klog.V(4).Info("Prometheus metrics is set and initializing collection.")
 
@@ -149,8 +149,8 @@ func (sc *SeachestCollector) collectErrors(ch chan<- prometheus.Metric) {
 	}
 }
 
-// GetMetricData gets the seachest metrics for each blockdevice and fills it in the blockdevice struct
-func GetMetricData(bds []blockdevice.BlockDevice) error {
+// getMetricData gets the seachest metrics for each blockdevice and fills it in the blockdevice struct
+func getMetricData(bds []blockdevice.BlockDevice) error {
 	var err error
 	ok := false
 	for i, bd := range bds {
@@ -163,7 +163,7 @@ func GetMetricData(bds []blockdevice.BlockDevice) error {
 				DevPath: bd.Path,
 			},
 		}
-		err = sc.GetSeachestData()
+		err = sc.getSeachestData()
 		if err != nil {
 			klog.Errorf("fetching seachest data for %s failed. %v", bd.Path, err)
 			continue
@@ -177,8 +177,8 @@ func GetMetricData(bds []blockdevice.BlockDevice) error {
 	return nil
 }
 
-// GetSeachestData fetches the data for a blockdevice using the seachest library from the disk.
-func (sc *SeachestMetricData) GetSeachestData() error {
+// getSeachestData fetches the data for a blockdevice using the seachest library from the disk.
+func (sc *SeachestMetricData) getSeachestData() error {
 	driveInfo, err := sc.SeachestIdentifier.SeachestBasicDiskInfo()
 	if err != 0 {
 		klog.Errorf("error fetching basic disk info using seachest. %s", seachest.SeachestErrors(err))
@@ -190,9 +190,9 @@ func (sc *SeachestMetricData) GetSeachestData() error {
 	return nil
 }
 
-// SetMetricData sets the SMART metric data collected using seachest onto
+// setMetricData sets the SMART metric data collected using seachest onto
 // the prometheus metrics
-func (sc *SeachestCollector) SetMetricData(blockdevices []blockdevice.BlockDevice) {
+func (sc *SeachestCollector) setMetricData(blockdevices []blockdevice.BlockDevice) {
 	for _, bd := range blockdevices {
 		// sets the label values
 		sc.metrics.WithBlockDeviceUUID(bd.UUID).

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -29,6 +29,8 @@ import (
 )
 
 const (
+	// SeachestCollectorNamespace is the namespace field in the prometheus metrics when
+	// seachest is used to collect the metrics.
 	SeachestCollectorNamespace = "seachest"
 )
 

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -162,9 +162,8 @@ func GetMetricData(bds []blockdevice.BlockDevice) error {
 	}
 	if !ok {
 		return fmt.Errorf("getting seachest metrics for the blockdevices failed")
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // GetSeachestData fetches the data for a blockdevice using the seachest library from the disk.

--- a/ndm-exporter/collector/seachest.go
+++ b/ndm-exporter/collector/seachest.go
@@ -1,0 +1,161 @@
+package collector
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/openebs/node-disk-manager/db/kubernetes"
+	seachestmetrics "github.com/openebs/node-disk-manager/pkg/metrics/seachest"
+	"github.com/openebs/node-disk-manager/pkg/seachest"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+// SeachestMetricCollector contains the metrics, concurrency handler and client to get the
+// metrics from seachest
+type SeachestMetricCollector struct {
+	// Client is the k8s client which will be used to interface with etcd
+	Client kubernetes.Client
+
+	// concurrency handling
+	sync.Mutex
+	requestInProgress bool
+
+	// all exposed metrics from seachest
+	metrics *seachestmetrics.Metrics
+}
+
+// SeachestMetricData is the struct which holds the data from seachest library
+// correspnding to each blockdevice
+type SeachestMetricData struct {
+	SeachestIdentifier *seachest.Identifier
+	TempInfo           blockdevice.TemperatureInformation
+}
+
+// NewSeachestMetricCollector creates a new instance of SeachestMetricCollector which
+// implements Collector interface
+func NewSeachestMetricCollector(c kubernetes.Client) prometheus.Collector {
+	klog.V(2).Infof("Seachest Metric Collector initialized")
+	return &SeachestMetricCollector{
+		Client:  c,
+		metrics: seachestmetrics.NewMetrics(),
+	}
+}
+
+// Describe is the implementation of Describe in prometheus.Collector
+func (mc *SeachestMetricCollector) Describe(ch chan<- *prometheus.Desc) {
+	for _, col := range mc.metrics.Collectors() {
+		col.Describe(ch)
+	}
+}
+
+// Collect is the implementation of Collect in prometheus.Collector
+func (mc *SeachestMetricCollector) Collect(ch chan<- prometheus.Metric) {
+	klog.V(4).Info("Starting to collect seachestmetrics metrics for a request")
+
+	mc.Lock()
+	if mc.requestInProgress {
+		klog.V(4).Info("Another request already in progress.")
+		mc.metrics.IncRejectRequestCounter()
+		mc.Unlock()
+		return
+	}
+
+	mc.requestInProgress = true
+	mc.Unlock()
+
+	// once a request is processed, set the progress flag to false
+	defer mc.setRequestProgressToFalse()
+
+	klog.V(4).Info("Setting client for this request.")
+
+	// set the client each time
+	if err := mc.Client.InitClient(); err != nil {
+		klog.Errorf("error setting client. %v", err)
+		mc.metrics.IncErrorRequestCounter()
+		mc.collectErrors(ch)
+		return
+	}
+
+	// get list of blockdevices from etcd
+	blockDevices, err := mc.Client.ListBlockDevice()
+	if err != nil {
+		mc.metrics.IncErrorRequestCounter()
+		mc.collectErrors(ch)
+		return
+	}
+
+	klog.V(4).Info("Blockdevices fetched from etcd")
+
+	err = GetMetricData(blockDevices)
+	if err != nil {
+		mc.metrics.IncErrorRequestCounter()
+		mc.collectErrors(ch)
+		return
+	}
+
+	klog.V(4).Infof("metrics data obtained from seachest library")
+
+	mc.metrics.SetMetrics(blockDevices)
+
+	klog.V(4).Info("Prometheus metrics is set and initializing collection.")
+
+	// collect each metric
+	for _, col := range mc.metrics.Collectors() {
+		col.Collect(ch)
+	}
+}
+
+// setRequestProgressToFalse is used to set the progress flag, when a request is
+// processed or errored
+func (mc *SeachestMetricCollector) setRequestProgressToFalse() {
+	mc.Lock()
+	mc.requestInProgress = false
+	mc.Unlock()
+}
+
+// collectErrors collects only the error metrics and set it on the channel
+func (mc *SeachestMetricCollector) collectErrors(ch chan<- prometheus.Metric) {
+	for _, col := range mc.metrics.ErrorCollectors() {
+		col.Collect(ch)
+	}
+}
+
+// GetMetricData gets the seachest metrics for each blockdevice and fills it in the blockdevice struct
+func GetMetricData(bds []blockdevice.BlockDevice) error {
+	var err error
+	ok := false
+	for i, bd := range bds {
+		sc := SeachestMetricData{
+			SeachestIdentifier: &seachest.Identifier{
+				DevPath: bd.Path,
+			},
+		}
+		err = sc.GetSeachestData()
+		if err != nil {
+			klog.Errorf("fetching seachest data for %s failed. %v", bd.Path, err)
+			continue
+		}
+		ok = true
+		bds[i].TemperatureInfo = sc.TempInfo
+	}
+	if !ok {
+		return fmt.Errorf("getting seachest metrics for the blockdevices failed")
+	} else {
+		return nil
+	}
+}
+
+// GetSeachestData fetches the data for a blockdevice using the seachest library from the disk.
+func (sc *SeachestMetricData) GetSeachestData() error {
+	driveInfo, err := sc.SeachestIdentifier.SeachestBasicDiskInfo()
+	if err != 0 {
+		klog.Errorf("error fetching basic disk info using seachest. %s", seachest.SeachestErrors(err))
+		return fmt.Errorf("error getting seachest data for metrics. %s", seachest.SeachestErrors(err))
+	}
+	sc.TempInfo.TemperatureDataValid = sc.SeachestIdentifier.GetTemperatureDataValidStatus(driveInfo)
+	sc.TempInfo.CurrentTemperature = sc.SeachestIdentifier.GetCurrentTemperature(driveInfo)
+
+	return nil
+}

--- a/ndm-exporter/collector/static.go
+++ b/ndm-exporter/collector/static.go
@@ -42,6 +42,7 @@ type StaticMetricCollector struct {
 // NewStaticMetricCollector creates a new instance of StaticMetricCollector which
 // implements Collector interface
 func NewStaticMetricCollector(c kubernetes.Client) prometheus.Collector {
+	klog.V(2).Infof("Static Metric Collector initialized")
 	return &StaticMetricCollector{
 		Client:  c,
 		metrics: static.NewMetrics(),

--- a/ndm-exporter/exporter.go
+++ b/ndm-exporter/exporter.go
@@ -108,8 +108,8 @@ func (e *Exporter) runClusterExporter() error {
 	klog.Info("Starting cluster level exporter . . .")
 
 	// create instance of a new static collector and register it.
-	c := collector.NewStaticMetricCollector(e.Client)
-	prometheus.MustRegister(c)
+	staticCollector := collector.NewStaticMetricCollector(e.Client)
+	prometheus.MustRegister(staticCollector)
 
 	return nil
 }
@@ -117,6 +117,10 @@ func (e *Exporter) runClusterExporter() error {
 // runNodeExporter starts the node level ndm exporter
 func (e *Exporter) runNodeExporter() error {
 	klog.Info("Starting node level exporter . . .")
-	// TODO code for node exporter
+
+	// create instances of collectors required for node level exporter and register them
+	seachestCollector := collector.NewSeachestMetricCollector(e.Client)
+	prometheus.MustRegister(seachestCollector)
+
 	return nil
 }

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -270,3 +270,44 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
 ---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ndm-node-exporter
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: ndm-node-exporter
+  template:
+    metadata:
+      labels:
+        name: ndm-node-exporter
+    spec:
+      serviceAccountName: openebs-ndm-operator
+      containers:
+        - name: node-disk-exporter
+          image: openebs/node-disk-exporter-amd64:ci
+          command:
+            - /usr/local/bin/exporter
+          args:
+            - "start"
+            - "--mode=node"
+            - "--port=:9101"
+            - "--metrics=/metrics"
+          ports:
+            - containerPort: 9101
+              protocol: TCP
+              name: metrics
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+
+
+

--- a/pkg/metrics/seachest/metrics.go
+++ b/pkg/metrics/seachest/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package seachest
 
 import (

--- a/pkg/metrics/seachest/metrics.go
+++ b/pkg/metrics/seachest/metrics.go
@@ -1,0 +1,128 @@
+package seachest
+
+import (
+	"strings"
+
+	bd "github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	SeachestName = "seachest"
+)
+
+type Metrics struct {
+	// blockDeviceCurrentTemperatureValid tells whether the current temperature data is valid
+	blockDeviceCurrentTemperatureValid *prometheus.GaugeVec
+	// blockDeviceTemperature is the temperature of the the blockdevice if it is reported
+	blockDeviceCurrentTemperature *prometheus.GaugeVec
+
+	// errors and rejected requests
+	rejectRequestCount prometheus.Counter
+	errorRequestCount  prometheus.Counter
+}
+
+func NewMetrics() *Metrics {
+	return new(Metrics).
+		withBlockDeviceCurrentTemperatureValid().
+		withBlockDeviceCurrentTemperature().
+		withRejectRequest().
+		withErrorRequest()
+}
+
+func (m *Metrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.blockDeviceCurrentTemperatureValid,
+		m.blockDeviceCurrentTemperature,
+		m.rejectRequestCount,
+		m.errorRequestCount,
+	}
+}
+
+func (m *Metrics) ErrorCollectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.rejectRequestCount,
+		m.errorRequestCount,
+	}
+}
+
+// IncRejectRequestCounter increments the reject request error counter
+func (m *Metrics) IncRejectRequestCounter() {
+	m.rejectRequestCount.Inc()
+}
+
+// IncErrorRequestCounter increments the no of requests errored out.
+func (m *Metrics) IncErrorRequestCounter() {
+	m.errorRequestCount.Inc()
+}
+
+func (m *Metrics) withBlockDeviceCurrentTemperature() *Metrics {
+	m.blockDeviceCurrentTemperature = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: SeachestName,
+			Name:      "block_device_current_temperature",
+			Help:      `Current reported temperature of the blockdevice. -1 if not reported`,
+		},
+		[]string{"blockdevicename", "path", "hostname", "nodename"},
+	)
+	return m
+}
+
+func (m *Metrics) withBlockDeviceCurrentTemperatureValid() *Metrics {
+	m.blockDeviceCurrentTemperatureValid = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: SeachestName,
+			Name:      "block_device_current_temperature_valid",
+			Help:      `Validity of the current temperature data reported. 0 means not valid, 1 means valid`,
+		},
+		[]string{"blockdevicename", "path", "hostname", "nodename"},
+	)
+	return m
+}
+
+func (m *Metrics) withRejectRequest() *Metrics {
+	m.rejectRequestCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: SeachestName,
+			Name:      "reject_request_count",
+			Help:      `No. of requests rejected by the exporter`,
+		},
+	)
+	return m
+}
+
+func (m *Metrics) withErrorRequest() *Metrics {
+	m.errorRequestCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: SeachestName,
+			Name:      "error_request_count",
+			Help:      `No. of requests errored out by the exporter`,
+		})
+	return m
+}
+
+func (m *Metrics) SetMetrics(blockDevices []bd.BlockDevice) {
+	for _, blockDevice := range blockDevices {
+		// remove /dev from the device path so that the device path is similar to the
+		// path given by node exporter
+		path := strings.ReplaceAll(blockDevice.Path, "/dev/", "")
+		m.blockDeviceCurrentTemperature.WithLabelValues(blockDevice.UUID,
+			path,
+			blockDevice.NodeAttributes[bd.HostName],
+			blockDevice.NodeAttributes[bd.NodeName]).
+			Set(float64(blockDevice.TemperatureInfo.CurrentTemperature))
+		m.blockDeviceCurrentTemperatureValid.WithLabelValues(blockDevice.UUID,
+			path,
+			blockDevice.NodeAttributes[bd.HostName],
+			blockDevice.NodeAttributes[bd.NodeName]).
+			Set(getTemperatureValidity(blockDevice.TemperatureInfo.TemperatureDataValid))
+	}
+}
+
+func getTemperatureValidity(isValid bool) float64 {
+	if isValid {
+		return 1
+	} else {
+		return 0
+	}
+}

--- a/pkg/metrics/seachest/metrics.go
+++ b/pkg/metrics/seachest/metrics.go
@@ -24,9 +24,12 @@ import (
 )
 
 const (
+	// SeachestName is the name prefix used for all seachest metrics
 	SeachestName = "seachest"
 )
 
+// Metrics is the prometheus metrics that are exposed by the exporter. This includes
+// all the metrics that can be fetched using seachest library
 type Metrics struct {
 	// blockDeviceCurrentTemperatureValid tells whether the current temperature data is valid
 	blockDeviceCurrentTemperatureValid *prometheus.GaugeVec
@@ -38,6 +41,7 @@ type Metrics struct {
 	errorRequestCount  prometheus.Counter
 }
 
+// NewMetrics creates instance of metrics
 func NewMetrics() *Metrics {
 	return new(Metrics).
 		withBlockDeviceCurrentTemperatureValid().
@@ -46,6 +50,7 @@ func NewMetrics() *Metrics {
 		withErrorRequest()
 }
 
+// Collectors lists out all the collectors for which the metrics is exposed
 func (m *Metrics) Collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		m.blockDeviceCurrentTemperatureValid,
@@ -55,6 +60,7 @@ func (m *Metrics) Collectors() []prometheus.Collector {
 	}
 }
 
+// ErrorCollectors lists out all collectors for metrics related to error
 func (m *Metrics) ErrorCollectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		m.rejectRequestCount,
@@ -76,7 +82,7 @@ func (m *Metrics) withBlockDeviceCurrentTemperature() *Metrics {
 	m.blockDeviceCurrentTemperature = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: SeachestName,
-			Name:      "block_device_current_temperature",
+			Name:      "block_device_current_temperature_celsius",
 			Help:      `Current reported temperature of the blockdevice. -1 if not reported`,
 		},
 		[]string{"blockdevicename", "path", "hostname", "nodename"},
@@ -117,6 +123,8 @@ func (m *Metrics) withErrorRequest() *Metrics {
 	return m
 }
 
+// SetMetrics is used to set the seachest metrics onto resepective fields
+// of prometheus metrics
 func (m *Metrics) SetMetrics(blockDevices []bd.BlockDevice) {
 	for _, blockDevice := range blockDevices {
 		// remove /dev from the device path so that the device path is similar to the
@@ -135,10 +143,11 @@ func (m *Metrics) SetMetrics(blockDevices []bd.BlockDevice) {
 	}
 }
 
+// getTemperatureValidity converts temperature validity
+// flag to a metric
 func getTemperatureValidity(isValid bool) float64 {
 	if isValid {
 		return 1
-	} else {
-		return 0
 	}
+	return 0
 }

--- a/pkg/metrics/smart/metrics.go
+++ b/pkg/metrics/smart/metrics.go
@@ -87,6 +87,8 @@ func (m *Metrics) IncErrorRequestCounter() {
 	m.errorRequestCount.Inc()
 }
 
+// WithBlockDeviceCurrentTemperature declares the metric current temperature
+// as a prometheus metric
 func (m *Metrics) WithBlockDeviceCurrentTemperature() *Metrics {
 	m.blockDeviceCurrentTemperature = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -99,6 +101,8 @@ func (m *Metrics) WithBlockDeviceCurrentTemperature() *Metrics {
 	return m
 }
 
+// WithBlockDeviceCurrentTemperatureValid declares the metric current temperature valid
+// as a prometheus metric
 func (m *Metrics) WithBlockDeviceCurrentTemperatureValid() *Metrics {
 	m.blockDeviceCurrentTemperatureValid = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -111,6 +115,7 @@ func (m *Metrics) WithBlockDeviceCurrentTemperatureValid() *Metrics {
 	return m
 }
 
+// WithRejectRequest declares the reject request count metric
 func (m *Metrics) WithRejectRequest() *Metrics {
 	m.rejectRequestCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -122,6 +127,7 @@ func (m *Metrics) WithRejectRequest() *Metrics {
 	return m
 }
 
+// WithErrorRequest declares the error request count metric
 func (m *Metrics) WithErrorRequest() *Metrics {
 	m.errorRequestCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -132,11 +138,13 @@ func (m *Metrics) WithErrorRequest() *Metrics {
 	return m
 }
 
+// WithBlockDeviceUUID sets the blockdevice UUID to the metric label
 func (ml *MetricsLabels) WithBlockDeviceUUID(uuid string) *MetricsLabels {
 	ml.UUID = uuid
 	return ml
 }
 
+// WithBlockDevicePath sets the blockdevice path to the metric label
 func (ml *MetricsLabels) WithBlockDevicePath(path string) *MetricsLabels {
 	// remove /dev from the device path so that the device path is similar to the
 	// path given by node exporter
@@ -144,16 +152,19 @@ func (ml *MetricsLabels) WithBlockDevicePath(path string) *MetricsLabels {
 	return ml
 }
 
+// WithBlockDeviceHostName sets the blockdevice hostname to the metric label
 func (ml *MetricsLabels) WithBlockDeviceHostName(hostName string) *MetricsLabels {
 	ml.HostName = hostName
 	return ml
 }
 
+// WithBlockDeviceNodeName sets the blockdevice nodename to the metric label
 func (ml *MetricsLabels) WithBlockDeviceNodeName(nodeName string) *MetricsLabels {
 	ml.NodeName = nodeName
 	return ml
 }
 
+// SetBlockDeviceCurrentTemperature sets the current temperature value to the metric
 func (m *Metrics) SetBlockDeviceCurrentTemperature(currentTemp int16) *Metrics {
 	m.blockDeviceCurrentTemperature.WithLabelValues(m.UUID,
 		m.Path,
@@ -163,6 +174,8 @@ func (m *Metrics) SetBlockDeviceCurrentTemperature(currentTemp int16) *Metrics {
 	return m
 }
 
+// SetBlockDeviceCurrentTemperatureValid sets the validity of the exposed current
+// temperature metrics
 func (m *Metrics) SetBlockDeviceCurrentTemperatureValid(valid bool) *Metrics {
 	m.blockDeviceCurrentTemperatureValid.WithLabelValues(m.UUID,
 		m.Path,


### PR DESCRIPTION
- added node level exporter for fetching metrics using seachest library. 
- In this PR, only the current temperature info of the disk is exposed as metrics. More metrics like disk rotation rate can be fetched from seachest library. 
- More collectors can be added by following steps in #347 . 