### PR TITLE
cherry-pick(install, crd): add env to enable/disable CRD installation

### DIFF
--- a/cmd/421_akhilerm
+++ b/cmd/421_akhilerm
@@ -1,0 +1,1 @@
+add env to enable / disable CRD installation

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/openebs/node-disk-manager/pkg/env"
 	"github.com/openebs/node-disk-manager/pkg/setup"
 	"github.com/openebs/node-disk-manager/pkg/upgrade"
 	"github.com/openebs/node-disk-manager/pkg/upgrade/v040_041"
@@ -100,18 +101,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	log.Info("Installing the components")
-	// get a new install setup
-	setupConfig, err := setup.NewInstallSetup(cfg)
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
+	// check if CRDs need to be installed.
+	// The OPENEBS_IO_INSTALL_CRD env is checked
+	if env.IsInstallCRDEnabled() {
+		log.Info("Installing the components")
+		// get a new install setup
+		setupConfig, err := setup.NewInstallSetup(cfg)
+		if err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
 
-	// install the components
-	if err = setupConfig.Install(); err != nil {
-		log.Error(err, "")
-		os.Exit(1)
+		// install the components
+		if err = setupConfig.Install(); err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
 	}
 
 	log.Info("Registering Components")

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"os"
+
+	"github.com/openebs/node-disk-manager/pkg/util"
+)
+
+const (
+	// INSTALL_CRD_ENV is the environment variable used to check if
+	// CRDs need to be installed by NDM or not.
+	INSTALL_CRD_ENV = "OPENEBS_IO_INSTALL_CRD"
+
+	// installCRDEnvDefaultValue is the default value for the INSTALL_CRD_ENV
+	installCRDEnvDefaultValue = true
+)
+
+// IsInstallCRDEnabled is used to check whether the CRDs need to be installed
+func IsInstallCRDEnabled() bool {
+	val := os.Getenv(INSTALL_CRD_ENV)
+
+	// if empty return the default value
+	if len(val) == 0 {
+		return installCRDEnvDefaultValue
+	}
+
+	return util.CheckTruthy(val)
+}

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package env
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInstallCRDEnabled(t *testing.T) {
+	tests := map[string]struct {
+		setEnv   bool
+		envValue string
+		want     bool
+	}{
+		"when INSTALL_CRD_ENV is set to true": {
+			setEnv:   true,
+			envValue: "true",
+			want:     true,
+		},
+		"when INSTALL_CRD_ENV is set to false": {
+			setEnv:   true,
+			envValue: "false",
+		},
+		"when INSTALL_CRD_ENV is not set": {
+			setEnv: false,
+			want:   true,
+		},
+		"when INSTALL_CRD is set to empty": {
+			setEnv:   true,
+			envValue: "",
+			want:     true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.setEnv {
+				os.Setenv(INSTALL_CRD_ENV, tt.envValue)
+			}
+			assert.Equal(t, tt.want, IsInstallCRDEnabled())
+			_ = os.Unsetenv(INSTALL_CRD_ENV)
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
When helm install for openebs was introduced, there was no way for helm to install CRDs. So both maya api-server and NDM had code to install the respective CRDs as part of initialization.

With Helm 3, the CRDs can be installed via helm. There have been some requests for moving the CRD installations outside of the code for cases where Kubernetes installers like Lokomotive and others, would like granular control on how the required objects are installed.

**What this PR does?**:
- add OPENEBS_IO_CRD_INSTALL environment variable to enable / disable
installation of BlockDevice and BlockDeviceClaim CRDs

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Cherry pick of PR #421 


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 