### PR TITLE
refact(seachest,probe): remove unused attributes from seachest probe

### DIFF
--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -102,41 +102,6 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 		return
 	}
 
-	if blockDevice.DevPath == "" {
-		blockDevice.DevPath = seachestProbe.SeachestIdentifier.GetPath(driveInfo)
-		klog.V(4).Infof("Path:%s filled by seachest.", blockDevice.DevPath)
-	}
-
-	if blockDevice.NodeAttributes[controller.HostNameKey] == "" {
-		blockDevice.NodeAttributes[controller.HostNameKey] = seachestProbe.SeachestIdentifier.GetHostName(driveInfo)
-		klog.V(4).Infof("Disk: %s NodeAttribute:%s filled by seachest.", blockDevice.DevPath, blockDevice.NodeAttributes[controller.HostNameKey])
-	}
-
-	if blockDevice.DeviceAttributes.Model == "" {
-		blockDevice.DeviceAttributes.Model = seachestProbe.SeachestIdentifier.GetModelNumber(driveInfo)
-		klog.V(4).Infof("Disk: %s Model:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.Model)
-	}
-
-	if blockDevice.DeviceAttributes.WWN == "" {
-		blockDevice.DeviceAttributes.WWN = seachestProbe.SeachestIdentifier.GetUuid(driveInfo)
-		klog.V(4).Infof("Disk: %s WWN:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.WWN)
-	}
-
-	if blockDevice.Capacity.Storage == 0 {
-		blockDevice.Capacity.Storage = seachestProbe.SeachestIdentifier.GetCapacity(driveInfo)
-		klog.V(4).Infof("Disk: %s Capacity:%d filled by seachest.", blockDevice.DevPath, blockDevice.Capacity.Storage)
-	}
-
-	if blockDevice.DeviceAttributes.Serial == "" {
-		blockDevice.DeviceAttributes.Serial = seachestProbe.SeachestIdentifier.GetSerialNumber(driveInfo)
-		klog.V(4).Infof("Disk: %s Serial:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.Serial)
-	}
-
-	if blockDevice.DeviceAttributes.Vendor == "" {
-		blockDevice.DeviceAttributes.Vendor = seachestProbe.SeachestIdentifier.GetVendorID(driveInfo)
-		klog.V(4).Infof("Disk: %s Vendor:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.Vendor)
-	}
-
 	if blockDevice.DeviceAttributes.FirmwareRevision == "" {
 		blockDevice.DeviceAttributes.FirmwareRevision = seachestProbe.SeachestIdentifier.GetFirmwareRevision(driveInfo)
 		klog.V(4).Infof("Disk: %s FirmwareRevision:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.FirmwareRevision)
@@ -152,14 +117,16 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 		klog.V(4).Infof("Disk: %s PhysicalSectorSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
 	}
 
+	if blockDevice.DeviceAttributes.DriveType == "" {
+		blockDevice.DeviceAttributes.DriveType = seachestProbe.SeachestIdentifier.DriveType(driveInfo)
+		klog.V(4).Infof("Disk: %s DriveType:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.DriveType)
+	}
+
+	// All the below mentioned fields will be filled in only after BlockDevice struct
+	// starts supporting them.
 	/*if d.RotationRate == 0 {
 		d.RotationRate = seachestProbe.SeachestIdentifier.GetRotationRate(driveInfo)
 		klog.V(4).Infof("Disk: %s RotationRate:%d filled by seachest.", d.Path, d.RotationRate)
-	}
-
-	if d.DriveType == "" {
-		d.DriveType = seachestProbe.SeachestIdentifier.DriveType(driveInfo)
-		klog.V(4).Infof("Disk: %s DriveType:%s filled by seachest.", d.Path, d.DriveType)
 	}*/
 
 	/*if d.TotalBytesRead == 0 {


### PR DESCRIPTION
Attributes that are guaranteed to be filled by other probes are removed from seachest. 
seachest-probe will be used to fetch details that are exclusively given by seachest library.

Note: seachest can't be used to fill in storage/capacity related fields,
because the library will always report the capacity/blocksize of the main
disk even if the query is made for the partition. This will result in wrong
information being filled in the blockdevice resource. The sysfs probe will be
used to get all capacity related information from the sysfs filesystem

The following fields which are removed will be filled using:
Controller : Hostname
UdevProbe : DevPath, Model, WWN, Serial, Vendor
SysfsProbe : Storage, DriveType

Some fields like RotationRate, Endurance etc has been removed as they are still not yet supported by the BlockDevice resource.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>