### PR TITLE
fix(controller): add finalizer to claimed BD

### DIFF
--- a/changelogs/unreleased/416_akhilerm
+++ b/changelogs/unreleased/416_akhilerm
@@ -1,0 +1,1 @@
+add finalizer on claimed BlockDevice resource to prevent accidental deletion

--- a/pkg/controller/util/finalizer.go
+++ b/pkg/controller/util/finalizer.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+const (
+	// BlockDeviceClaimFinalizer is the finalizer on BDCs that are in Bound phase
+	BlockDeviceClaimFinalizer = "openebs.io/bdc-protection"
+
+	// BlockDeviceFinalizer is the finalizer on block devices bound to a block device claim
+	BlockDeviceFinalizer = "openebs.io/bd-protection"
+)


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
When a user deletes a BD that is claimed, the BD will be automatically recreated by NDM daemon pod. But the recreated BD will be in Unclaimed state. Thus another claim can get bound to the same BD resulting in data corruption.

**What this PR does?**:
- add `openebs.io/bd-protection` finalizer to BDs that are in `Claimed` state

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- claimed a BD, try to delete the BD, the delete should not happen. the BD should get deleted only after it is Unclaimed. (after cleanup)
- old BDs already in claimed state should get this finalizer on the first reconciliation 

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [x] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 