### PR TITLE
feat(core, udev): add partition related information to blockdevice

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -28,6 +28,7 @@ package blockdevice
 //				}
 // 				NodeAttributes:map[hostname:my-machine]
 // 				FSInfo:{
+// 					FileSystemUUID:7e7f160b-0e79-478b-b006-1ebc6d0050dd
 // 					FileSystem:ext4
 // 					MountPoint:[/home]
 // 				}
@@ -50,6 +51,7 @@ package blockdevice
 //				}
 // 				NodeAttributes:map[hostname:my-machine]
 // 				FSInfo:{
+// 					FileSystemUUID:AQkPql-2MBI-O5cY-gn3O-EFvZ-66Oe-d4mnjD
 // 					FileSystem:LVM2_member
 // 					MountPoint:[]
 // 				}
@@ -71,7 +73,8 @@ package blockdevice
 //				}
 // 				NodeAttributes:map[hostname:my-machine]
 // 				FSInfo:{
-// 					FileSystem:ext4
+// 					FileSystemUUID:7e7f160b-0e79-478b-b006-1ebc6d0050dd
+//					FileSystem:ext4
 // 					MountPoint:[]
 // 				}
 // 				Parent:
@@ -107,6 +110,9 @@ type BlockDevice struct {
 	// DeviceAttributes contains the attributes of this device, like hardcoded
 	// information on the disk
 	DeviceAttributes DeviceAttribute
+
+	// PartitionInfo contains details if this blockdevice is a partition
+	PartitionInfo PartitionInformation
 
 	// Parent is the parent device of this blockdevice, if it exists.
 	// It will always be a single device.
@@ -178,6 +184,9 @@ const (
 
 // FileSystemInformation contains the filesystem and mount information of blockdevice, if present
 type FileSystemInformation struct {
+	// FileSystemUUID is the UUID of the filesystem on the blockdevice
+	FileSystemUUID string
+
 	// FileSystem is the filesystem present on the blockdevice
 	FileSystem string
 
@@ -269,6 +278,22 @@ type TemperatureInformation struct {
 
 	// CurrentTemperature is the temperature of the drive in celsius
 	CurrentTemperature int16
+}
+
+// PartitionInformation contains information related to the partition, if this
+// blockdevice is a partition
+type PartitionInformation struct {
+	// PartitionNumber is the partition number
+	PartitionNumber uint8
+
+	// PartitionEntryUUID is the UUID of the partition
+	PartitionEntryUUID string
+
+	// PartitionTableUUID is the UUID of the partition table
+	PartitionTableUUID string
+
+	// PartitionTableType is the type of the partition (dos/gpt)
+	PartitionTableType string
 }
 
 // Status is used to represent the status of the blockdevice

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -18,10 +18,10 @@ package probe
 
 import (
 	"errors"
-	"github.com/openebs/node-disk-manager/blockdevice"
-	"github.com/openebs/node-disk-manager/pkg/hierarchy"
 
+	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	"github.com/openebs/node-disk-manager/pkg/hierarchy"
 	libudevwrapper "github.com/openebs/node-disk-manager/pkg/udev"
 	"github.com/openebs/node-disk-manager/pkg/udevevent"
 	"github.com/openebs/node-disk-manager/pkg/util"
@@ -148,6 +148,11 @@ func (up *udevProbe) scan() error {
 			deviceDetails.UUID = uuid
 			deviceDetails.SysPath = newUdevice.GetSyspath()
 			deviceDetails.DevPath = newUdevice.GetPath()
+			deviceDetails.DeviceAttributes.DeviceType = newUdevice.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
+			deviceDetails.DeviceAttributes.WWN = newUdevice.GetPropertyValue(libudevwrapper.UDEV_WWN)
+			deviceDetails.PartitionInfo.PartitionTableUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_TABLE_UUID)
+			deviceDetails.PartitionInfo.PartitionEntryUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_UUID)
+			deviceDetails.FSInfo.FileSystemUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_FS_UUID)
 			diskInfo = append(diskInfo, deviceDetails)
 
 			// get the dependents of the block device and log it
@@ -158,6 +163,10 @@ func (up *udevProbe) scan() error {
 			if err != nil {
 				klog.Error("error getting dependent devices for ", deviceDetails.DevPath)
 			} else {
+				deviceDetails.Partitions = dependents.Partitions
+				deviceDetails.Holders = dependents.Holders
+				deviceDetails.Parent = dependents.Parent
+				deviceDetails.Slaves = dependents.Slaves
 				klog.Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
 			}
 		}
@@ -200,9 +209,17 @@ func (up *udevProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice
 		})
 	}
 	blockDevice.DeviceAttributes.DeviceType = udevDiskDetails.DiskType
+
 	// filesystem info of the attached device. Only filesystem data will be filled in the struct,
 	// as the mountpoint related information will be filled in by the mount probe
 	blockDevice.FSInfo.FileSystem = udevDiskDetails.FileSystem
+
+	blockDevice.PartitionInfo.PartitionTableType = udevDiskDetails.PartitionTableType
+
+	// if this is a partition, partition number and partition UUID need to be filled
+	if udevDiskDetails.DiskType == libudevwrapper.UDEV_PARTITION {
+		blockDevice.PartitionInfo.PartitionNumber = udevDiskDetails.PartitionNumber
+	}
 }
 
 // listen listens for event message over UdevEventMessages channel

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -112,6 +112,7 @@ func TestFillDiskDetails(t *testing.T) {
 	expectedDiskInfo.DeviceAttributes.Serial = mockOsDiskDetails.Serial
 	expectedDiskInfo.DeviceAttributes.Vendor = mockOsDiskDetails.Vendor
 	expectedDiskInfo.DeviceAttributes.WWN = mockOsDiskDetails.Wwn
+	expectedDiskInfo.PartitionInfo.PartitionTableType = mockOsDiskDetails.PartTableType
 	expectedDiskInfo.DevLinks = append(expectedDiskInfo.DevLinks, blockdevice.DevLink{
 		Kind:  libudevwrapper.BY_ID_LINK,
 		Links: mockOsDiskDetails.ByIdDevLinks,

--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -77,16 +77,16 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 	}
 	defer device.UdevDeviceUnref()
 	expectedDiskDetails := UdevDiskDetails{
-		Model:          diskDetails.Model,
-		Serial:         diskDetails.Serial,
-		Vendor:         diskDetails.Vendor,
-		WWN:            diskDetails.Wwn,
-		DiskType:       diskDetails.DevType,
-		Path:           diskDetails.DevNode,
-		ByIdDevLinks:   diskDetails.ByIdDevLinks,
-		ByPathDevLinks: diskDetails.ByPathDevLinks,
+		Model:              diskDetails.Model,
+		Serial:             diskDetails.Serial,
+		Vendor:             diskDetails.Vendor,
+		WWN:                diskDetails.Wwn,
+		DiskType:           diskDetails.DevType,
+		Path:               diskDetails.DevNode,
+		ByIdDevLinks:       diskDetails.ByIdDevLinks,
+		ByPathDevLinks:     diskDetails.ByPathDevLinks,
+		PartitionTableType: diskDetails.PartTableType,
 	}
-	assert.Equal(t, expectedDiskDetails, device.DiskInfoFromLibudev())
 	tests := map[string]struct {
 		actualDetails   UdevDiskDetails
 		expectedDetails UdevDiskDetails
@@ -95,7 +95,7 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.actualDetails, test.expectedDetails)
+			assert.Equal(t, test.expectedDetails, test.actualDetails)
 		})
 	}
 }

--- a/pkg/udevevent/event_test.go
+++ b/pkg/udevevent/event_test.go
@@ -54,6 +54,17 @@ func TestProcess(t *testing.T) {
 	deviceDetails := &blockdevice.BlockDevice{}
 	deviceDetails.UUID = osDiskDetails.Uid
 	deviceDetails.SysPath = osDiskDetails.SysPath
+	deviceDetails.DevPath = osDiskDetails.DevNode
+
+	deviceDetails.DeviceAttributes.DeviceType = osDiskDetails.DevType
+	deviceDetails.DeviceAttributes.WWN = osDiskDetails.Wwn
+	deviceDetails.PartitionInfo.PartitionTableUUID = osDiskDetails.PartTableUUID
+
+	deviceDetails.Parent = osDiskDetails.Dependents.Parent
+	deviceDetails.Partitions = osDiskDetails.Dependents.Partitions
+	deviceDetails.Holders = osDiskDetails.Dependents.Holders
+	deviceDetails.Slaves = osDiskDetails.Dependents.Slaves
+
 	diskInfo = append(diskInfo, deviceDetails)
 	expectedEvent.eventDetails.Action = ""
 	expectedEvent.eventDetails.Devices = diskInfo


### PR DESCRIPTION
- added PartitionInfo struct which contains information if the given blockdevice is a partition. The information includes, partition number, parition UUID, partition table UUID and partition table type.
- added FileSystemUUID which will store the UUID of the filesystem, if a filesystem exists on the blockdevice
- fetch partition number, partition table (UUID/type), partition UUID from udev
- fetch partition number, partition table (UUID/type), partition UUID from udev
- fill all details required for creating UUID during udev event, instead of relying on additional probe. This will help to generate UUID even if all the probe fails.