### PR TITLE
refact(core, api): fill block sizes in blockdevice resource

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -39,10 +39,12 @@ type DeviceInfo struct {
 	ByIdDevLinks       []string // ByIdDevLinks contains by-id devlinks
 	ByPathDevLinks     []string // ByPathDevLinks contains by-path devlinks
 	FirmwareRevision   string   // FirmwareRevision is the firmware revision for a disk
-	LogicalSectorSize  uint32   // LogicalSectorSize is the Logical size of blockdevice sector in bytes
-	PhysicalSectorSize uint32   // PhysicalSectorSize is the Physical size of blockdevice sector in bytes
+	LogicalBlockSize   uint32   // LogicalBlockSize is the logical block size of the device in bytes
+	PhysicalBlockSize  uint32   // PhysicalBlockSize is the physical block size in bytes
+	HardwareSectorSize uint32   // HardwareSectorSize is the hardware sector size in bytes
 	Compliance         string   // Compliance is implemented specifications version i.e. SPC-1, SPC-2, etc
-	DeviceType         string   // DeviceType represents the type of backing disk
+	DeviceType         string   // DeviceType represents the type of device, like disk/sparse/partition
+	DriveType          string   // DriveType represents the type of backing drive HDD/SSD
 	PartitionType      string   // Partition type if the blockdevice is a partition
 	FileSystemInfo     FSInfo   // FileSystem info of the blockdevice like FSType and MountPoint
 }
@@ -143,6 +145,11 @@ func (di *DeviceInfo) getDeviceDetails() apis.DeviceDetails {
 	deviceDetails.FirmwareRevision = di.FirmwareRevision
 	deviceDetails.Compliance = di.Compliance
 	deviceDetails.DeviceType = di.DeviceType
+	deviceDetails.DriveType = di.DriveType
+	deviceDetails.LogicalBlockSize = di.LogicalBlockSize
+	deviceDetails.PhysicalBlockSize = di.PhysicalBlockSize
+	deviceDetails.HardwareSectorSize = di.HardwareSectorSize
+
 	return deviceDetails
 }
 
@@ -154,8 +161,8 @@ func (di *DeviceInfo) getDeviceDetails() apis.DeviceDetails {
 func (di *DeviceInfo) getDeviceCapacity() apis.DeviceCapacity {
 	capacity := apis.DeviceCapacity{}
 	capacity.Storage = di.Capacity
-	capacity.LogicalSectorSize = di.LogicalSectorSize
-	capacity.PhysicalSectorSize = di.PhysicalSectorSize
+	capacity.LogicalSectorSize = di.LogicalBlockSize
+	capacity.PhysicalSectorSize = di.PhysicalBlockSize
 	return capacity
 }
 

--- a/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
+++ b/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
@@ -49,8 +49,12 @@ func (c *Controller) NewDeviceInfoFromBlockDevice(blockDevice *bd.BlockDevice) *
 			deviceDetails.ByPathDevLinks = devlink.Links
 		}
 	}
-	deviceDetails.LogicalSectorSize = blockDevice.DeviceAttributes.LogicalBlockSize
-	deviceDetails.PhysicalSectorSize = blockDevice.DeviceAttributes.PhysicalBlockSize
+	deviceDetails.LogicalBlockSize = blockDevice.DeviceAttributes.LogicalBlockSize
+	deviceDetails.PhysicalBlockSize = blockDevice.DeviceAttributes.PhysicalBlockSize
+	deviceDetails.HardwareSectorSize = blockDevice.DeviceAttributes.HardwareSectorSize
+	deviceDetails.DriveType = blockDevice.DeviceAttributes.DriveType
+	deviceDetails.DeviceType = blockDevice.DeviceAttributes.DeviceType
+
 	deviceDetails.Compliance = blockDevice.DeviceAttributes.Compliance
 	deviceDetails.FileSystemInfo.FileSystem = blockDevice.FSInfo.FileSystem
 	// currently only the first mount point will be taken.

--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -198,6 +198,7 @@ func TestAddBlockDeviceEvent(t *testing.T) {
 	fakeDr.Spec.Details.Model = fakeModel
 	fakeDr.Spec.Details.Serial = fakeSerial
 	fakeDr.Spec.Details.Vendor = fakeVendor
+	fakeDr.Spec.Details.DeviceType = controller.NDMDefaultDiskType
 	fakeDr.Spec.Partitioned = controller.NDMNotPartitioned
 
 	tests := map[string]struct {

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -109,12 +109,12 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 
 	if blockDevice.DeviceAttributes.LogicalBlockSize == 0 {
 		blockDevice.DeviceAttributes.LogicalBlockSize = seachestProbe.SeachestIdentifier.GetLogicalSectorSize(driveInfo)
-		klog.V(4).Infof("Disk: %s LogicalSectorSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.LogicalBlockSize)
+		klog.V(4).Infof("Disk: %s LogicalBlockSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.LogicalBlockSize)
 	}
 
 	if blockDevice.DeviceAttributes.PhysicalBlockSize == 0 {
 		blockDevice.DeviceAttributes.PhysicalBlockSize = seachestProbe.SeachestIdentifier.GetPhysicalSectorSize(driveInfo)
-		klog.V(4).Infof("Disk: %s PhysicalSectorSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
+		klog.V(4).Infof("Disk: %s PhysicalBlockSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
 	}
 
 	if blockDevice.DeviceAttributes.DriveType == "" {

--- a/cmd/ndm_daemonset/probe/smartprobe_test.go
+++ b/cmd/ndm_daemonset/probe/smartprobe_test.go
@@ -44,6 +44,8 @@ func mockOsDiskToAPIBySmart() (apis.BlockDevice, error) {
 	fakeDetails := apis.DeviceDetails{
 		Compliance:       mockOsDiskDetails.Compliance,
 		FirmwareRevision: mockOsDiskDetails.FirmwareRevision,
+		DeviceType:       controller.NDMDefaultDiskType,
+		LogicalBlockSize: mockOsDiskDetails.LBSize,
 	}
 
 	fakeCapacity := apis.DeviceCapacity{

--- a/cmd/ndm_daemonset/probe/sysfsprobe.go
+++ b/cmd/ndm_daemonset/probe/sysfsprobe.go
@@ -98,7 +98,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			klog.Warning("unable to read logical block size", err)
 		} else if logicalBlockSize != 0 {
 			blockDevice.DeviceAttributes.LogicalBlockSize = uint32(logicalBlockSize)
-			klog.Infof("blockdevice path: %s logical block size :%d filled by sysfs probe.",
+			klog.V(4).Infof("blockdevice path: %s logical block size :%d filled by sysfs probe.",
 				blockDevice.DevPath, blockDevice.DeviceAttributes.LogicalBlockSize)
 		}
 	}
@@ -109,7 +109,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			klog.Warning("unable to read physical block size", err)
 		} else if physicalBlockSize != 0 {
 			blockDevice.DeviceAttributes.PhysicalBlockSize = uint32(physicalBlockSize)
-			klog.Infof("blockdevice path: %s physical block size :%d filled by sysfs probe.",
+			klog.V(4).Infof("blockdevice path: %s physical block size :%d filled by sysfs probe.",
 				blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
 		}
 	}
@@ -120,7 +120,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			klog.Warning("unable to read hardware sector size", err)
 		} else if hwSectorSize != 0 {
 			blockDevice.DeviceAttributes.HardwareSectorSize = uint32(hwSectorSize)
-			klog.Infof("blockdevice path: %s hardware sector size :%d filled by sysfs probe.",
+			klog.V(4).Infof("blockdevice path: %s hardware sector size :%d filled by sysfs probe.",
 				blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
 		}
 	}
@@ -136,7 +136,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			} else if rotational == 0 {
 				blockDevice.DeviceAttributes.DriveType = "SSD"
 			}
-			klog.Infof("blockdevice path: %s drive type :%s filled by sysfs probe.",
+			klog.V(4).Infof("blockdevice path: %s drive type :%s filled by sysfs probe.",
 				blockDevice.DevPath, blockDevice.DeviceAttributes.DriveType)
 		}
 	}
@@ -156,7 +156,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			return
 		} else if numberOfBlocks != 0 {
 			blockDevice.Capacity.Storage = uint64(numberOfBlocks * sectorSize)
-			klog.Infof("blockdevice path: %s capacity :%d filled by sysfs probe.",
+			klog.V(4).Infof("blockdevice path: %s capacity :%d filled by sysfs probe.",
 				blockDevice.DevPath, blockDevice.Capacity.Storage)
 		}
 	}

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -47,9 +47,10 @@ func mockOsDiskToAPI() (apis.BlockDevice, error) {
 		return apis.BlockDevice{}, err
 	}
 	fakeDetails := apis.DeviceDetails{
-		Model:  mockOsDiskDetails.Model,
-		Serial: mockOsDiskDetails.Serial,
-		Vendor: mockOsDiskDetails.Vendor,
+		Model:      mockOsDiskDetails.Model,
+		Serial:     mockOsDiskDetails.Serial,
+		Vendor:     mockOsDiskDetails.Vendor,
+		DeviceType: controller.NDMDefaultDiskType,
 	}
 	fakeObj := apis.DeviceSpec{
 		Path:        mockOsDiskDetails.DevNode,


### PR DESCRIPTION
Fill the following details into the BD resource:
- drive type, logical/physical block size, hw sector size

The above details will be fetched by sysfs probe and then filled into the block device resource

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>