### PR TITLE
fix(block-device): allow client to label and annotate bd

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -254,6 +254,8 @@ func (c *Controller) MarkBlockDeviceStatusToUnknown() {
 	}
 }
 
+// mergeMetadata merges oldMetadata with newMetadata. It takes old metadata and
+// update it's value with the help of new metadata.
 func mergeMetadata(newMetadata, oldMetadata metav1.ObjectMeta) metav1.ObjectMeta {
 	// metadata of older object which contains -
 	// - name - no patch required we can use old object.

--- a/cmd/ndm_daemonset/controller/blockdevicestore_test.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore_test.go
@@ -168,9 +168,11 @@ func TestUpdateDevice(t *testing.T) {
 
 	// Retrieve disk resource
 	cdevR, err := fakeController.GetBlockDevice(fakeDeviceUID)
-
-	devR.ObjectMeta.Name = "disk-updated-fake-uuid"
-	err = fakeController.UpdateBlockDevice(devR, cdevR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cdevR.ObjectMeta.Name = "disk-updated-fake-uuid"
+	err = fakeController.UpdateBlockDevice(*cdevR, nil)
 	if err == nil {
 		t.Error("if resource is not present then it should return error")
 	}


### PR DESCRIPTION
This PR fix metadata part of a block device. Now users can label and annotate block devices. What it does it actually takes metadata of older block device and patch that with system generated information.

Signed-off-by: Shovan Maity <shovan.maity@mayadata.io>