### PR TITLE
feat(script, yaml): customize the location for ndm cores (#362)

### DIFF
--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -2,17 +2,28 @@
 
 export GOTRACEBACK=crash
 
+# openebs base directory inside the container
+OPENEBS_BASE_DIR="/var/openebs"
+# ndm base directory inside the container. It will be the ndm
+# directory inside openebs base directory
+NDM_BASE_DIR="${OPENEBS_BASE_DIR}/ndm"
+
 # set ulimit to 0, if the core dump is not enabled
 if [ -z "$ENABLE_COREDUMP" ]; then
   ulimit -c 0
 else
+  # making sure mountpath inside the container is available
+  if ! [ -d "${NDM_BASE_DIR}" ]; then
+    echo "OpenEBS/NDM Base directory not found"
+    exit 1
+  fi
   # set ulimit to unlimited and create a core directory for creating coredump
   echo "[entrypoint.sh] enabling core dump."
   ulimit -c unlimited
-  echo "[entrypoint.sh] creating $SPARSE_FILE_DIR/core if not exists."
-  mkdir -p "$SPARSE_FILE_DIR/core"
-  echo "[entrypoint.sh] changing directory to $SPARSE_FILE_DIR/core"
-  cd "$SPARSE_FILE_DIR/core" || exit
+  echo "[entrypoint.sh] creating ${NDM_BASE_DIR}/core if not exists."
+  mkdir -p "${NDM_BASE_DIR}/core"
+  echo "[entrypoint.sh] changing directory to ${NDM_BASE_DIR}/core"
+  cd "${NDM_BASE_DIR}/core" || exit
 fi
 
 echo "[entrypoint.sh] launching ndm process."

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -139,6 +139,8 @@ spec:
         - name: procmount
           mountPath: /host/proc
           readOnly: true
+        - name: basepath
+          mountPath: /var/openebs/ndm
         - name: sparsepath
           mountPath: /var/openebs/sparse
         env:
@@ -180,6 +182,10 @@ spec:
         hostPath:
           path: /proc
           type: Directory
+      - name: basepath
+        hostPath:
+          path: /var/openebs/ndm
+          type: DirectoryOrCreate
       - name: sparsepath
         hostPath:
           path: /var/openebs/sparse


### PR DESCRIPTION
Make the location for saving the NDM cores inline with other openebs components by providing the location where core's should be saved. 

The default location is /var/openebs/ndm, which can be changed by passing the right value in the deployment file.
 
cherry-pick : 692804837755a2166353a19c95b7f799eb24c6ea

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

