### PR TITLE
feat(partition, uuid): add partition support and UUID implementation

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -114,23 +114,8 @@ type BlockDevice struct {
 	// PartitionInfo contains details if this blockdevice is a partition
 	PartitionInfo PartitionInformation
 
-	// Parent is the parent device of this blockdevice, if it exists.
-	// It will always be a single device.
-	Parent string
-
-	// Partitions is the list of partitions(again blockdevices) for
-	// this blockdevice, if it exists.
-	Partitions []string
-
-	// Holders is the list of blockdevices that are held by this blockdevice.
-	// eg: sda1 can hold dm-0. Then the list of sda1 will contain dm-0.
-	Holders []string
-
-	// Slaves is the list of blockdevices to which this blockdevice is a slave.
-	// Slaves are represented in SysFS under the block device layer,
-	// so they are dependent on the device
-	// eg: dm-0 is a slave to sda1. Then the list of dm-0 will contain sda1
-	Slaves []string
+	// DependentDevices stores the dependent devices
+	DependentDevices DependentBlockDevices
 
 	// TemperatureInfo stores the temperature information of the drive
 	TemperatureInfo TemperatureInformation
@@ -296,6 +281,28 @@ type PartitionInformation struct {
 	PartitionTableType string
 }
 
+// DependentBlockDevices contains path of all devices that are
+// related to this BlockDevice
+type DependentBlockDevices struct {
+	// Parent is the parent device of this blockdevice, if it exists.
+	// It will always be a single device.
+	Parent string
+
+	// Partitions is the list of partitions(again blockdevices) for
+	// this blockdevice, if it exists.
+	Partitions []string
+
+	// Holders is the list of blockdevices that are held by this blockdevice.
+	// eg: sda1 can hold dm-0. Then the list of sda1 will contain dm-0.
+	Holders []string
+
+	// Slaves is the list of blockdevices to which this blockdevice is a slave.
+	// Slaves are represented in SysFS under the block device layer,
+	// so they are dependent on the device
+	// eg: dm-0 is a slave to sda1. Then the list of dm-0 will contain sda1
+	Slaves []string
+}
+
 // Status is used to represent the status of the blockdevice
 type Status struct {
 	// State is the state of this BD like Active(Online), Inactive(Offline) or
@@ -323,3 +330,6 @@ const (
 	// claiming
 	Unclaimed string = "Unclaimed"
 )
+
+// Hierarchy is the block device hierarchy on the system
+type Hierarchy map[string]BlockDevice

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -331,5 +331,11 @@ const (
 	Unclaimed string = "Unclaimed"
 )
 
-// Hierarchy is the block device hierarchy on the system
+// Hierarchy is the block device hierarchy on the system.
+// This map will be used as in memory cache for storing the current state of
+// all block devices on the system. This cache helps to get the details of any
+// dependent blockdevices from a device.
+// eg: If at a certain point, we are processing sda1 and we need to get the UUID
+// of its parent device. We will get /dev/sda is the parent of /dev/sda1.
+// This will be used to query the cache and get/generate the UUID of /dev/sda.
 type Hierarchy map[string]BlockDevice

--- a/changelogs/unreleased/386_akhilerm
+++ b/changelogs/unreleased/386_akhilerm
@@ -1,0 +1,1 @@
+add support for partitions and enable the new UUID algorithm for blockdevice UUID generation

--- a/cmd/ndm_daemonset/app/command/device-list.go
+++ b/cmd/ndm_daemonset/app/command/device-list.go
@@ -87,7 +87,7 @@ func deviceList() error {
 		return err
 	}
 	// TODO @akhilerm should pass the filter as args to List, so that all devices will be listed
-	diskList, err := ctrl.ListBlockDeviceResource()
+	diskList, err := ctrl.ListBlockDeviceResource(false)
 	if err != nil {
 		return err
 	}

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -164,9 +164,9 @@ func (c *Controller) DeleteBlockDevice(name string) {
 		"ndm.blockdevice.delete.success", "Deleted blockdevice object ", name)
 }
 
-// ListBlockDeviceResource queries the etcd for the devices for the host/node
+// ListBlockDeviceResource queries the etcd for the devices
 // and returns list of blockdevice resources.
-func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
+func (c *Controller) ListBlockDeviceResource(listAll bool) (*apis.BlockDeviceList, error) {
 
 	blockDeviceList := &apis.BlockDeviceList{
 		TypeMeta: metav1.TypeMeta{
@@ -174,8 +174,11 @@ func (c *Controller) ListBlockDeviceResource() (*apis.BlockDeviceList, error) {
 			APIVersion: "openebs.io/v1alpha1",
 		},
 	}
-	filter := KubernetesHostNameLabel + "=" + c.NodeAttributes[HostNameKey]
-	filter = filter + "," + NDMManagedKey + "!=" + FalseString
+	filter := NDMManagedKey + "!=" + FalseString
+	// whether to list all devices in the cluster, or the devices that belong to this node
+	if !listAll {
+		filter = filter + "," + KubernetesHostNameLabel + "=" + c.NodeAttributes[HostNameKey]
+	}
 	opts := &client.ListOptions{}
 	_ = opts.SetLabelSelector(filter)
 	err := c.Clientset.List(context.TODO(), opts, blockDeviceList)
@@ -213,7 +216,7 @@ func (c *Controller) GetExistingBlockDeviceResource(blockDeviceList *apis.BlockD
 // system that will be marked as inactive.
 func (c *Controller) DeactivateStaleBlockDeviceResource(devices []string) {
 	listDevices := append(devices, GetActiveSparseBlockDevicesUUID(c.NodeAttributes[HostNameKey])...)
-	blockDeviceList, err := c.ListBlockDeviceResource()
+	blockDeviceList, err := c.ListBlockDeviceResource(false)
 	if err != nil {
 		klog.Error(err)
 		return
@@ -241,7 +244,7 @@ func (c *Controller) PushBlockDeviceResource(oldBlockDevice *apis.BlockDevice,
 // MarkBlockDeviceStatusToUnknown makes state of all resources owned by node unknown
 // This will call as a cleanup process before shutting down.
 func (c *Controller) MarkBlockDeviceStatusToUnknown() {
-	blockDeviceList, err := c.ListBlockDeviceResource()
+	blockDeviceList, err := c.ListBlockDeviceResource(false)
 	if err != nil {
 		klog.Error(err)
 		return

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -165,6 +165,8 @@ func (c *Controller) DeleteBlockDevice(name string) {
 
 // ListBlockDeviceResource queries the etcd for the devices
 // and returns list of blockdevice resources.
+// if listAll = true, all the BlockDevices in the cluster will be listed,
+// else only devices present in this node will be listed.
 func (c *Controller) ListBlockDeviceResource(listAll bool) (*apis.BlockDeviceList, error) {
 
 	blockDeviceList := &apis.BlockDeviceList{

--- a/cmd/ndm_daemonset/controller/blockdevicestore_test.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore_test.go
@@ -301,7 +301,7 @@ func TestListDeviceResource(t *testing.T) {
 	newDr.ObjectMeta.Labels[KubernetesHostNameLabel] = fakeController.NodeAttributes[HostNameKey]
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
-	listDevice, err := fakeController.ListBlockDeviceResource()
+	listDevice, err := fakeController.ListBlockDeviceResource(false)
 
 	// TypeMeta should be same
 	typeMeta := newFakeDeviceTypeMeta
@@ -352,7 +352,7 @@ func TestGetExistingDeviceResource(t *testing.T) {
 	newDr.ObjectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	fakeController.CreateBlockDevice(newDr)
 
-	listDr, err := fakeController.ListBlockDeviceResource()
+	listDr, err := fakeController.ListBlockDeviceResource(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/openebs/node-disk-manager/blockdevice"
 	"os"
 	"sync"
 	"time"
@@ -119,6 +120,8 @@ type Controller struct {
 	NodeAttributes map[string]string
 	// Feature gates for the NDM daemon
 	FeatureGates features.FeatureGate
+	// BDHierarchy stores the hierarchy of devices on this node
+	BDHierarchy blockdevice.Hierarchy
 }
 
 // NewController returns a controller pointer for any error case it will return nil
@@ -249,7 +252,7 @@ func getNamespace() (string, error) {
 // into Kubernetes
 func (c *Controller) WaitForBlockDeviceCRD() {
 	for {
-		_, err := c.ListBlockDeviceResource()
+		_, err := c.ListBlockDeviceResource(false)
 		if err != nil {
 			klog.Errorf("BlockDevice CRD is not available yet. Retrying after %v, error: %v", CRDRetryInterval, err)
 			time.Sleep(CRDRetryInterval)

--- a/cmd/ndm_daemonset/controller/probe.go
+++ b/cmd/ndm_daemonset/controller/probe.go
@@ -101,7 +101,6 @@ func (c *Controller) ListProbe() []*Probe {
 // FillBlockDeviceDetails lists registered probes and fills details from each probe
 func (c *Controller) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice) {
 	blockDevice.NodeAttributes = c.NodeAttributes
-	blockDevice.DeviceAttributes.DeviceType = NDMDefaultDiskType
 	probes := c.ListProbe()
 	for _, probe := range probes {
 		probe.FillBlockDeviceDetails(blockDevice)

--- a/cmd/ndm_daemonset/controller/probe_test.go
+++ b/cmd/ndm_daemonset/controller/probe_test.go
@@ -191,7 +191,6 @@ func TestFillDetails(t *testing.T) {
 	expectedDr.DeviceAttributes.Model = fakeModel
 	expectedDr.DeviceAttributes.Serial = fakeSerial
 	expectedDr.DeviceAttributes.Vendor = fakeVendor
-	expectedDr.DeviceAttributes.DeviceType = NDMDefaultDiskType
 
 	// create one fake Disk struct
 	actualDr := &bd.BlockDevice{}

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -72,9 +72,9 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 				continue
 			}
 			uuid, ok := generateUUID(*device)
-			// manaully create a single partition on the device
+			// manually create a single partition on the device
 			if !ok {
-				klog.Info("starting to create partitions")
+				klog.Info("starting to create partition")
 				d := partition.Disk{
 					DevPath:          device.DevPath,
 					DiskSize:         device.Capacity.Storage,

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -144,8 +144,6 @@ func (pe *ProbeEvent) deleteBlockDeviceEvent(msg controller.EventMessage) {
 		pe.Controller.DeactivateBlockDevice(*existingBlockDeviceResource)
 	}
 
-	// TODO @akhilerm check if rescan is required every time and take appropriate actions
-	//
 	// rescan only if GPT based UUID is disabled.
 	if !isDeactivated && !isGPTBasedUUIDEnabled {
 		go pe.initOrErrorEvent()

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -83,16 +83,8 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 					DiskSize:         device.Capacity.Storage,
 					LogicalBlockSize: uint64(device.DeviceAttributes.LogicalBlockSize),
 				}
-				if err := d.CreatePartitionTable(); err != nil {
-					klog.Errorf("error creating partition table for %s, %v", device.DevPath, err)
-					continue
-				}
-				if err = d.AddPartition(); err != nil {
+				if err := d.CreateSinglePartition(); err != nil {
 					klog.Errorf("error creating partition for %s, %v", device.DevPath, err)
-					continue
-				}
-				if err = d.ApplyPartitionTable(); err != nil {
-					klog.Errorf("error writing partition data to %s, %v", device.DevPath, err)
 					continue
 				}
 				klog.Infof("created new partition in %s", device.DevPath)

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -72,6 +72,8 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 			if err != nil {
 				isErrorDuringUpdate = true
 				klog.Error(err)
+				// if error occurs we should start the scan again
+				break
 			}
 		} else {
 			// if GPTBasedUUID is disabled and the device type is partition,

--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -198,7 +198,6 @@ func TestAddBlockDeviceEvent(t *testing.T) {
 	fakeDr.Spec.Details.Model = fakeModel
 	fakeDr.Spec.Details.Serial = fakeSerial
 	fakeDr.Spec.Details.Vendor = fakeVendor
-	fakeDr.Spec.Details.DeviceType = controller.NDMDefaultDiskType
 	fakeDr.Spec.Partitioned = controller.NDMNotPartitioned
 
 	tests := map[string]struct {

--- a/cmd/ndm_daemonset/probe/smartprobe_test.go
+++ b/cmd/ndm_daemonset/probe/smartprobe_test.go
@@ -44,7 +44,6 @@ func mockOsDiskToAPIBySmart() (apis.BlockDevice, error) {
 	fakeDetails := apis.DeviceDetails{
 		Compliance:       mockOsDiskDetails.Compliance,
 		FirmwareRevision: mockOsDiskDetails.FirmwareRevision,
-		DeviceType:       controller.NDMDefaultDiskType,
 		LogicalBlockSize: mockOsDiskDetails.LBSize,
 	}
 

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -181,13 +181,10 @@ func (up *udevProbe) scan() error {
 		}
 		newUdevice.UdevDeviceUnref()
 	}
-	if !up.controller.FeatureGates.IsEnabled(features.GPTBasedUUID) {
-		up.controller.DeactivateStaleBlockDeviceResource(disksUid)
-	} else {
-		// TODO deactivate all the stale blockdevices
-		// can deactivate all the blockdevices and they will be marked as active once
-		// the event is processed.
-	}
+
+	// when GPTBasedUUID is enabled, all the blockdevices will be made inactive initially.
+	// after that each device that is detected by the probe will be marked as Active.
+	up.controller.DeactivateStaleBlockDeviceResource(disksUid)
 	eventDetails := controller.EventMessage{
 		Action:  libudevwrapper.UDEV_ACTION_ADD,
 		Devices: diskInfo,

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -146,9 +146,10 @@ func (up *udevProbe) scan() error {
 		if newUdevice.IsDisk() || newUdevice.IsParitition() {
 			deviceDetails := &blockdevice.BlockDevice{}
 			if up.controller.FeatureGates.IsEnabled(features.GPTBasedUUID) {
-				// all fields that is used to generate UUID to be filled whenever the event is
-				// generated. This is required so that even if none of the probes work, the
-				// system should be able to generate the UUID of the blockdevice
+				// WWN, PartitionTableUUID/GPTLabel, PartitionUUID, FileSystemUUID and DeviceType
+				// are the fields we use to generate the UUID. These fields will be fetched
+				// from the udev event itself. This is to guarantee that we do not need to rely
+				// on any other probes to fill in those details which are critical for device identification.
 				deviceDetails.DeviceAttributes.DeviceType = newUdevice.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
 				deviceDetails.DeviceAttributes.WWN = newUdevice.GetPropertyValue(libudevwrapper.UDEV_WWN)
 				deviceDetails.PartitionInfo.PartitionTableUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_TABLE_UUID)

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -150,7 +150,6 @@ func (up *udevProbe) scan() error {
 				// are the fields we use to generate the UUID. These fields will be fetched
 				// from the udev event itself. This is to guarantee that we do not need to rely
 				// on any other probes to fill in those details which are critical for device identification.
-				deviceDetails.DeviceAttributes.DeviceType = newUdevice.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
 				deviceDetails.DeviceAttributes.WWN = newUdevice.GetPropertyValue(libudevwrapper.UDEV_WWN)
 				deviceDetails.PartitionInfo.PartitionTableUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_TABLE_UUID)
 				deviceDetails.PartitionInfo.PartitionEntryUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_UUID)
@@ -160,6 +159,7 @@ func (up *udevProbe) scan() error {
 				disksUid = append(disksUid, uuid)
 				deviceDetails.UUID = uuid
 			}
+			deviceDetails.DeviceAttributes.DeviceType = newUdevice.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
 			deviceDetails.SysPath = newUdevice.GetSyspath()
 			deviceDetails.DevPath = newUdevice.GetPath()
 			diskInfo = append(diskInfo, deviceDetails)

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -137,6 +137,9 @@ func (up *udevProbe) scan() error {
 	if err != nil {
 		return err
 	}
+	// everytime while performing the scan, we are re-initializing the
+	// disk map of the system
+	up.controller.BDHierarchy = make(blockdevice.Hierarchy)
 	for l := up.udevEnumerate.ListEntry(); l != nil; l = l.GetNextEntry() {
 		s := l.GetName()
 		newUdevice, err := up.udev.NewDeviceFromSysPath(s)
@@ -173,10 +176,7 @@ func (up *udevProbe) scan() error {
 			if err != nil {
 				klog.Error("error getting dependent devices for ", deviceDetails.DevPath)
 			} else {
-				deviceDetails.Partitions = dependents.Partitions
-				deviceDetails.Holders = dependents.Holders
-				deviceDetails.Parent = dependents.Parent
-				deviceDetails.Slaves = dependents.Slaves
+				deviceDetails.DependentDevices = dependents
 				klog.Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
 			}
 		}

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -173,6 +173,7 @@ func (up *udevProbe) scan() error {
 				Path: deviceDetails.DevPath,
 			}
 			dependents, err := devicePath.GetDependents()
+			// TODO if error occurs need to do a scan from the beginning
 			if err != nil {
 				klog.Error("error getting dependent devices for ", deviceDetails.DevPath)
 			} else {

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -126,7 +126,7 @@ spec:
       - name: node-disk-manager
         image: openebs/node-disk-manager-amd64:ci
         args:
-          - -v=2
+          - -v=4
           - --feature-gates="GPTBasedUUID"
         imagePullPolicy: Always
         securityContext:

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -127,16 +127,16 @@ spec:
         image: openebs/node-disk-manager-amd64:ci
         args:
           - -v=2
-#          - --feature-gates="GPTBasedUUID"
+          - --feature-gates="GPTBasedUUID"
         imagePullPolicy: Always
         securityContext:
           privileged: true
-        # make udev database available inside container
         volumeMounts:
         - name: config
           mountPath: /host/node-disk-manager.config
           subPath: node-disk-manager.config
           readOnly: true
+          # make udev database available inside container
         - name: udev
           mountPath: /run/udev
         - name: procmount
@@ -167,7 +167,7 @@ spec:
           value: "1073741824"
         # Specify the number of sparse files to be created
         - name: SPARSE_FILE_COUNT
-          value: "1"
+          value: "0"
         # Set the core dump env to enable core dump for NDM daemon
         #- name: ENABLE_COREDUMP
         #  value: "1"

--- a/pkg/hierarchy/device.go
+++ b/pkg/hierarchy/device.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package hierarchy
 
+import "github.com/openebs/node-disk-manager/blockdevice"
+
 var sysFSDirectoryPath = "/sys/"
 
 // Device represents a blockdevice. This struct is used by hierarchy pkg which is used to
@@ -25,26 +27,9 @@ type Device struct {
 	Path string
 }
 
-// DependentDevices represents all the dependent blockdevices of the given Device
-type DependentDevices struct {
-	// Parent is the parent device of the given blockdevice
-	Parent string
-
-	// Partitions are the partitions of this device if any
-	Partitions []string
-
-	// Holders is the slice of block-devices that are held by a given
-	// blockdevice
-	Holders []string
-
-	// Slaves is the slice of blockdevices to which the given blockdevice
-	// is a slave
-	Slaves []string
-}
-
 // GetDependents gets all the dependent devices for a given Device
-func (d *Device) GetDependents() (DependentDevices, error) {
-	dependents := DependentDevices{}
+func (d *Device) GetDependents() (blockdevice.DependentBlockDevices, error) {
+	dependents := blockdevice.DependentBlockDevices{}
 
 	// get the syspath of the blockdevice
 	blockDeviceSysPath, err := getDeviceSysPath(d.Path)

--- a/pkg/partition/partition_test.go
+++ b/pkg/partition/partition_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package partition
 
 import (
+	"testing"
+
 	"github.com/diskfs/go-diskfs/partition/gpt"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCreatePartitionTable(t *testing.T) {

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -33,7 +33,6 @@ import (
 )
 
 const (
-	NDMDiskPrefix             = "disk-"                // NDMPrefix used as disk's uuid prefix
 	NDMBlockDevicePrefix      = "blockdevice-"         // NDMBlockDevicePrefix used as device's uuid prefix
 	UDEV_SUBSYSTEM            = "block"                // udev to filter this device type
 	UDEV_SYSTEM               = "disk"                 // used to filter devices other than disk which udev tracks (eg. CD ROM)

--- a/pkg/udev/mockdata.go
+++ b/pkg/udev/mockdata.go
@@ -25,6 +25,7 @@ package udev
 import "C"
 import (
 	"bufio"
+	bd "github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/pkg/hierarchy"
 	"io/ioutil"
 	"os"
@@ -49,7 +50,7 @@ type MockOsDiskDetails struct {
 	PartTableUUID  string
 	ByIdDevLinks   []string
 	ByPathDevLinks []string
-	Dependents     hierarchy.DependentDevices
+	Dependents     bd.DependentBlockDevices
 }
 
 // mockDataStructUdev returns C udev struct for unit test.

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -72,7 +72,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 		deviceDetails.Holders = dependents.Holders
 		deviceDetails.Parent = dependents.Parent
 		deviceDetails.Slaves = dependents.Slaves
-		klog.Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
+		klog.V(4).Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
 	}
 
 	diskInfo = append(diskInfo, deviceDetails)

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -68,10 +68,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 		if err != nil {
 			klog.Errorf("could not get dependents for %s, %v", devicePath, err)
 		}
-		deviceDetails.Partitions = dependents.Partitions
-		deviceDetails.Holders = dependents.Holders
-		deviceDetails.Parent = dependents.Parent
-		deviceDetails.Slaves = dependents.Slaves
+		deviceDetails.DependentDevices = dependents
 		klog.V(4).Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
 	}
 

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -65,6 +65,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 			Path: deviceDetails.DevPath,
 		}
 		dependents, err := devicePath.GetDependents()
+		// TODO if error occurs need to do a scan from the beginning
 		if err != nil {
 			klog.Errorf("could not get dependents for %s, %v", devicePath, err)
 		}

--- a/pkg/udevevent/event_test.go
+++ b/pkg/udevevent/event_test.go
@@ -60,10 +60,7 @@ func TestProcess(t *testing.T) {
 	deviceDetails.DeviceAttributes.WWN = osDiskDetails.Wwn
 	deviceDetails.PartitionInfo.PartitionTableUUID = osDiskDetails.PartTableUUID
 
-	deviceDetails.Parent = osDiskDetails.Dependents.Parent
-	deviceDetails.Partitions = osDiskDetails.Dependents.Partitions
-	deviceDetails.Holders = osDiskDetails.Dependents.Holders
-	deviceDetails.Slaves = osDiskDetails.Dependents.Slaves
+	deviceDetails.DependentDevices = osDiskDetails.Dependents
 
 	diskInfo = append(diskInfo, deviceDetails)
 	expectedEvent.eventDetails.Action = ""

--- a/pkg/udevevent/monitor.go
+++ b/pkg/udevevent/monitor.go
@@ -93,7 +93,8 @@ func (m *monitor) process(fd int) error {
 	if err != nil {
 		return err
 	}
-	if !device.IsDisk() {
+	// if device is not disk or partition, do not process it
+	if !device.IsDisk() && !device.IsParitition() {
 		device.UdevDeviceUnref()
 		return nil
 	}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR fixes the issue of disk unique identification in NDM. It implements the algorithm mentioned in [OEP#2666](https://github.com/openebs/openebs/pull/2666). This will make NDM uniquely identify disks without an identifier in a cluster. Disk movement from one node to another, creating block device resources for partitions is also supported.

**What this PR does?**:
- add support for partitions in NDM
- implement the new UUID algorithm mentioned in [#2666](https://github.com/openebs/openebs/pull/2666)
- changes made on the a claimed BlockDevice (like creating partitions) are ignored.
- if partitions are created on an unclaimed device, the device is marked inactive and resources will be created for the partitions.

**Does this PR require any upgrade changes?**:
Yes, But not automated.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. disk with WWN - single BlockDevice resource is created
2. disk with WWN and 2 partitions - 2 Block Device resources are created for each partition
3. disks of type 1) and 2) are connected and disconnected while NDM is running
4. disks of type 1) and 2) are removed from one node and attached to another node
5. cstor clamining and creating pool on a disk with WWN and a partitioned disk
6. formatting the device with ext4 after claiming and NDM pod is restarted. Filesystem details are not updated on the the resource

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [x] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 