### PR TITLE
fix(script): disable coredump in NDM daemon

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -2,12 +2,19 @@
 
 export GOTRACEBACK=crash
 
-echo "[entrypoint.sh] enabling core dump."
-ulimit -c unlimited
-echo "[entrypoint.sh] creating /var/openebs/sparse if not exists."
-mkdir -p /var/openebs/sparse
-echo "[entrypoint.sh] changing directory to /var/openebs/sparse"
-cd /var/openebs/sparse || exit
+# set ulimit to 0, if the core dump is not enabled
+if [ -z "$ENABLE_COREDUMP" ]; then
+  ulimit -c 0
+else
+  # set ulimit to unlimited and create a core directory for creating coredump
+  echo "[entrypoint.sh] enabling core dump."
+  ulimit -c unlimited
+  echo "[entrypoint.sh] creating $SPARSE_FILE_DIR/core if not exists."
+  mkdir -p "$SPARSE_FILE_DIR/core"
+  echo "[entrypoint.sh] changing directory to $SPARSE_FILE_DIR/core"
+  cd "$SPARSE_FILE_DIR/core" || exit
+fi
+
 echo "[entrypoint.sh] launching ndm process."
 /usr/sbin/ndm start &
 

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -163,6 +163,9 @@ spec:
         # Specify the number of sparse files to be created
         - name: SPARSE_FILE_COUNT
           value: "1"
+        # Set the core dump env to enable core dump for NDM daemon
+        #- name: ENABLE_COREDUMP
+        #  value: "1"
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
disable coredump from NDM daemon by default. `ENABLE_COREDUMP` env needs to be used to enable core dump. When core dump is enabled, the ulimit will be set to unlimited and a core directory will be created inside `SPARSE_FILE_DIR` to store the core files.