### PR TITLE
fix(featuregate): fix parsing feature flags with escaped strings

### DIFF
--- a/changelogs/unreleased/418_akhilerm
+++ b/changelogs/unreleased/418_akhilerm
@@ -1,0 +1,1 @@
+fix parsing of escaped strings in feature flags

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -57,6 +57,27 @@ func ParseFeatureGate(features []string, defaultFGs []Feature) (FeatureGate, err
 	}
 	// iterate through each feature and set its state onto the FeatureGate map
 	for _, feature := range features {
+		// if feature is just an empty string "", it should be ignored.
+		// This can happen if the image is run from k8s.
+		//
+		// If running from k8s, the container specs will be like
+		// "Cmd": [
+		//        "-v=4",
+		//        "--feature-gates=\"\""
+		//      ],
+		//
+		// If running as a standalone docker image, the container spec will be like
+		// "Cmd": [
+		//        "-v=4",
+		//        "--feature-gates=",
+		//      ],
+		//
+		// The additional escaped double quotes will be parsed as a string with "" by cobra CLI.
+		// Thus we need to remove that empty string while checking for features
+		if len(feature) == 0 {
+			continue
+		}
+
 		var f Feature
 		// by default if a feature gate is provided, it is enabled
 		isEnabled := true

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -81,6 +81,14 @@ func TestParseFeatureGate(t *testing.T) {
 			want:    make(map[Feature]bool),
 			wantErr: false,
 		},
+		"feature gate slice with escaped strings": {
+			args: args{
+				features:   []string{"\"\""},
+				defaultFGs: DefaultFeatureGates,
+			},
+			want:    make(map[Feature]bool),
+			wantErr: false,
+		},
 		"a single feature is added": {
 			args: args{
 				features:   []string{"GPTBasedUUID"},


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
The feature flag command line argument is different for en empty string when run as a standalone docker image and from k8s.
If running from k8s, the container specs will be like:
```
"Cmd": [
       "-v=4",
       "--feature-gates=\"\""
     ],
```
If running as a standalone docker image, the container spec will be like:
```
"Cmd": [
       "-v=4",
       "--feature-gates=",
     ],
```
This difference causes the cobra CLI to parse the string as "", instead of nil.

**What this PR does?**:
- add check for empty string while parsing feature flags
- add unit test cases with escaped double quotes

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 