### PR TITLE
fix(script): fix changing the system core pattern

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -4,8 +4,10 @@ export GOTRACEBACK=crash
 
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
+echo "[entrypoint.sh] creating /var/openebs/sparse if not exists."
+mkdir -p /var/openebs/sparse
 echo "[entrypoint.sh] changing directory to /var/openebs/sparse"
-cd /var/openebs/sparse || exit
+cd /var/openebs/sparse
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -4,7 +4,8 @@ export GOTRACEBACK=crash
 
 echo "[entrypoint.sh] enabling core dump."
 ulimit -c unlimited
-echo "/var/openebs/sparse/core.%e.%p.%h.%t" > /proc/sys/kernel/core_pattern
+echo "[entrypoint.sh] changing directory to /var/openebs/sparse"
+cd /var/openebs/sparse || exit
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -7,7 +7,7 @@ ulimit -c unlimited
 echo "[entrypoint.sh] creating /var/openebs/sparse if not exists."
 mkdir -p /var/openebs/sparse
 echo "[entrypoint.sh] changing directory to /var/openebs/sparse"
-cd /var/openebs/sparse
+cd /var/openebs/sparse || exit
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 


### PR DESCRIPTION
Earlier NDM used to rewrite the system core pattern so that the core
dump is available in the persistent `/var/openebs/sparse` directory.
But this will cause all process on the host to write core files to that directory.
Now NDM process will be launched from the openebs directory, so core
files will get automatically written to the `$PWD`. This will help to
remove changing the system core pattern.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>