### PR TITLE
refactor(operator): add klog into NDM operator

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -33,18 +33,18 @@ func init() {
 	flag.Set("logtostderr", "true")
 }
 
-// GlogWriter serves as a bridge between the standard log package and the glog package.
-type GlogWriter struct{}
+// KlogWriter serves as a bridge between the standard log package and the klog package.
+type KlogWriter struct{}
 
 // Write implements the io.Writer interface.
-func (writer GlogWriter) Write(data []byte) (n int, err error) {
+func (writer KlogWriter) Write(data []byte) (n int, err error) {
 	klog.Info(string(data))
 	return len(data), nil
 }
 
 // InitLogs initializes logs the way we want for kubernetes.
 func InitLogs() {
-	log.SetOutput(GlogWriter{})
+	log.SetOutput(KlogWriter{})
 	log.SetFlags(0)
 	// The default glog flush interval is 30 seconds, which is frighteningly long.
 	go wait.Until(klog.Flush, *logFlushFreq, wait.NeverStop)
@@ -57,5 +57,5 @@ func FlushLogs() {
 
 // NewLogger creates a new log.Logger which sends logs to klog.Info.
 func NewLogger(prefix string) *log.Logger {
-	return log.New(GlogWriter{}, prefix, 0)
+	return log.New(KlogWriter{}, prefix, 0)
 }


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
When using controller runtime logs, the logs contained information even from vendored packages with the complete stack rather than the point of error. This was making it difficult for debugging and also flooded the logs.
```
{"level":"info","ts":1588942250.7956839,"logger":"controller_deviceclaim","msg":"BlockDeviceClaim State is:Pending","Request.Namespace":"default","Request.Name":"bdc-ssa"}
{"level":"error","ts":1588942250.7958782,"logger":"controller_deviceclaim","msg":"Error selecting device","Request.Namespace":"default","Request.Name":"bdc-ssa","error":"no devices found matching the criteria","stacktrace":"github.com/openebs/node-disk-manager/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openebs/node-disk-manager/pkg/controller/blockdeviceclaim.(*ReconcileBlockDeviceClaim).claimDeviceForBlockDeviceClaim\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go:176\ngithub.com/openebs/node-disk-manager/pkg/controller/blockdeviceclaim.(*ReconcileBlockDeviceClaim).Reconcile\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller.go:121\ngithub.com/openebs/node-disk-manager/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:215\ngithub.com/openebs/node-disk-manager/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/travis/gopath/src/github.com/openebs/node-disk-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```
With the change to klog
```
I0508 12:53:23.038552       1 blockdeviceclaim_controller.go:110] BDC bdc-ssa claim phase is Pending
E0508 12:53:23.038814       1 blockdeviceclaim_controller.go:170] Error selecting device for bdc-ssa: no devices found matching the criteria
I0508 12:53:28.038732       1 blockdeviceclaim_controller.go:110] BDC bdc-ssa claim phase is Pending
E0508 12:53:28.039020       1 blockdeviceclaim_controller.go:170] Error selecting device for bdc-ssa: no devices found matching the criteria
```


**What this PR does?**:
- klog has also been added to make logs more readable
- controller logs has been changed to klog
- zap logger is still initialized so that controller runtime logs
are logged into console

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 