### PR TITLE
feat(config): add support for feature gates.

### DIFF
--- a/build/ndm-daemonset/Dockerfile.in
+++ b/build/ndm-daemonset/Dockerfile.in
@@ -9,10 +9,4 @@ ARG ARCH
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm
-COPY build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint.sh
-
-#Expose port 9090
-EXPOSE 9090
-
-#Set the default command
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+COPY build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint

--- a/build/ndm-daemonset/Dockerfile.in
+++ b/build/ndm-daemonset/Dockerfile.in
@@ -9,4 +9,8 @@ ARG ARCH
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm
-COPY build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint
+COPY build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+
+#Set the default command
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/ndm-daemonset/entrypoint.sh
+++ b/build/ndm-daemonset/entrypoint.sh
@@ -27,7 +27,7 @@ else
 fi
 
 echo "[entrypoint.sh] launching ndm process."
-/usr/sbin/ndm start &
+/usr/sbin/ndm start "$@" &
 
 #sigterm caught SIGTERM signal and forward it to child process
 _sigterm() {

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -46,6 +46,9 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 	cmd.PersistentFlags().StringVar(&options.ConfigFilePath, "config",
 		controller.DefaultConfigFilePath,
 		"Path to config file")
+	cmd.PersistentFlags().StringSliceVar(&options.FeatureGate, "feature-gates",
+		nil,
+		"FeatureGates to be enabled or disabled")
 	_ = goflag.CommandLine.Parse([]string{})
 
 	cmd.AddCommand(

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -163,11 +163,11 @@ func (c *Controller) SetControllerOptions(opts NDMOptions) error {
 	// set the config for running NDM daemon
 	c.SetNDMConfig(opts)
 	// set the feature gates on NDM daemon
-	if fg, err := features.ParseFeatureGate(opts.FeatureGate, features.DefaultFeatureGates); err != nil {
+	fg, err := features.ParseFeatureGate(opts.FeatureGate, features.DefaultFeatureGates)
+	if err != nil {
 		return fmt.Errorf("error setting feature gate %v", err)
-	} else {
-		c.FeatureGates = fg
 	}
+	c.FeatureGates = fg
 	c.Filters = make([]*Filter, 0)
 	c.Probes = make([]*Probe, 0)
 	c.NodeAttributes = make(map[string]string, 0)

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openebs/node-disk-manager/pkg/apis"
+	"github.com/openebs/node-disk-manager/pkg/features"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -101,6 +102,8 @@ var ControllerBroadcastChannel = make(chan *Controller)
 // NDMOptions defines the options to run the NDM daemon
 type NDMOptions struct {
 	ConfigFilePath string
+	// holds the slice of feature gates.
+	FeatureGate []string
 }
 
 // Controller is the controller implementation for disk resources
@@ -115,6 +118,8 @@ type Controller struct {
 	// NodeAttribute is a map of various attributes of the node in which this daemon is running.
 	// The attributes can be hostname, nodename, zone, failure-domain etc
 	NodeAttributes map[string]string
+	// Feature gates for the NDM daemon
+	FeatureGates features.FeatureGate
 }
 
 // NewController returns a controller pointer for any error case it will return nil
@@ -157,6 +162,12 @@ func NewController() (*Controller, error) {
 func (c *Controller) SetControllerOptions(opts NDMOptions) error {
 	// set the config for running NDM daemon
 	c.SetNDMConfig(opts)
+	// set the feature gates on NDM daemon
+	if fg, err := features.ParseFeatureGate(opts.FeatureGate, features.DefaultFeatureGates); err != nil {
+		return fmt.Errorf("error setting feature gate %v", err)
+	} else {
+		c.FeatureGates = fg
+	}
 	c.Filters = make([]*Filter, 0)
 	c.Probes = make([]*Probe, 0)
 	c.NodeAttributes = make(map[string]string, 0)

--- a/cmd/ndm_daemonset/controller/ndmconfig.go
+++ b/cmd/ndm_daemonset/controller/ndmconfig.go
@@ -20,8 +20,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
-	"github.com/openebs/node-disk-manager/pkg/util"
-
 	"github.com/ghodss/yaml"
 	"k8s.io/klog"
 )
@@ -36,10 +34,6 @@ const (
 type NodeDiskManagerConfig struct {
 	ProbeConfigs  []ProbeConfig  `json:"probeconfigs"`  // ProbeConfigs contains configs of Probes
 	FilterConfigs []FilterConfig `json:"filterconfigs"` // FilterConfigs contains configs of Filters
-
-	// FeatureGates contains configs to enable and disable experimental
-	// features
-	FeatureGates []FeatureGate `json:"featuregates,omitempty"`
 }
 
 // ProbeConfig contains configs of Probe
@@ -56,15 +50,6 @@ type FilterConfig struct {
 	State   string `json:"state"`   // State is state of Filter
 	Include string `json:"include"` // Include contains , separated values which we want to include for filter
 	Exclude string `json:"exclude"` // Exclude contains , separated values which we want to exclude for filter
-}
-
-// FeatureGate contains state for an experimental feature.
-type FeatureGate struct {
-	// Feature to be made available
-	Feature string `json:"feature"`
-
-	// State of the feature.
-	State string `json:"state"`
 }
 
 // SetNDMConfig sets config for probes and filters which user provides via configmap. If
@@ -87,14 +72,6 @@ func (c *Controller) SetNDMConfig(opts NDMOptions) {
 		c.NDMConfig = nil
 		klog.Error("unable to set ndm config : ", err)
 		return
-	}
-
-	for _, featureGate := range ndmConfig.FeatureGates {
-		if util.CheckTruthy(featureGate.State) {
-			klog.V(2).Infof("Feature Gate %s enabled", featureGate.Feature)
-		} else {
-			klog.V(2).Infof("Feature Gate %s disabled", featureGate.Feature)
-		}
 	}
 
 	c.NDMConfig = &ndmConfig

--- a/integration_tests/yamls/daemonset.yaml
+++ b/integration_tests/yamls/daemonset.yaml
@@ -27,8 +27,6 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
-        command:
-          - "/usr/local/bin/entrypoint"
         args:
           - -v=2
 #          - --feature-gates="GPTBasedUUID"

--- a/integration_tests/yamls/daemonset.yaml
+++ b/integration_tests/yamls/daemonset.yaml
@@ -27,6 +27,11 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
+        command:
+          - "/usr/local/bin/entrypoint"
+        args:
+          - -v=2
+#          - --feature-gates="GPTBasedUUID"
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -125,6 +125,11 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
+        command:
+          - "/usr/local/bin/entrypoint"
+        args:
+          - -v=2
+#          - --feature-gates="GPTBasedUUID"
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -125,8 +125,6 @@ spec:
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
-        command:
-          - "/usr/local/bin/entrypoint"
         args:
           - -v=2
 #          - --feature-gates="GPTBasedUUID"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,0 +1,68 @@
+package features
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openebs/node-disk-manager/pkg/util"
+
+	"k8s.io/klog"
+)
+
+// FeatureGate type represents the map of features and the state
+type FeatureGate map[Feature]bool
+
+// Feature is a typed string for a given feature
+type Feature string
+
+const (
+	// Feature flag to enable the blockdevice algorithm mentioned
+	// in https://github.com/openebs/openebs/pull/2666
+	GPTBasedUUID Feature = "GPTBasedUUID"
+)
+
+// DefaultFeatureGates is the list of feature gates that are added by default
+var DefaultFeatureGates = []Feature{
+	GPTBasedUUID,
+}
+
+// IsEnabled returns true if the feature is enabled
+func (fg FeatureGate) IsEnabled(f Feature) bool {
+	return fg[f]
+}
+
+// ParseFeatureGate parses a slice of string and create the feature-gate map
+func ParseFeatureGate(features []string, defaultFGs []Feature) (FeatureGate, error) {
+	fg := make(FeatureGate)
+	if len(features) == 0 {
+		klog.V(4).Info("No feature gates are set")
+		return fg, nil
+	}
+	// iterate through each feature and set its state onto the FeatureGate map
+	for _, feature := range features {
+		var f Feature
+		// by default if a feature gate is provided, it is enabled
+		isEnabled := true
+		// if the feature is specified in the format
+		// MyFeature=false, the string need to be parsed and
+		// corresponding state to be set on the feature
+		s := strings.Split(feature, "=")
+		f = Feature(s[0])
+		// only if length after splitting =2, we need to check whether the
+		// feature is enabled or disabled
+		if len(s) == 2 {
+			isEnabled = util.CheckTruthy(s[1])
+		} else if len(s) > 2 {
+			// if length > 2 , there is some error in the format specified
+			return fg, fmt.Errorf("incorrect format. cannot parse feature %s", feature)
+		}
+		// check if the feature flag provided was available in the list of
+		// supported features
+		if !containsFeature(defaultFGs, f) {
+			return fg, fmt.Errorf("unknown feature flag %s", f)
+		}
+		fg[f] = isEnabled
+		klog.Infof("Feature gate: %s, state: %s", f, util.StateStatus(isEnabled))
+	}
+	return fg, nil
+}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -16,8 +16,9 @@ type FeatureGate map[Feature]bool
 type Feature string
 
 const (
-	// Feature flag to enable the blockdevice algorithm mentioned
-	// in https://github.com/openebs/openebs/pull/2666
+	// GPTBasedUUID feature flag is used to enable the
+	// blockdevice UUID algorithm mentioned in
+	// https://github.com/openebs/openebs/pull/2666
 	GPTBasedUUID Feature = "GPTBasedUUID"
 )
 

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -1,0 +1,130 @@
+package features
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFeatureGateIsEnabled(t *testing.T) {
+	testFG := make(FeatureGate)
+	testFG["feature1"] = false
+	testFG["feature2"] = true
+	tests := map[string]struct {
+		fg      FeatureGate
+		feature Feature
+		want    bool
+	}{
+		"when feature gate is empty": {
+			fg:      nil,
+			feature: "test",
+			want:    false,
+		},
+		"when feature gate does not have the feature": {
+			fg:      testFG,
+			feature: "feature3",
+			want:    false,
+		},
+		"when feature gate has the feature and feature is disabled": {
+			fg:      testFG,
+			feature: "feature1",
+			want:    false,
+		},
+		"when feature gate has the feature and feature is enabled": {
+			fg:      testFG,
+			feature: "feature2",
+			want:    true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := tt.fg.IsEnabled(tt.feature); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFeatureGate(t *testing.T) {
+	F1 := Feature("FeatureGate1")
+	F2 := Feature("FeatureGate2")
+	F3 := Feature("FeatureGate3")
+	type args struct {
+		features   []string
+		defaultFGs []Feature
+	}
+	tests := map[string]struct {
+		args    args
+		want    FeatureGate
+		wantErr bool
+	}{
+		"empty feature gate slice": {
+			args: args{
+				features:   nil,
+				defaultFGs: DefaultFeatureGates,
+			},
+			want:    make(map[Feature]bool),
+			wantErr: false,
+		},
+		"a single feature is added": {
+			args: args{
+				features:   []string{"GPTBasedUUID"},
+				defaultFGs: DefaultFeatureGates,
+			},
+			want: map[Feature]bool{
+				GPTBasedUUID: true,
+			},
+		},
+		"a single feature is set in disabled mode": {
+			args: args{
+				features:   []string{"GPTBasedUUID=false"},
+				defaultFGs: DefaultFeatureGates,
+			},
+			want: map[Feature]bool{
+				GPTBasedUUID: false,
+			},
+			wantErr: false,
+		},
+		"feature that is not present in the default feature": {
+			args: args{
+				features:   []string{"WrongFeatureGate"},
+				defaultFGs: DefaultFeatureGates,
+			},
+			want:    make(map[Feature]bool),
+			wantErr: true,
+		},
+		"multiple features in enabled and disabled state": {
+			args: args{
+				features:   []string{"FeatureGate1", "FeatureGate2=false", "FeatureGate3=true"},
+				defaultFGs: []Feature{F1, F2, F3},
+			},
+			want: FeatureGate{
+				F1: true,
+				F2: false,
+				F3: true,
+			},
+			wantErr: false,
+		},
+		"wrong format in one feature gate": {
+			args: args{
+				features:   []string{"FeatureGate1", "FeatureGate2=true=true"},
+				defaultFGs: []Feature{F1, F2, F3},
+			},
+			want: FeatureGate{
+				F1: true,
+			},
+			wantErr: true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParseFeatureGate(tt.args.features, tt.args.defaultFGs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseFeatureGate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseFeatureGate() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/features/util.go
+++ b/pkg/features/util.go
@@ -1,0 +1,12 @@
+package features
+
+// containsFeature checks if the given feature is present in the
+// list of features.
+func containsFeature(features []Feature, f Feature) bool {
+	for _, feature := range features {
+		if f == feature {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
added support for feature gates. The features to be enabled or disabled can be specified via the command line arguments in the operator-yaml.

example:
```
serviceAccountName: openebs-ndm-operator
      containers:
      - name: node-disk-manager
        image: akhilerm/node-disk-manager-amd64:ci
        args:
          - -v=4
          - --feature-gates="GPTBasedUUID"
        imagePullPolicy: Always
        securityContext:
          privileged: true
```
The above will enable the UUID feature on the NDM daemon.

If NDM is used as a standalone binary instead of the operator-yaml/docker image, then the feature flags are enabled by `--feature-gates="Feature1,Feature2,Feature3"`

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>