### PR TITLE
chore(bd): Add support for display PATH in kubectl output

### DIFF
--- a/pkg/crds/build.go
+++ b/pkg/crds/build.go
@@ -135,6 +135,34 @@ func (b *Builder) WithPrinterColumns(columnName, columnType, jsonPath string) *B
 	return b
 }
 
+// WithPriorityPrinterColumns is used to add printercolumns field to the CRD with priority field
+func (b *Builder) WithPriorityPrinterColumns(columnName, columnType, jsonPath string, priority int32) *Builder {
+	if len(columnName) == 0 {
+		b.errs = append(b.errs,
+			errors.New("missing column name in additional printer columns"))
+		return b
+	}
+	if len(columnType) == 0 {
+		b.errs = append(b.errs,
+			errors.New("missing column type in additional printer columns"))
+		return b
+	}
+	if len(jsonPath) == 0 {
+		b.errs = append(b.errs,
+			errors.New("missing json path in additional printer columns"))
+		return b
+	}
+
+	printerColumn := apiext.CustomResourceColumnDefinition{
+		Name:     columnName,
+		Type:     columnType,
+		JSONPath: jsonPath,
+		Priority: priority,
+	}
+	b.crd.object.Spec.AdditionalPrinterColumns = append(b.crd.object.Spec.AdditionalPrinterColumns, printerColumn)
+	return b
+}
+
 // Build returns the CustomResourceDefinition from the builder
 func (b *Builder) Build() (*apiext.CustomResourceDefinition, error) {
 	if len(b.errs) > 0 {

--- a/pkg/setup/build_crd.go
+++ b/pkg/setup/build_crd.go
@@ -51,6 +51,7 @@ func buildBlockDeviceCRD() (*apiext.CustomResourceDefinition, error) {
 		WithPlural(apis.BlockDeviceResourcePlural).
 		WithShortNames([]string{apis.BlockDeviceResourceShort}).
 		WithPrinterColumns("NodeName", "string", ".spec.nodeAttributes.nodeName").
+		WithPriorityPrinterColumns("Path", "string", ".spec.path", 1).
 		WithPrinterColumns("Size", "string", ".spec.capacity.storage").
 		WithPrinterColumns("ClaimState", "string", ".status.claimState").
 		WithPrinterColumns("Status", "string", ".status.state").


### PR DESCRIPTION
**Why we need this?**

This commit will add the support for display `PATH` of `BlockDevice`
- The `PATH` will only be displayed when `-o wide` flag is passed

Issue Fixed: https://github.com/openebs/openebs/issues/2836

Outputs:
```
$ kubectl get bd 
NAME                                           NODENAME           SIZE          CLAIMSTATE   STATUS   AGE
blockdevice-b8c766547ce524dd9cf53ef003d54558   node-dev-setup03   5368709120    Unclaimed    Active   21m
sparse-01e10418d6b3ff0e5955046bd36b0f79        node-dev-setup02   10737418240   Unclaimed    Active   21m
sparse-5698d9c1a580e6af110a8359fa292926        node-dev-setup01   10737418240   Unclaimed    Active   21m
sparse-d1806a93ae6ecc94cebe50a225dc1cc5        node-dev-setup03   10737418240   Unclaimed    Active   21m
```
```
$ kubectl get bd -o wide
NAME                                           NODENAME           PATH                                   SIZE          CLAIMSTATE   STATUS   AGE
blockdevice-b8c766547ce524dd9cf53ef003d54558   node-dev-setup03   /dev/dm-0                              5368709120    Unclaimed    Active   21m
sparse-01e10418d6b3ff0e5955046bd36b0f79        node-dev-setup02   /var/openebs/sparse/0-ndm-sparse.img   10737418240   Unclaimed    Active   21m
sparse-5698d9c1a580e6af110a8359fa292926        node-dev-setup01   /var/openebs/sparse/0-ndm-sparse.img   10737418240   Unclaimed    Active   21m
sparse-d1806a93ae6ecc94cebe50a225dc1cc5        node-dev-setup03   /var/openebs/sparse/0-ndm-sparse.img   10737418240   Unclaimed    Active   21m
```



Signed-off-by: chandan kumar <chandan.kr404@gmail.com>
