### PR TITLE
feat(filter): add new filter to validate block devices

### DIFF
--- a/build/custom-boilerplate.go.txt
+++ b/build/custom-boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The OpenEBS Authors
+Copyright 2020 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/changelogs/unreleased/410_akhilerm
+++ b/changelogs/unreleased/410_akhilerm
@@ -1,0 +1,1 @@
+add new filter to validate BlockDevices and remove invalid entries

--- a/cmd/ndm_daemonset/filter/devicevalidityfilter.go
+++ b/cmd/ndm_daemonset/filter/devicevalidityfilter.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package filter
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	"k8s.io/klog"
+)
+
+// NOTE: This is an internal filter used by NDM to validate the block devices.
+// Devices having invalid values in various fields(Path, Capacity etc) will be
+// filtered out.
+//
+// The filter cannot be configured or disabled by user.
+
+var (
+	deviceValidityFilterName  = "device validity filter" // filter valid devices
+	deviceValidityFilterState = defaultEnabled           // filter state
+)
+
+// deviceValidityFilterRegister contains registration process of DeviceValidityFilter
+var deviceValidityFilterRegister = func() {
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		return
+	}
+
+	var fi controller.FilterInterface = newDeviceValidityFilter(ctrl)
+	newRegisterFilter := &registerFilter{
+		name:       deviceValidityFilterName,
+		state:      deviceValidityFilterState,
+		fi:         fi,
+		controller: ctrl,
+	}
+	newRegisterFilter.register()
+}
+
+// deviceValidityFilter contains controller and validator functions
+type deviceValidityFilter struct {
+	controller             *controller.Controller
+	excludeValidationFuncs []validationFunc
+}
+
+// validationFunc is a function type for the validations to be performed on the
+// block device
+type validationFunc func(*blockdevice.BlockDevice) bool
+
+// newDeviceValidityFilter returns new pointer to a deviceValidityFilter
+func newDeviceValidityFilter(ctrl *controller.Controller) *deviceValidityFilter {
+	return &deviceValidityFilter{
+		controller: ctrl,
+	}
+}
+
+// Start sets the validator functions to be used
+func (dvf *deviceValidityFilter) Start() {
+	dvf.excludeValidationFuncs = make([]validationFunc, 0)
+	dvf.excludeValidationFuncs = append(dvf.excludeValidationFuncs,
+		isValidDevPath,
+		isValidCapacity,
+	)
+}
+
+// Include returns true because no specific internal validations are done
+// for a device.
+func (dvf *deviceValidityFilter) Include(blockDevice *blockdevice.BlockDevice) bool {
+	return true
+}
+
+// Exclude returns true if all the exclude validation function passes.
+// i.e The given block device is a valid entry.
+func (dvf *deviceValidityFilter) Exclude(blockDevice *blockdevice.BlockDevice) bool {
+	for _, vf := range dvf.excludeValidationFuncs {
+		if !vf(blockDevice) {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidDevPath checks if the path is not empty
+func isValidDevPath(bd *blockdevice.BlockDevice) bool {
+	if len(bd.DevPath) == 0 {
+		klog.V(4).Infof("device has an invalid dev path")
+		return false
+	}
+	return true
+}
+
+// isValidCapacity checks if the device has a valid capacity
+func isValidCapacity(bd *blockdevice.BlockDevice) bool {
+	if bd.Capacity.Storage == 0 {
+		klog.V(4).Infof("device: %s has invalid capacity", bd.DevPath)
+		return false
+	}
+	return true
+}

--- a/cmd/ndm_daemonset/filter/devicevalidityfilter_test.go
+++ b/cmd/ndm_daemonset/filter/devicevalidityfilter_test.go
@@ -1,0 +1,124 @@
+package filter
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeviceValidityFilterExclude(t *testing.T) {
+	tests := map[string]struct {
+		blockDevice *blockdevice.BlockDevice
+		want        bool
+	}{
+		"valid BlockDevice": {
+			blockDevice: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda",
+				},
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 1024,
+				},
+			},
+			want: true,
+		},
+		"invalid Path in BlockDevice": {
+			blockDevice: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "",
+				},
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 1024,
+				},
+			},
+			want: false,
+		},
+		"invalid Capacity in BlockDevice": {
+			blockDevice: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda",
+				},
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 0,
+				},
+			},
+			want: false,
+		},
+		"invalid Capacity and DevPath": {
+			blockDevice: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "",
+				},
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 0,
+				},
+			},
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			dvf := deviceValidityFilter{}
+			dvf.Start()
+			assert.Equal(t, test.want, dvf.Exclude(test.blockDevice))
+		})
+	}
+}
+
+func TestIsValidDevPath(t *testing.T) {
+	tests := map[string]struct {
+		bd   *blockdevice.BlockDevice
+		want bool
+	}{
+		"valid dev path": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda",
+				},
+			},
+			want: true,
+		},
+		"invalid dev path": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "",
+				},
+			},
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, isValidDevPath(test.bd))
+		})
+	}
+}
+
+func Test_isValidCapacity(t *testing.T) {
+	tests := map[string]struct {
+		bd   *blockdevice.BlockDevice
+		want bool
+	}{
+		"valid capacity": {
+			bd: &blockdevice.BlockDevice{
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 102400,
+				},
+			},
+			want: true,
+		},
+		"invalid capacity": {
+			bd: &blockdevice.BlockDevice{
+				Capacity: blockdevice.CapacityInformation{
+					Storage: 0,
+				},
+			},
+			want: false,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.want, isValidCapacity(test.bd))
+		})
+	}
+}

--- a/cmd/ndm_daemonset/filter/filter.go
+++ b/cmd/ndm_daemonset/filter/filter.go
@@ -30,7 +30,9 @@ const (
 var RegisteredFilters = []func(){
 	oSDiskExcludeFilterRegister,
 	vendorFilterRegister,
-	pathFilterRegister}
+	pathFilterRegister,
+	deviceValidityFilterRegister,
+}
 
 type registerFilter struct {
 	name       string


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Fixes: [#3020](https://github.com/openebs/openebs/issues/3020).
This PR prevents NDM from creating BlockDevice resource for invalid disk events (events that are generated due to iscsi login issues). Thus, large no.of resources without any identity will not be created.

**What this PR does?**:
- add new DeviceValidityFilter to check if the device has valid fields
- dev path and capacity will be currently validated
- add unit test cases for the new filter

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
No

**Checklist:**
- [x] Fixes [#3020](https://github.com/openebs/openebs/issues/3020)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 