### PR TITLE
fix(tools): set the default tag to latest for helper pod

### DIFF
--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -230,7 +230,7 @@ spec:
             - name: OPERATOR_NAME
               value: "node-disk-operator"
             - name: CLEANUP_JOB_IMAGE
-              value: "quay.io/openebs/linux-utils:3.9"
+              value: "quay.io/openebs/linux-utils:latest"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -29,7 +29,7 @@ const (
 
 var (
 	// defaultCleanUpJobImage is the default job container image
-	defaultCleanUpJobImage = "quay.io/openebs/linux-utils:3.9"
+	defaultCleanUpJobImage = "quay.io/openebs/linux-utils:latest"
 )
 
 // getCleanUpImage gets the image to be used for the cleanup job


### PR DESCRIPTION
The default helper pod which can be overridden via the
ENV was set to fixed older version. This can result in
default image to have some security vulnerabilities.

As part of the release process, the helper pod images will
be rebuilt allowing to pull in a image that has fixed
known security vulnerabilities.

Signed-off-by: kmova <kiran.mova@mayadata.io>