### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ tags
 *.swo
 Dockerfile.ndm
 Dockerfile.ndo
+Dockerfile.exporter
 coverage.txt
 build/_output

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,30 @@ endif
 endif
 export BASEIMAGE
 
-ifeq (${IMAGE_REPO}, )
-  IMAGE_REPO = "openebs"
-  export IMAGE_REPO
+# The images can be pushed to any docker/image registeries
+# like docker hub, quay. The registries are specified in 
+# the `build/push` script.
+#
+# The images of a project or company can then be grouped
+# or hosted under a unique organization key like `openebs`
+#
+# Each component (container) will be pushed to a unique 
+# repository under an organization. 
+# Putting all this together, an unique uri for a given 
+# image comprises of:
+#   <registry url>/<image org>/<image repo>:<image-tag>
+#
+# IMAGE_REPO can be used to customize the organization 
+# under which images should be pushed. 
+# By default the organization name is `openebs`. 
+
+ifeq (${IMAGE_ORG}, )
+  IMAGE_ORG="openebs"
+  export IMAGE_ORG
 endif
+
+# Specify the date of build
+DBUILD_DATE=$(shell date +'%Y%m%d%H%M%S')
 
 # Specify the docker arg for repository url
 ifeq (${DBUILD_REPO_URL}, )
@@ -76,7 +96,7 @@ NODE_DISK_MANAGER=ndm
 # Specify the sub path under ./cmd/ for NDM DaemonSet
 BUILD_PATH_NDM=ndm_daemonset
 # Name of the image for NDM DaemoneSet
-DOCKER_IMAGE_NDM:=${IMAGE_REPO}/node-disk-manager-${XC_ARCH}:ci
+DOCKER_IMAGE_NDM:=${IMAGE_ORG}/node-disk-manager-${XC_ARCH}:ci
 
 # Initialize the NDM Operator variables
 # Specify the NDM Operator binary name
@@ -84,7 +104,7 @@ NODE_DISK_OPERATOR=ndo
 # Specify the sub path under ./cmd/ for NDM Operator
 BUILD_PATH_NDO=manager
 # Name of the image for ndm operator
-DOCKER_IMAGE_NDO:=${IMAGE_REPO}/node-disk-operator-${XC_ARCH}:ci
+DOCKER_IMAGE_NDO:=${IMAGE_ORG}/node-disk-operator-${XC_ARCH}:ci
 
 # Initialize the NDM Exporter variables
 # Specfiy the NDM Exporter binary name
@@ -92,7 +112,7 @@ NODE_DISK_EXPORTER=exporter
 # Specify the sub path under ./cmd/ for NDM Exporter
 BUILD_PATH_EXPORTER=ndm-exporter
 # Name of the image for ndm exporter
-DOCKER_IMAGE_EXPORTER:=${IMAGE_REPO}/node-disk-exporter-${XC_ARCH}:ci
+DOCKER_IMAGE_EXPORTER:=${IMAGE_ORG}/node-disk-exporter-${XC_ARCH}:ci
 
 # Compile binaries and build docker images
 .PHONY: build
@@ -263,6 +283,6 @@ license-check-go:
 
 .PHONY: push
 push: 
-	DIMAGE=${IMAGE_REPO}/node-disk-manager-${XC_ARCH} ./build/push;
-	DIMAGE=${IMAGE_REPO}/node-disk-operator-${XC_ARCH} ./build/push;
-	DIMAGE=${IMAGE_REPO}/node-disk-exporter-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_ORG}/node-disk-manager-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_ORG}/node-disk-operator-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_ORG}/node-disk-exporter-${XC_ARCH} ./build/push;

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The OpenEBS Authors. All rights reserved.
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,25 @@ endif
 endif
 export BASEIMAGE
 
+ifeq (${IMAGE_REPO}, )
+  IMAGE_REPO = "openebs"
+  export IMAGE_REPO
+endif
+
+# Specify the docker arg for repository url
+ifeq (${DBUILD_REPO_URL}, )
+  DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
+  export DBUILD_REPO_URL
+endif
+
+# Specify the docker arg for website url
+ifeq (${DBUILD_SITE_URL}, )
+  DBUILD_SITE_URL="https://openebs.io"
+  export DBUILD_SITE_URL
+endif
+
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
+
 
 # Initialize the NDM DaemonSet variables
 # Specify the NDM DaemonSet binary name
@@ -57,7 +76,7 @@ NODE_DISK_MANAGER=ndm
 # Specify the sub path under ./cmd/ for NDM DaemonSet
 BUILD_PATH_NDM=ndm_daemonset
 # Name of the image for NDM DaemoneSet
-DOCKER_IMAGE_NDM:=openebs/node-disk-manager-${XC_ARCH}:ci
+DOCKER_IMAGE_NDM:=${IMAGE_REPO}/node-disk-manager-${XC_ARCH}:ci
 
 # Initialize the NDM Operator variables
 # Specify the NDM Operator binary name
@@ -65,7 +84,7 @@ NODE_DISK_OPERATOR=ndo
 # Specify the sub path under ./cmd/ for NDM Operator
 BUILD_PATH_NDO=manager
 # Name of the image for ndm operator
-DOCKER_IMAGE_NDO:=openebs/node-disk-operator-${XC_ARCH}:ci
+DOCKER_IMAGE_NDO:=${IMAGE_REPO}/node-disk-operator-${XC_ARCH}:ci
 
 # Initialize the NDM Exporter variables
 # Specfiy the NDM Exporter binary name
@@ -73,7 +92,7 @@ NODE_DISK_EXPORTER=exporter
 # Specify the sub path under ./cmd/ for NDM Exporter
 BUILD_PATH_EXPORTER=ndm-exporter
 # Name of the image for ndm exporter
-DOCKER_IMAGE_EXPORTER:=openebs/node-disk-exporter-${XC_ARCH}:ci
+DOCKER_IMAGE_EXPORTER:=${IMAGE_REPO}/node-disk-exporter-${XC_ARCH}:ci
 
 # Compile binaries and build docker images
 .PHONY: build
@@ -175,7 +194,7 @@ build.ndm:
 .PHONY: docker.ndm
 docker.ndm: build.ndm Dockerfile.ndm 
 	@echo "--> Building docker image for ndm-daemonset..."
-	@sudo docker build -t "$(DOCKER_IMAGE_NDM)" --build-arg ARCH=${ARCH} -f Dockerfile.ndm .
+	@sudo docker build -t "$(DOCKER_IMAGE_NDM)" ${DBUILD_ARGS} -f Dockerfile.ndm .
 	@echo "--> Build docker image: $(DOCKER_IMAGE_NDM)"
 	@echo
 
@@ -190,7 +209,7 @@ build.ndo:
 .PHONY: docker.ndo
 docker.ndo: build.ndo Dockerfile.ndo 
 	@echo "--> Building docker image for ndm-operator..."
-	@sudo docker build -t "$(DOCKER_IMAGE_NDO)" --build-arg ARCH=${ARCH} -f Dockerfile.ndo .
+	@sudo docker build -t "$(DOCKER_IMAGE_NDO)" ${DBUILD_ARGS} -f Dockerfile.ndo .
 	@echo "--> Build docker image: $(DOCKER_IMAGE_NDO)"
 	@echo
 
@@ -205,7 +224,7 @@ build.exporter:
 .PHONY: docker.exporter
 docker.exporter: build.exporter Dockerfile.exporter
 	@echo "--> Building docker image for ndm-exporter..."
-	@sudo docker build -t "$(DOCKER_IMAGE_EXPORTER)" --build-arg ARCH=${ARCH} -f Dockerfile.exporter .
+	@sudo docker build -t "$(DOCKER_IMAGE_EXPORTER)" ${DBUILD_ARGS} -f Dockerfile.exporter .
 	@echo "--> Build docker image: $(DOCKER_IMAGE_EXPORTER)"
 	@echo
 
@@ -223,7 +242,9 @@ clean: header
 	rm -rf ${GOPATH}/bin/${NODE_DISK_MANAGER}
 	rm -rf ${GOPATH}/bin/${NODE_DISK_OPERATOR}
 	rm -rf ${GOPATH}/bin/${NODE_DISK_EXPORTER}
-	rm -rf ${GOPATH}/pkg/*
+	rm -rf Dockerfile.ndm
+	rm -rf Dockerfile.ndo
+	rm -rf Dockerfile.exporter
 	@echo '--> Done cleaning.'
 	@echo
 
@@ -242,6 +263,6 @@ license-check-go:
 
 .PHONY: push
 push: 
-	DIMAGE=openebs/node-disk-manager-${XC_ARCH} ./build/push;
-	DIMAGE=openebs/node-disk-operator-${XC_ARCH} ./build/push;
-	DIMAGE=openebs/node-disk-exporter-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_REPO}/node-disk-manager-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_REPO}/node-disk-operator-${XC_ARCH} ./build/push;
+	DIMAGE=${IMAGE_REPO}/node-disk-exporter-${XC_ARCH} ./build/push;

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ export BASEIMAGE
 # image comprises of:
 #   <registry url>/<image org>/<image repo>:<image-tag>
 #
-# IMAGE_REPO can be used to customize the organization 
+# IMAGE_ORG can be used to customize the organization 
 # under which images should be pushed. 
 # By default the organization name is `openebs`. 
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifeq (${IMAGE_ORG}, )
 endif
 
 # Specify the date of build
-DBUILD_DATE=$(shell date +'%Y%m%d%H%M%S')
+DBUILD_DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 
 # Specify the docker arg for repository url
 ifeq (${DBUILD_REPO_URL}, )

--- a/build/ndm-daemonset/Dockerfile.in
+++ b/build/ndm-daemonset/Dockerfile.in
@@ -1,3 +1,16 @@
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # This Dockerfile builds node-disk-manager
 # 
@@ -6,6 +19,16 @@
 FROM @BASEIMAGE@
 
 ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
+ARG DBUILD_SITE_URL="http://www.openebs.io/"
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.description="OpenEBS Node Disk Manager"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 #Copy binary to /usr/sbin/ndm
 COPY bin/${ARCH}/ndm /usr/sbin/ndm

--- a/build/ndm-daemonset/Dockerfile.in
+++ b/build/ndm-daemonset/Dockerfile.in
@@ -20,8 +20,8 @@ FROM @BASEIMAGE@
 
 ARG ARCH
 ARG DBUILD_DATE
-ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
-ARG DBUILD_SITE_URL="http://www.openebs.io/"
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.name="node-disk-manager"

--- a/build/ndm-exporter/Dockerfile.in
+++ b/build/ndm-exporter/Dockerfile.in
@@ -1,3 +1,16 @@
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # This Dockerfile builds NDM exporter
 # 
@@ -6,5 +19,15 @@
 FROM @BASEIMAGE@
 
 ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
+ARG DBUILD_SITE_URL="http://www.openebs.io/"
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.description="OpenEBS NDM Exporter"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ADD bin/${ARCH}/exporter /usr/local/bin/exporter

--- a/build/ndm-exporter/Dockerfile.in
+++ b/build/ndm-exporter/Dockerfile.in
@@ -20,11 +20,11 @@ FROM @BASEIMAGE@
 
 ARG ARCH
 ARG DBUILD_DATE
-ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
-ARG DBUILD_SITE_URL="http://www.openebs.io/"
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.name="node-disk-exporter"
 LABEL org.label-schema.description="OpenEBS NDM Exporter"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/ndm-operator/Dockerfile.in
+++ b/build/ndm-operator/Dockerfile.in
@@ -1,3 +1,16 @@
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # This Dockerfile builds node-disk-operator
 # 
@@ -6,6 +19,16 @@
 FROM @BASEIMAGE@
 
 ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
+ARG DBUILD_SITE_URL="http://www.openebs.io/"
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.description="OpenEBS NDM Operator"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ADD bin/${ARCH}/ndo /usr/local/bin/ndo
 

--- a/build/ndm-operator/Dockerfile.in
+++ b/build/ndm-operator/Dockerfile.in
@@ -20,11 +20,11 @@ FROM @BASEIMAGE@
 
 ARG ARCH
 ARG DBUILD_DATE
-ARG DBUILD_REPO_URL="https://github.com/openebs/node-disk-manager"
-ARG DBUILD_SITE_URL="http://www.openebs.io/"
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.name="node-disk-operator"
 LABEL org.label-schema.description="OpenEBS NDM Operator"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/push
+++ b/build/push
@@ -1,4 +1,19 @@
 #!/bin/bash
+
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${DIMAGE} ];
@@ -42,7 +57,10 @@ function TagAndPushImage() {
   REPO="$1"
   TAG="$2"
 
-  IMAGE_URI="${REPO}:${TAG}";
+  #Add an option to specify a custom TAG_SUFFIX 
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

There are cases where users might want to build and push
container images in their own environments.

**What this PR does?**:

This commit will help customizing docker images via environment variables:
- The following ENV help specify custom docker build args
  - DBUILD_SITE_URL ( default: https://openebs.io )
  - DBUILD_REPO_URL ( default: https://github.com/openebs/node-disk-manager )
- The following ENV allows Travis to specify custom image org
  - IMAGE_ORG (default: openebs )
- The following ENV will allow specifying an extra tag suffix
  - TAG_SUFFIX ( default: none )

**Does this PR require any upgrade changes?**:
No. 

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Used make file commands to create images. 
Travis CI verifies the image generation. 

Signed-off-by: kmova <kiran.mova@mayadata.io>

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on 