### PR TITLE
feat(build): enable auto build for arm64 binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,45 +15,37 @@ sudo: required
 services:
   - docker
 
+jobs:
+  include:
+    - os: linux
+      arch: amd64
+    - os: linux
+      arch: arm64
+
 addons:
   apt:
     update: true
 
 install:
   - make bootstrap
-  - sudo apt-get install --yes libudev-dev
   - if [ "$TRAVIS_BUILD_DIR" != "$GOPATH/src/github.com/openebs/node-disk-manager" ]; then
       mkdir -p $GOPATH/src/github.com/openebs/;
       mv $TRAVIS_BUILD_DIR $GOPATH/src/github.com/openebs;
       cd $GOPATH/src/github.com/openebs/node-disk-manager;
     fi
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64
-  - sudo chmod +x minikube
-  - sudo mv minikube /usr/local/bin/
-  # we need openSeaChest repo to build node-disk-manager
-  - pushd .
-  - cd ..
-  # Hotfix-Makefile_fix is the Release-19.06 with certain fixes in Makefile
-  - git clone --recursive --branch Release-19.06.02 https://github.com/openebs/openSeaChest.git
-  - cd openSeaChest/Make/gcc 
-  - make release
-  - cd ../../
-  - sudo cp opensea-common/Make/gcc/lib/libopensea-common.a /usr/lib 
-  - sudo cp opensea-operations/Make/gcc/lib/libopensea-operations.a /usr/lib 
-  - sudo cp opensea-transport/Make/gcc/lib/libopensea-transport.a /usr/lib
-  - popd 
+  - make install-dep
+  - make install-test-infra
 
 before_script:
-  - sudo minikube start --vm-driver=none
-  - sudo minikube update-context
-  # By default root is the owner of the .minikube directory. This is changed to $USER so that
-  # from the integration tests which run as a non-root user can access the files and connect
-  # to the minikube cluster
-  - sudo chown -R $USER $HOME/.minikube
-  - sudo chown -R $USER $HOME/.kube
+  - if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then
+      sudo minikube start --vm-driver=none;
+      sudo minikube update-context;
+      sudo chown -R $USER $HOME/.minikube;
+      sudo chown -R $USER $HOME/.kube;
+      make shellcheck;
+    fi
 
 script:
-  - make shellcheck
   - make
   # Here sudo -E env "PATH=$PATH" make test is required for running tests with
   # sudo permissions since we are making use of scsi device mockdata in smartprobe_test

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,17 @@ bootstrap:
 		go get -u $$tool; \
 	done
 
+.PHONY: install-dep
+install-dep:
+	@echo "--> Installing external dependencies for building node-disk-manager"
+	$(PWD)/build/install-dep.sh
+
+.PHONY: install-test-infra
+install-test-infra:
+	@echo "--> Installing test infra for running integration tests"
+	# installing test infrastructure is dependent on the platform
+	$(PWD)/build/install-test-infra.sh ${XC_ARCH}
+
 .PHONY: header
 header:
 	@echo "----------------------------"
@@ -134,11 +145,12 @@ version:
 .PHONY: test
 test: 	vet fmt
 	@echo "--> Running go test";
-	$(PWD)/build/test.sh
+	$(PWD)/build/test.sh ${XC_ARCH}
 
 .PHONY: integration-test
 integration-test:
-	go test -v -timeout 20m github.com/openebs/node-disk-manager/integration_tests/sanity
+	@echo "--> Running integration test"
+	$(PWD)/build/integration-test.sh ${XC_ARCH}
 
 .PHONY: Dockerfile.ndm
 Dockerfile.ndm: ./build/ndm-daemonset/Dockerfile.in

--- a/build/install-dep.sh
+++ b/build/install-dep.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script is used to install external dependencies that are
+# used for building NDM as well as checking
+
+set -e
+# udev is required for building NDM.
+sudo apt-get install --yes libudev-dev
+pushd .
+cd ..
+# we need openSeaChest repo to build node-disk-manager
+git clone --recursive --branch Release-19.06.02 https://github.com/openebs/openSeaChest.git
+cd openSeaChest/Make/gcc
+make release
+cd ../../
+sudo cp opensea-common/Make/gcc/lib/libopensea-common.a /usr/lib
+sudo cp opensea-operations/Make/gcc/lib/libopensea-operations.a /usr/lib
+sudo cp opensea-transport/Make/gcc/lib/libopensea-transport.a /usr/lib
+popd

--- a/build/install-test-infra.sh
+++ b/build/install-test-infra.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Test infrastructure for running integration tests on NDM.
+# Currently minikube is used to run the integration tests. Since
+# minikube is available only on amd64, integration tests can be run
+# only on that platform
+
+ARCH=$1
+if [ -z "$ARCH" ]; then
+  echo "Test Infra platform not specified. Exiting. "
+  exit 1
+fi
+
+if [ "$ARCH" == "amd64" ]; then
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.0.0/minikube-linux-amd64
+  sudo chmod +x minikube
+  sudo mv minikube /usr/local/bin/
+fi

--- a/build/integration-test.sh
+++ b/build/integration-test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+# architecute on which integration tests need to be run
+ARCH=$1
+
+if [ -z "$ARCH" ]; then
+  echo "platform not specified for running tests. Exiting."
+  exit 1
+fi
+
+# currently integration tests are run only for amd64
+if [ "$ARCH" != "amd64" ]; then
+  exit 0
+fi
+
+go test -v -timeout 20m github.com/openebs/node-disk-manager/integration_tests/sanity

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 #
 # This script runs tests and generates a report file.
+
 set -e
+
+# architecute on which tests need to be run
+ARCH=$1
+
+if [ -z "$ARCH" ]; then
+  echo "platform not specified for running tests. Exiting."
+  exit 1
+fi
+
+# currently tests are run only for amd64
+if [ "$ARCH" != "amd64" ]; then
+  exit 0
+fi
+
 echo "" > coverage.txt
 PACKAGES=$(go list ./... | grep -v '/vendor/\|/pkg/apis/\|/pkg/client/\|integration_test')
 for d in $PACKAGES; do


### PR DESCRIPTION
- auto build and push `arm64` and `amd64` binaries
- make tests dependent on the platform

shellcheck, unit-tests and integration tests will be run only on `amd64`, along with the build. On all other platforms the binary will be built and image will be pushed.