### PR TITLE
fix(cleanup) : Fixed creation of cleanUp Job

### DIFF
--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -25,7 +25,6 @@ import (
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -145,7 +144,8 @@ func (c *CleanupStatusTracker) CancelJob(bdName string) error {
 func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error {
 
 	//retreive node Object to pass tolerations to the Job
-	selectedNode, err := c.getNodeObjectByNodeName(bd.Labels[controller.KubernetesHostNameLabel])
+	nodeName := GetNodeName(bd)
+	selectedNode, err := c.getNodeObjectByNodeName(nodeName)
 	if err != nil {
 		return err
 	}

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -158,6 +158,7 @@ func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error 
 	return c.Client.Create(context.TODO(), job)
 }
 
+// getNodeObjectByNodeName returns Node Object, using NodeName
 func (c *Cleaner) getNodeObjectByNodeName(nodeName string) (*v1.Node, error) {
 	node := &v1.Node{}
 	err := c.Client.Get(context.TODO(), client.ObjectKey{Namespace: "", Name: nodeName}, node)
@@ -167,8 +168,8 @@ func (c *Cleaner) getNodeObjectByNodeName(nodeName string) (*v1.Node, error) {
 	return node, nil
 }
 
+// getTolerationsForTaints returns tolerations, taking input as taints
 func getTolerationsForTaints(taints ...v1.Taint) []v1.Toleration {
-
 	tolerations := []v1.Toleration{}
 	for i := range taints {
 		var toleration v1.Toleration

--- a/pkg/cleaner/cleaner.go
+++ b/pkg/cleaner/cleaner.go
@@ -24,6 +24,9 @@ import (
 	"context"
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	v1 "k8s.io/api/core/v1"
 )
 
 // CleanupState represents the current state of the cleanup job
@@ -140,11 +143,46 @@ func (c *CleanupStatusTracker) CancelJob(bdName string) error {
 
 // runJob creates a new cleanup job in the namespace
 func (c *Cleaner) runJob(bd *v1alpha1.BlockDevice, volumeMode VolumeMode) error {
-	job, err := NewCleanupJob(bd, volumeMode, c.Namespace)
+
+	//retreive node Object to pass tolerations to the Job
+	selectedNode, err := c.getNodeObjectByNodeName(bd.Labels[controller.KubernetesHostNameLabel])
+	if err != nil {
+		return err
+	}
+	tolerations := getTolerationsForTaints(selectedNode.Spec.Taints...)
+
+	job, err := NewCleanupJob(bd, volumeMode, tolerations, c.Namespace)
 	if err != nil {
 		return err
 	}
 	return c.Client.Create(context.TODO(), job)
+}
+
+func (c *Cleaner) getNodeObjectByNodeName(nodeName string) (*v1.Node, error) {
+	node := &v1.Node{}
+	err := c.Client.Get(context.TODO(), client.ObjectKey{Namespace: "", Name: nodeName}, node)
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+func getTolerationsForTaints(taints ...v1.Taint) []v1.Toleration {
+
+	tolerations := []v1.Toleration{}
+	for i := range taints {
+		var toleration v1.Toleration
+		toleration.Key = taints[i].Key
+		toleration.Effect = taints[i].Effect
+		if len(taints[i].Value) == 0 {
+			toleration.Operator = v1.TolerationOpExists
+		} else {
+			toleration.Value = taints[i].Value
+			toleration.Operator = v1.TolerationOpEqual
+		}
+		tolerations = append(tolerations, toleration)
+	}
+	return tolerations
 }
 
 // getVolumeMode returns the volume mode of the BD that is being released

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -190,7 +190,7 @@ func (c *jobController) CancelJob(bdName string) error {
 	job := &batchv1.Job{}
 	err := c.client.Get(context.TODO(), objKey, job)
 
-	//err = c.client.Delete(context.TODO(), job, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	err = c.client.Delete(context.TODO(), job, client.PropagationPolicy(metav1.DeletePropagationForeground))
 	return err
 }
 

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -207,6 +207,11 @@ func getCommand(cmd string, args ...string) []string {
 	return command
 }
 
+// GetNodeName gets the Node name from BlockDevice
+func GetNodeName(bd *v1alpha1.BlockDevice) string {
+	return bd.Spec.NodeAttributes.NodeName
+}
+
 // getVolumeMounts returns the volume and volume mount for the given hostpath and
 // mountpath
 func getVolumeMounts(hostPath, mountPath, mountName string) (v1.Volume, v1.VolumeMount) {

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -58,7 +58,7 @@ type jobController struct {
 
 // NewCleanupJob creates a new cleanup job in the  namespace. It returns a Job object which can be used to
 // start the job
-func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace string) (*batchv1.Job, error) {
+func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v1.Toleration, namespace string) (*batchv1.Job, error) {
 	nodeName := bd.Labels[controller.KubernetesHostNameLabel]
 
 	priv := true
@@ -96,10 +96,10 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, namespace strin
 		podSpec.Volumes = []v1.Volume{volume}
 	}
 
+	podSpec.Tolerations = tolerations
 	podSpec.ServiceAccountName = getServiceAccount()
 	podSpec.Containers = []v1.Container{jobContainer}
 	podSpec.NodeSelector = map[string]string{controller.KubernetesHostNameLabel: nodeName}
-
 	podTemplate := v1.Pod{}
 	podTemplate.Spec = podSpec
 
@@ -190,7 +190,7 @@ func (c *jobController) CancelJob(bdName string) error {
 	job := &batchv1.Job{}
 	err := c.client.Get(context.TODO(), objKey, job)
 
-	err = c.client.Delete(context.TODO(), job, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	//err = c.client.Delete(context.TODO(), job, client.PropagationPolicy(metav1.DeletePropagationForeground))
 	return err
 }
 


### PR DESCRIPTION
    - Added function to get Node Object using Cleaner Operator
    - Added function to get Tolerations from the Node Taints
    - Added one more parameter in NewCleanupJob to set Tolerations of Job to be created.

Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

Logs: These are sequential logs, will the steps I performed:
```
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl get pods -n openebs
NAME                                           READY   STATUS    RESTARTS   AGE
maya-apiserver-5865d7d548-bmzck                1/1     Running   0          2d
openebs-admission-server-684d455954-zvgrv      1/1     Running   0          2d
openebs-localpv-provisioner-58f5df5458-ttmw8   1/1     Running   0          2d
openebs-ndm-8c4cs                              1/1     Running   0          21s
openebs-ndm-dmf9f                              1/1     Running   0          21s
openebs-ndm-gw9bx                              1/1     Running   0          21s
openebs-ndm-operator-8456cf565c-kh9mk          1/1     Running   0          2m2s
openebs-provisioner-594bd6cf78-4zqf5           1/1     Running   0          2d
openebs-snapshot-operator-777cfb86df-kpzs8     2/2     Running   0          2d
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl apply -f bdc.yaml -n openebs
blockdeviceclaim.openebs.io/example-blockdeviceclaim created
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl get bdc -n openebs
NAME                       BLOCKDEVICENAME                                PHASE   AGE
example-blockdeviceclaim   blockdevice-860ab5d1205c0f2891d5bbfea2e223e5   Bound   10s
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl get pods -n openebs
NAME                                           READY   STATUS    RESTARTS   AGE
maya-apiserver-5865d7d548-bmzck                1/1     Running   0          2d
openebs-admission-server-684d455954-zvgrv      1/1     Running   0          2d
openebs-localpv-provisioner-58f5df5458-ttmw8   1/1     Running   0          2d
openebs-ndm-8c4cs                              1/1     Running   0          51s
openebs-ndm-dmf9f                              1/1     Running   0          51s
openebs-ndm-gw9bx                              1/1     Running   0          51s
openebs-ndm-operator-8456cf565c-kh9mk          1/1     Running   0          2m32s
openebs-provisioner-594bd6cf78-4zqf5           1/1     Running   0          2d
openebs-snapshot-operator-777cfb86df-kpzs8     2/2     Running   0          2d
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl taint nodes --all user=pass:NoSchedule
node/gke-standard-cluster-4-default-pool-ad827b74-jvcc tainted
node/gke-standard-cluster-4-default-pool-ad827b74-rj80 tainted
node/gke-standard-cluster-4-default-pool-ad827b74-w2j4 tainted
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl delete bdc example-blockdeviceclaim -n openebs
kublockdeviceclaim.openebs.io "example-blockdeviceclaim" deleted
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl get pods -n openebs
NAME                                                         READY   STATUS      RESTARTS   AGE
cleanup-blockdevice-860ab5d1205c0f2891d5bbfea2e223e5-gmn2q   0/1     Completed   0          3s
maya-apiserver-5865d7d548-bmzck                              1/1     Running     0          2d
openebs-admission-server-684d455954-zvgrv                    1/1     Running     0          2d
openebs-localpv-provisioner-58f5df5458-ttmw8                 1/1     Running     0          2d
openebs-ndm-8c4cs                                            1/1     Running     0          116s
openebs-ndm-dmf9f                                            1/1     Running     0          116s
openebs-ndm-gw9bx                                            1/1     Running     0          116s
openebs-ndm-operator-8456cf565c-kh9mk                        1/1     Running     0          3m37s
openebs-provisioner-594bd6cf78-4zqf5                         1/1     Running     0          2d
openebs-snapshot-operator-777cfb86df-kpzs8                   2/2     Running     0          2d
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ kubectl get pods -n openebs
NAME                                                         READY   STATUS      RESTARTS   AGE
cleanup-blockdevice-860ab5d1205c0f2891d5bbfea2e223e5-gmn2q   0/1     Completed   0          5s
maya-apiserver-5865d7d548-bmzck                              1/1     Running     0          2d
openebs-admission-server-684d455954-zvgrv                    1/1     Running     0          2d
openebs-localpv-provisioner-58f5df5458-ttmw8                 1/1     Running     0          2d
openebs-ndm-8c4cs                                            1/1     Running     0          118s
openebs-ndm-dmf9f                                            1/1     Running     0          118s
openebs-ndm-gw9bx                                            1/1     Running     0          118s
openebs-ndm-operator-8456cf565c-kh9mk                        1/1     Running     0          3m39s
openebs-provisioner-594bd6cf78-4zqf5                         1/1     Running     0          2d
openebs-snapshot-operator-777cfb86df-kpzs8                   2/2     Running     0          2d
rahul_chheda_mayadata_io@rahulchheda:~/openebs$ 
```
