### PR TITLE
feat(daemon): make config file path configurable

### DIFF
--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -44,7 +44,7 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	cmd.PersistentFlags().StringVar(&options.ConfigFilePath, "config",
-		"/host/node-disk-manager.config",
+		controller.DefaultConfigFilePath,
 		"Path to config file")
 	_ = goflag.CommandLine.Parse([]string{})
 

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -18,6 +18,7 @@ package command
 
 import (
 	goflag "flag"
+	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/version"
 
 	"github.com/openebs/node-disk-manager/pkg/util"
@@ -26,8 +27,12 @@ import (
 	"k8s.io/klog"
 )
 
+// options is the options with which the daemon is to be run
+var options controller.NDMOptions
+
 // NewNodeDiskManager creates a new ndm.
 func NewNodeDiskManager() (*cobra.Command, error) {
+
 	// Create a new command
 	cmd := &cobra.Command{
 		Use:   "ndm",
@@ -38,6 +43,9 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 	}
 
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	cmd.PersistentFlags().StringVar(&options.ConfigFilePath, "config",
+		"/host/node-disk-manager.config",
+		"Path to config file")
 	_ = goflag.CommandLine.Parse([]string{})
 
 	cmd.AddCommand(

--- a/cmd/ndm_daemonset/app/command/device-list.go
+++ b/cmd/ndm_daemonset/app/command/device-list.go
@@ -82,7 +82,7 @@ func NewSubCmdListBlockDevice() *cobra.Command {
 
 // deviceList prints list of devices using defaultDeviceList template
 func deviceList() error {
-	ctrl, err := controller.NewController()
+	ctrl, err := controller.NewController(options)
 	if err != nil {
 		return err
 	}

--- a/cmd/ndm_daemonset/app/command/device-list.go
+++ b/cmd/ndm_daemonset/app/command/device-list.go
@@ -82,11 +82,12 @@ func NewSubCmdListBlockDevice() *cobra.Command {
 
 // deviceList prints list of devices using defaultDeviceList template
 func deviceList() error {
-	ctrl, err := controller.NewController(options)
+	ctrl, err := controller.NewController()
 	if err != nil {
 		return err
 	}
-	diskList, err := ctrl.ListDiskResource()
+	// TODO @akhilerm should pass the filter as args to List, so that all devices will be listed
+	diskList, err := ctrl.ListBlockDeviceResource()
 	if err != nil {
 		return err
 	}

--- a/cmd/ndm_daemonset/app/command/start.go
+++ b/cmd/ndm_daemonset/app/command/start.go
@@ -34,7 +34,7 @@ func NewCmdStart() *cobra.Command {
 		Short: "Node disk controller",
 		Long:  ` watches for ndm custom resources via "ndm start" command `,
 		Run: func(cmd *cobra.Command, args []string) {
-			ctrl, err := controller.NewController()
+			ctrl, err := controller.NewController(options)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/ndm_daemonset/app/command/start.go
+++ b/cmd/ndm_daemonset/app/command/start.go
@@ -34,7 +34,14 @@ func NewCmdStart() *cobra.Command {
 		Short: "Node disk controller",
 		Long:  ` watches for ndm custom resources via "ndm start" command `,
 		Run: func(cmd *cobra.Command, args []string) {
-			ctrl, err := controller.NewController(options)
+			ctrl, err := controller.NewController()
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
+
+			// set the NDM config from the options
+			err = ctrl.SetControllerOptions(options)
 			if err != nil {
 				fmt.Println(err)
 				os.Exit(1)

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -94,6 +94,11 @@ var Namespace string
 // Each probe can get the copy of controller struct any time they need to read the channel.
 var ControllerBroadcastChannel = make(chan *Controller)
 
+// NDMOptions defines the options to run the NDM daemon
+type NDMOptions struct {
+	ConfigFilePath string
+}
+
 // Controller is the controller implementation for disk resources
 type Controller struct {
 	config *rest.Config // config is the generated config using kubeconfig/incluster config
@@ -109,7 +114,7 @@ type Controller struct {
 }
 
 // NewController returns a controller pointer for any error case it will return nil
-func NewController() (*Controller, error) {
+func NewController(opts NDMOptions) (*Controller, error) {
 	controller := &Controller{}
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -132,7 +137,7 @@ func NewController() (*Controller, error) {
 		return controller, err
 	}
 
-	controller.SetNDMConfig()
+	controller.SetNDMConfig(opts)
 	controller.Filters = make([]*Filter, 0)
 	controller.Probes = make([]*Probe, 0)
 	controller.NodeAttributes = make(map[string]string, 0)

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -114,7 +114,7 @@ type Controller struct {
 }
 
 // NewController returns a controller pointer for any error case it will return nil
-func NewController(opts NDMOptions) (*Controller, error) {
+func NewController() (*Controller, error) {
 	controller := &Controller{}
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -137,25 +137,30 @@ func NewController(opts NDMOptions) (*Controller, error) {
 		return controller, err
 	}
 
-	controller.SetNDMConfig(opts)
-	controller.Filters = make([]*Filter, 0)
-	controller.Probes = make([]*Probe, 0)
-	controller.NodeAttributes = make(map[string]string, 0)
-	controller.Mutex = &sync.Mutex{}
-
 	// get the namespace in which NDM is installed
 	Namespace, err = getNamespace()
 	if err != nil {
 		return controller, err
 	}
 
-	if err := controller.setNodeAttributes(); err != nil {
-		return nil, err
-	}
-
 	controller.WaitForDiskCRD()
 	controller.WaitForBlockDeviceCRD()
 	return controller, nil
+}
+
+// SetControllerOptions sets the various attributes and options
+// on the controller
+func (c *Controller) SetControllerOptions(opts NDMOptions) error {
+	// set the config for running NDM daemon
+	c.SetNDMConfig(opts)
+	c.Filters = make([]*Filter, 0)
+	c.Probes = make([]*Probe, 0)
+	c.NodeAttributes = make(map[string]string, 0)
+	c.Mutex = &sync.Mutex{}
+	if err := c.setNodeAttributes(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // newClientSet set Clientset field in Controller struct

--- a/cmd/ndm_daemonset/controller/ndmconfig.go
+++ b/cmd/ndm_daemonset/controller/ndmconfig.go
@@ -51,8 +51,8 @@ type FilterConfig struct {
 
 // SetNDMConfig sets config for probes and filters which user provides via configmap. If
 // no configmap present then ndm will load default config for each probes and filters.
-func (c *Controller) SetNDMConfig() {
-	data, err := ioutil.ReadFile(ConfigFilePath)
+func (c *Controller) SetNDMConfig(opts NDMOptions) {
+	data, err := ioutil.ReadFile(opts.ConfigFilePath)
 	if err != nil {
 		c.NDMConfig = nil
 		klog.Error("unable to set ndm config : ", err)

--- a/cmd/ndm_daemonset/controller/ndmconfig.go
+++ b/cmd/ndm_daemonset/controller/ndmconfig.go
@@ -24,8 +24,11 @@ import (
 	"k8s.io/klog"
 )
 
-// ConfigFilePath contains configmap file path
-var ConfigFilePath = "/host/node-disk-manager.config"
+const (
+	// DefaultConfigFilePath is the default path at which config is present inside
+	// container
+	DefaultConfigFilePath = "/host/node-disk-manager.config"
+)
 
 // NodeDiskManagerConfig contains congigs of probes and filters
 type NodeDiskManagerConfig struct {

--- a/cmd/ndm_daemonset/controller/ndmconfig_test.go
+++ b/cmd/ndm_daemonset/controller/ndmconfig_test.go
@@ -26,16 +26,18 @@ import (
 
 func TestSetNDMConfig(t *testing.T) {
 	fakeConfigFilePath := "/tmp/fakendm.config"
-	defaultConfigFilePath := ConfigFilePath
+
+	options := NDMOptions{
+		ConfigFilePath: fakeConfigFilePath,
+	}
 
 	// test case : when file not present
 	fakeController := &Controller{}
-	fakeController.SetNDMConfig()
+	fakeController.SetNDMConfig(options)
 	if fakeController.NDMConfig != nil {
 		t.Error("NDMConfig should nil for invalid file path")
 	}
-	// test case for invalid json
-	ConfigFilePath = fakeConfigFilePath
+
 	fileContent := []byte(`{
         "probeconfigs": [
             {
@@ -85,15 +87,15 @@ func TestSetNDMConfig(t *testing.T) {
 	}
 	expectedNDMConfig.FilterConfigs = append(expectedNDMConfig.FilterConfigs, expectedFilterConfig)
 	expectedNDMConfig.ProbeConfigs = append(expectedNDMConfig.ProbeConfigs, expectedProbeConfig)
-	ConfigFilePath = fakeConfigFilePath
+
 	err = ioutil.WriteFile(fakeConfigFilePath, fileContent, 0644)
 	if err != nil {
 		t.Fatal(err)
 	}
-	fakeController.SetNDMConfig()
+	fakeController.SetNDMConfig(options)
 	assert.Equal(t, expectedNDMConfig, *fakeController.NDMConfig)
 	os.Remove(fakeConfigFilePath)
-	ConfigFilePath = defaultConfigFilePath
+
 }
 
 func TestController_SetNDMConfig_yaml(t *testing.T) {
@@ -101,10 +103,12 @@ func TestController_SetNDMConfig_yaml(t *testing.T) {
 	writeTestYaml(t, fakeConfigFilePath)
 	defer os.Remove(fakeConfigFilePath)
 
-	ConfigFilePath = fakeConfigFilePath
+	options := NDMOptions{
+		ConfigFilePath: fakeConfigFilePath,
+	}
 
 	ctrl := &Controller{}
-	ctrl.SetNDMConfig()
+	ctrl.SetNDMConfig(options)
 
 	assert.NotNil(t, ctrl.NDMConfig)
 


### PR DESCRIPTION
The config file path was hardcoded to `/host/node-disk-manager.config`. This is now made configurable and can be provided via `--config`. This will help to run the NDM daemon as a standalone binary without needing to be in a container. When in the container the config file will be provided via a `ConfigMap`.