### PR TITLE
fix(filter): add default vendor OpenEBS in vendor filter

### DIFF
--- a/changelogs/unreleased/409_akhilerm
+++ b/changelogs/unreleased/409_akhilerm
@@ -1,0 +1,1 @@
+add OpenEBS to the list of default excluded vendors

--- a/cmd/ndm_daemonset/filter/vendorfilter.go
+++ b/cmd/ndm_daemonset/filter/vendorfilter.go
@@ -26,6 +26,8 @@ import (
 
 const (
 	vendorFilterKey = "vendor-filter"
+	// vendorValueOpenEBS is the vendor for iscsi disks created by OpenEBS
+	vendorValueOpenEBS = "OpenEBS"
 )
 
 var (
@@ -33,6 +35,9 @@ var (
 	vendorFilterState = defaultEnabled  // filter state
 	includeVendors    = ""
 	excludeVendors    = ""
+	// list of vendors that are excluded by default. This is done so that OpenEBS created disks are excluded
+	// by default
+	defaultExcludedVendors = []string{vendorValueOpenEBS}
 )
 
 // vendorFilterRegister contains registration process of VendorFilter
@@ -80,11 +85,15 @@ func newVendorFilter(ctrl *controller.Controller) *vendorFilter {
 func (vf *vendorFilter) Start() {
 	vf.includeVendors = make([]string, 0)
 	vf.excludeVendors = make([]string, 0)
+
+	// add the default exclude list to exclude vendors.
+	vf.excludeVendors = append(vf.excludeVendors, defaultExcludedVendors...)
+
 	if includeVendors != "" {
 		vf.includeVendors = strings.Split(includeVendors, ",")
 	}
 	if excludeVendors != "" {
-		vf.excludeVendors = strings.Split(excludeVendors, ",")
+		vf.excludeVendors = append(vf.excludeVendors, strings.Split(excludeVendors, ",")...)
 	}
 }
 

--- a/cmd/ndm_daemonset/filter/vendorfilter_test.go
+++ b/cmd/ndm_daemonset/filter/vendorfilter_test.go
@@ -40,7 +40,8 @@ func TestVendorFilterRegister(t *testing.T) {
 	var fi controller.FilterInterface = &vendorFilter{
 		controller:     fakeController,
 		includeVendors: make([]string, 0),
-		excludeVendors: make([]string, 0),
+		// default vendor OpenEBS is always excluded
+		excludeVendors: []string{vendorValueOpenEBS},
 	}
 	filter := &controller.Filter{
 		Name:      vendorFilterName,
@@ -77,11 +78,16 @@ func TestVendorStart(t *testing.T) {
 			includeVendors = test.includeVendor
 			excludeVendors = test.excludeVendor
 			test.filter.Start()
+
+			// even if no vendors are specified in the filter config
+			// by default the registered filter will have OpenEBS vendor for excluding
+			excludedVendors := []string{vendorValueOpenEBS}
 			if test.excludeVendor != "" {
-				assert.Equal(t, strings.Split(test.excludeVendor, ","), test.filter.excludeVendors)
-			} else {
-				assert.Equal(t, make([]string, 0), test.filter.excludeVendors)
+				excludedVendors = append(excludedVendors, strings.Split(test.excludeVendor, ",")...)
 			}
+
+			assert.Equal(t, excludedVendors, test.filter.excludeVendors)
+
 			if test.includeVendor != "" {
 				assert.Equal(t, strings.Split(test.excludeVendor, ","), test.filter.includeVendors)
 			} else {


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR adds `OpenEBS` to the list of default excluded vendors. This is done so that, even if user removes the vendor filter, OpenEBS created iscsi disks are excluded by NDM.

**What this PR does?**:
- add OpenEBS as a default vendor in vendor filter
- modify test cases to add OpenEBS as a default vendor

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
None

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 