### PR TITLE
chore(cherry-pick): disable reconciliation on custom resources (#307)

### DIFF
--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -57,6 +57,10 @@ const (
 	KubernetesHostNameLabel = kubernetesLabelPrefix + HostNameKey
 	// NDMVersion is the CR version.
 	NDMVersion = openEBSLabelPrefix + "v1alpha1"
+	// reconcileKey is the key used for enable/disable of reconcilation
+	reconcileKey = "reconcile"
+	// OpenEBSReconcile is used in annotation to check whether CR is to be reconciled or not
+	OpenEBSReconcile = openEBSLabelPrefix + reconcileKey
 	// NDMNotPartitioned is used to say blockdevice does not have any partition.
 	NDMNotPartitioned = "No"
 	// NDMPartitioned is used to say blockdevice has some partitions.

--- a/pkg/controller/blockdevice/blockdevice_controller.go
+++ b/pkg/controller/blockdevice/blockdevice_controller.go
@@ -108,6 +108,11 @@ func (r *ReconcileBlockDevice) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, err
 	}
 
+	// check if the this block device need to reconciled
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	switch instance.Status.ClaimState {
 	case openebsv1alpha1.BlockDeviceReleased:
 		jobController := cleaner.NewJobController(r.client, request.Namespace)
@@ -200,4 +205,10 @@ func (r *ReconcileBlockDevice) updateBDStatus(state openebsv1alpha1.DeviceClaimS
 		return err
 	}
 	return nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// BlockDevice
+func IsReconcileDisabled(bd *openebsv1alpha1.BlockDevice) bool {
+	return bd.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -110,6 +110,11 @@ func (r *ReconcileBlockDeviceClaim) Reconcile(request reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
+	// check if reconcilation is disabled for this resource
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	switch instance.Status.Phase {
 	case apis.BlockDeviceClaimStatusPending:
 		fallthrough
@@ -361,4 +366,10 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.B
 	}
 
 	return listBlockDevice, nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// BlockDeviceClaim
+func IsReconcileDisabled(bdc *apis.BlockDeviceClaim) bool {
+	return bdc.Annotations[ndm.OpenEBSReconcile] == "false"
 }

--- a/pkg/controller/disk/disk_controller.go
+++ b/pkg/controller/disk/disk_controller.go
@@ -18,6 +18,8 @@ package disk
 
 import (
 	"context"
+	ndm "github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+
 	//"fmt"
 
 	openebsv1alpha1 "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
@@ -102,5 +104,17 @@ func (r *ReconcileDisk) Reconcile(request reconcile.Request) (reconcile.Result, 
 		// Error reading the object - requeue the request.
 		return reconcile.Result{}, err
 	}
+
+	// check if reconciliation is disabled on this disk resource
+	if IsReconcileDisabled(instance) {
+		return reconcile.Result{}, nil
+	}
+
 	return reconcile.Result{}, nil
+}
+
+// IsReconcileDisabled is used to check if reconcilation is disabled for
+// Disk resource
+func IsReconcileDisabled(disk *openebsv1alpha1.Disk) bool {
+	return disk.Annotations[ndm.OpenEBSReconcile] == "false"
 }


### PR DESCRIPTION
`openebs.io/reconcile: "false"` annotation can be set on BlockDevice, Disk and BlockDeviceClaim custom resources to stop reconcilation of those resources.

add functionality to disable reconcilation from daemon also. When the annotation is specified, the daemon also will not update the details into the disk and blockdevice resource.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>