### PR TITLE
cherry-pick(controller, api): add label selector to BlockDeviceClaim (#397)

### DIFF
--- a/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
@@ -39,6 +39,10 @@ type BlockDeviceClaim struct {
 
 // DeviceClaimSpec defines the request details for a BlockDevice
 type DeviceClaimSpec struct {
+
+	// Selector is used to find block devices to be considered for claiming
+	Selector *metav1.LabelSelector `json:"selector,omitempty"`
+
 	// Resources will help with placing claims on Capacity, IOPS
 	Resources DeviceClaimResources `json:"resources"`
 

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go
@@ -19,23 +19,20 @@ package blockdeviceclaim
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	ndm "github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
 	"github.com/openebs/node-disk-manager/pkg/select/blockdevice"
 	"github.com/openebs/node-disk-manager/pkg/select/verify"
 	"github.com/openebs/node-disk-manager/pkg/util"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/reference"
-
-	apis "github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/reference"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -168,23 +165,11 @@ func (r *ReconcileBlockDeviceClaim) claimDeviceForBlockDeviceClaim(
 		}
 	}
 
-	//select block device from list of devices.
-	labelFilter := make([]string, 0)
-	var hostName string
-	if len(instance.Spec.HostName) != 0 {
-		hostName = instance.Spec.HostName
-	}
-	// the hostname in NodeAttribute will override the hostname in spec, since spec.hostName
-	// will be deprecated shortly
-	if len(instance.Spec.BlockDeviceNodeAttributes.HostName) != 0 {
-		hostName = instance.Spec.BlockDeviceNodeAttributes.HostName
-	}
-	// only if any hostname is provided create the filter
-	if len(hostName) != 0 {
-		labelFilter = append(labelFilter, ndm.KubernetesHostNameLabel+"="+hostName)
-	}
+	// create selector from the label selector given in BDC spec.
+	selector := generateSelector(*instance)
 
-	bdList, err := r.getListofDevices(labelFilter...)
+	// get list of block devices.
+	bdList, err := r.getListofDevices(selector)
 	if err != nil {
 		return err
 	}
@@ -284,13 +269,15 @@ func (r *ReconcileBlockDeviceClaim) releaseClaimedBlockDevice(
 	reqLogger.Info("Deleting external dependencies for CR:" + instance.Name)
 
 	//Get BlockDevice list on all nodes
-	listDVR, err := r.getListofDevices()
+	//empty selector is used to select everything.
+	selector := &v1.LabelSelector{}
+	bdList, err := r.getListofDevices(selector)
 	if err != nil {
 		return err
 	}
 
 	// Check if same deviceclaim holding the ObjRef
-	for _, item := range listDVR.Items {
+	for _, item := range bdList.Items {
 		if !r.isDeviceRequestedByThisDeviceClaim(instance, item, reqLogger) {
 			continue
 		}
@@ -342,7 +329,7 @@ func (r *ReconcileBlockDeviceClaim) GetBlockDevice(name string) (*apis.BlockDevi
 // TODO:
 //  ListBlockDeviceResource in package cmd/ndm_daemonset/controller has the same functionality.
 //  Need to merge these 2 functions.
-func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.BlockDeviceList, error) {
+func (r *ReconcileBlockDeviceClaim) getListofDevices(selector *v1.LabelSelector) (*apis.BlockDeviceList, error) {
 
 	//Initialize a deviceList object.
 	listBlockDevice := &apis.BlockDeviceList{
@@ -354,9 +341,11 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.B
 
 	opts := &client.ListOptions{}
 
-	// if filter strings are present, apply them before querying etcd
-	if len(filters) != 0 {
-		opts.SetLabelSelector(strings.Join(filters, ","))
+	if sel, err := v1.LabelSelectorAsSelector(selector); err != nil {
+		// if conversion of selector errors out, the list call will be errored
+		return nil, err
+	} else {
+		opts.LabelSelector = sel
 	}
 
 	//Fetch deviceList with matching criteria
@@ -372,4 +361,35 @@ func (r *ReconcileBlockDeviceClaim) getListofDevices(filters ...string) (*apis.B
 // BlockDeviceClaim
 func IsReconcileDisabled(bdc *apis.BlockDeviceClaim) bool {
 	return bdc.Annotations[ndm.OpenEBSReconcile] == "false"
+}
+
+// generateSelector creates the label selector for BlockDevices from
+// the BlockDeviceClaim spec
+func generateSelector(bdc apis.BlockDeviceClaim) *v1.LabelSelector {
+	var hostName string
+	// get the hostname
+	if len(bdc.Spec.HostName) != 0 {
+		hostName = bdc.Spec.HostName
+	}
+	// the hostname in NodeAttribute will override the hostname in spec, since spec.hostName
+	// will be deprecated shortly
+	if len(bdc.Spec.BlockDeviceNodeAttributes.HostName) != 0 {
+		hostName = bdc.Spec.BlockDeviceNodeAttributes.HostName
+	}
+
+	// the hostname label is added into the user given list of labels. If the user hasn't
+	// given any selector, then the selector object is initialized.
+	selector := bdc.Spec.Selector
+	if selector == nil {
+		selector = &v1.LabelSelector{}
+	}
+	if selector.MatchLabels == nil {
+		selector.MatchLabels = make(map[string]string)
+	}
+
+	// if any hostname is provided, add it to selector
+	if len(hostName) != 0 {
+		selector.MatchLabels[ndm.KubernetesHostNameLabel] = hostName
+	}
+	return selector
 }


### PR DESCRIPTION
- add label selector to BDC api.
- add label selector to list method using labels.Selector
- include hostname label in the metav1.LabelSelector from BlockDeviceClaim
- add test cases for selector in BDC

cherry-pick #397

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>