### PR TITLE
feat(script, yaml): add openebs basepath

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -2,19 +2,28 @@
 
 export GOTRACEBACK=crash
 
+# openebs base directory inside the container
+OPENEBS_BASE_DIR="/var/openebs"
+# ndm base directory inside the container. It will be the ndm
+# directory inside openebs base directory
+NDM_BASE_DIR="${OPENEBS_BASE_DIR}/ndm"
+
 # set ulimit to 0, if the core dump is not enabled
 if [ -z "$ENABLE_COREDUMP" ]; then
   ulimit -c 0
 else
   # making sure mountpath inside the container is available
-  cd /var/openebs/ndm || (echo "OpenEBS Base directory not found" && exit 1)
+  if ! [ -d "${NDM_BASE_DIR}" ]; then
+    echo "OpenEBS/NDM Base directory not found"
+    exit 1
+  fi
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited
-  echo "[entrypoint.sh] creating /var/openebs/ndm/core if not exists."
-  mkdir -p "/var/openebs/ndm/core"
-  echo "[entrypoint.sh] changing directory to /var/openebs/ndm/core"
-  cd "/var/openebs/ndm/core" || exit
+  echo "[entrypoint.sh] creating ${NDM_BASE_DIR}/core if not exists."
+  mkdir -p "${NDM_BASE_DIR}/core"
+  echo "[entrypoint.sh] changing directory to ${NDM_BASE_DIR}/core"
+  cd "${NDM_BASE_DIR}/core" || exit
 fi
 
 echo "[entrypoint.sh] launching ndm process."

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -7,7 +7,7 @@ if [ -z "$ENABLE_COREDUMP" ]; then
   ulimit -c 0
 else
   # making sure mountpath inside the container is available
-  cd /var/openebs || (echo "OpenEBS Base directory not found" && exit)
+  cd /var/openebs || (echo "OpenEBS Base directory not found" && exit 1)
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -6,13 +6,15 @@ export GOTRACEBACK=crash
 if [ -z "$ENABLE_COREDUMP" ]; then
   ulimit -c 0
 else
+  # making sure mountpath inside the container is available
+  cd /var/openebs || (echo "OpenEBS Base directory not found" && exit)
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited
-  echo "[entrypoint.sh] creating $OPENEBS_IO_BASE_DIR/core if not exists."
-  mkdir -p "$OPENEBS_IO_BASE_DIR/core"
-  echo "[entrypoint.sh] changing directory to $OPENEBS_IO_BASE_DIR/core"
-  cd "$OPENEBS_IO_BASE_DIR/core" || exit
+  echo "[entrypoint.sh] creating /var/openebs/core if not exists."
+  mkdir -p "/var/openebs/core"
+  echo "[entrypoint.sh] changing directory to /var/openebs/core"
+  cd "/var/openebs/core" || exit
 fi
 
 echo "[entrypoint.sh] launching ndm process."

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -7,14 +7,14 @@ if [ -z "$ENABLE_COREDUMP" ]; then
   ulimit -c 0
 else
   # making sure mountpath inside the container is available
-  cd /var/openebs || (echo "OpenEBS Base directory not found" && exit 1)
+  cd /var/openebs/ndm || (echo "OpenEBS Base directory not found" && exit 1)
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited
-  echo "[entrypoint.sh] creating /var/openebs/core if not exists."
-  mkdir -p "/var/openebs/core"
-  echo "[entrypoint.sh] changing directory to /var/openebs/core"
-  cd "/var/openebs/core" || exit
+  echo "[entrypoint.sh] creating /var/openebs/ndm/core if not exists."
+  mkdir -p "/var/openebs/ndm/core"
+  echo "[entrypoint.sh] changing directory to /var/openebs/ndm/core"
+  cd "/var/openebs/ndm/core" || exit
 fi
 
 echo "[entrypoint.sh] launching ndm process."

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -9,10 +9,10 @@ else
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited
-  echo "[entrypoint.sh] creating $SPARSE_FILE_DIR/core if not exists."
-  mkdir -p "$SPARSE_FILE_DIR/core"
-  echo "[entrypoint.sh] changing directory to $SPARSE_FILE_DIR/core"
-  cd "$SPARSE_FILE_DIR/core" || exit
+  echo "[entrypoint.sh] creating $OPENEBS_IO_BASE_DIR/core if not exists."
+  mkdir -p "$OPENEBS_IO_BASE_DIR/core"
+  echo "[entrypoint.sh] changing directory to $OPENEBS_IO_BASE_DIR/core"
+  cd "$OPENEBS_IO_BASE_DIR/core" || exit
 fi
 
 echo "[entrypoint.sh] launching ndm process."

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -139,6 +139,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: basepath
+          mountPath: /var/openebs
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -152,15 +154,17 @@ spec:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
-        # specify the directory where the sparse files need to be created.
-        # if not specified, then sparse files will not be created.
+            fieldPath: spec.nodeName
+        - name: OPENEBS_IO_BASE_DIR
+          value: "/var/openebs"
+          # specify the directory where the sparse files need to be created.
+          # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR
           value: "/var/openebs/sparse"
-        # Size of the sparse file to be created.
+          # Size of the sparse file to be created.
         - name: SPARSE_FILE_SIZE
           value: "1073741824"
-        # Specify the number of sparse files to be created
+          # Specify the number of sparse files to be created
         - name: SPARSE_FILE_COUNT
           value: "1"
         # Set the core dump env to enable core dump for NDM daemon
@@ -180,6 +184,9 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: basepath
+        hostPath:
+          path: /var/openebs
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -187,6 +187,7 @@ spec:
       - name: basepath
         hostPath:
           path: /var/openebs/ndm
+          type: DirectoryOrCreate
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -155,8 +155,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: OPENEBS_IO_BASE_DIR
-          value: "/var/openebs"
         # specify the directory where the sparse files need to be created.
         # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -154,17 +154,17 @@ spec:
         - name: NODE_NAME
           valueFrom:
             fieldRef:
-            fieldPath: spec.nodeName
+              fieldPath: spec.nodeName
         - name: OPENEBS_IO_BASE_DIR
           value: "/var/openebs"
-          # specify the directory where the sparse files need to be created.
-          # if not specified, then sparse files will not be created.
+        # specify the directory where the sparse files need to be created.
+        # if not specified, then sparse files will not be created.
         - name: SPARSE_FILE_DIR
           value: "/var/openebs/sparse"
-          # Size of the sparse file to be created.
+        # Size of the sparse file to be created.
         - name: SPARSE_FILE_SIZE
           value: "1073741824"
-          # Specify the number of sparse files to be created
+        # Specify the number of sparse files to be created
         - name: SPARSE_FILE_COUNT
           value: "1"
         # Set the core dump env to enable core dump for NDM daemon
@@ -186,7 +186,7 @@ spec:
           type: Directory
       - name: basepath
         hostPath:
-          path: /var/openebs
+          path: /var/openebs/ndm
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -140,7 +140,7 @@ spec:
           mountPath: /host/proc
           readOnly: true
         - name: basepath
-          mountPath: /var/openebs
+          mountPath: /var/openebs/ndm
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:


### PR DESCRIPTION
OpenEBS basepath has been added. Each component of openebs will have a directory under OPENEBS_IO_BASE_DIR on the host machine. 

NDM components will be stored under `OPENEBS_IO_BASE_DIR/ndm` on the host. Inside the NDM container this path will be mapped to `/var/openebs/ndm`. 