### PR TITLE
Adding ppc64le build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
       arch: amd64
     - os: linux
       arch: arm64
+    - os: linux
+      arch: ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
This PR adds ppc64le to travis builds.