### PR TITLE
fix(uuid): add serial number to UUID algorithm

### DIFF
--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -149,11 +149,12 @@ func (up *udevProbe) scan() error {
 		if newUdevice.IsDisk() || newUdevice.IsParitition() {
 			deviceDetails := &blockdevice.BlockDevice{}
 			if up.controller.FeatureGates.IsEnabled(features.GPTBasedUUID) {
-				// WWN, PartitionTableUUID/GPTLabel, PartitionUUID, FileSystemUUID and DeviceType
+				// WWN, Serial, PartitionTableUUID/GPTLabel, PartitionUUID, FileSystemUUID and DeviceType
 				// are the fields we use to generate the UUID. These fields will be fetched
 				// from the udev event itself. This is to guarantee that we do not need to rely
 				// on any other probes to fill in those details which are critical for device identification.
 				deviceDetails.DeviceAttributes.WWN = newUdevice.GetPropertyValue(libudevwrapper.UDEV_WWN)
+				deviceDetails.DeviceAttributes.Serial = newUdevice.GetPropertyValue(libudevwrapper.UDEV_SERIAL)
 				deviceDetails.PartitionInfo.PartitionTableUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_TABLE_UUID)
 				deviceDetails.PartitionInfo.PartitionEntryUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_PARTITION_UUID)
 				deviceDetails.FSInfo.FileSystemUUID = newUdevice.GetPropertyValue(libudevwrapper.UDEV_FS_UUID)

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -54,6 +54,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 	// GPTBasedUUID feature-gate is enabled.
 	deviceDetails.DeviceAttributes.DeviceType = device.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
 	deviceDetails.DeviceAttributes.WWN = device.GetPropertyValue(libudevwrapper.UDEV_WWN)
+	deviceDetails.DeviceAttributes.Serial = device.GetPropertyValue(libudevwrapper.UDEV_SERIAL)
 	deviceDetails.PartitionInfo.PartitionTableUUID = device.GetPropertyValue(libudevwrapper.UDEV_PARTITION_TABLE_UUID)
 	deviceDetails.PartitionInfo.PartitionEntryUUID = device.GetPropertyValue(libudevwrapper.UDEV_PARTITION_UUID)
 	deviceDetails.FSInfo.FileSystemUUID = device.GetPropertyValue(libudevwrapper.UDEV_FS_UUID)

--- a/pkg/udevevent/event_test.go
+++ b/pkg/udevevent/event_test.go
@@ -58,6 +58,7 @@ func TestProcess(t *testing.T) {
 
 	deviceDetails.DeviceAttributes.DeviceType = osDiskDetails.DevType
 	deviceDetails.DeviceAttributes.WWN = osDiskDetails.Wwn
+	deviceDetails.DeviceAttributes.Serial = osDiskDetails.Serial
 	deviceDetails.PartitionInfo.PartitionTableUUID = osDiskDetails.PartTableUUID
 
 	deviceDetails.DependentDevices = osDiskDetails.Dependents


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Some storage arrays give LUNs having same WWN,  but with different serial number. We need to uniquely identify those LUNs. Therefore, if WWN is present a combination of WWN and Serial will be used.

**What this PR does?**:
- add Serial number to UUID generation algorithm
- fix test case using Serial  number along with WWN

**Does this PR require any upgrade changes?**:
Yes. Upgrade changes will be same as that of #386 

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
Continuation of #386 


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 