### PR TITLE
fix(featuregate): make feature gate independent of controller

### DIFF
--- a/changelogs/unreleased/426-akhilerm
+++ b/changelogs/unreleased/426-akhilerm
@@ -1,0 +1,1 @@
+make feature gates independent of daemon controller

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -18,10 +18,12 @@ package command
 
 import (
 	goflag "flag"
+
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	"github.com/openebs/node-disk-manager/pkg/features"
+	"github.com/openebs/node-disk-manager/pkg/util"
 	"github.com/openebs/node-disk-manager/pkg/version"
 
-	"github.com/openebs/node-disk-manager/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
@@ -39,6 +41,12 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 		Short: "ndm controls the Node-Disk-Manager ",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(RunNodeDiskManager(cmd), util.Fatal)
+
+			// set the feature gates on NDM daemon
+			err := features.DefaultFeatureGates.SetFeatureGate(options.FeatureGate)
+			if err != nil {
+				klog.Fatalf("error setting feature gate: %v", err)
+			}
 		},
 	}
 

--- a/cmd/ndm_daemonset/app/command/commands.go
+++ b/cmd/ndm_daemonset/app/command/commands.go
@@ -43,7 +43,7 @@ func NewNodeDiskManager() (*cobra.Command, error) {
 			util.CheckErr(RunNodeDiskManager(cmd), util.Fatal)
 
 			// set the feature gates on NDM daemon
-			err := features.DefaultFeatureGates.SetFeatureGate(options.FeatureGate)
+			err := features.FeatureGates.SetFeatureFlag(options.FeatureGate)
 			if err != nil {
 				klog.Fatalf("error setting feature gate: %v", err)
 			}

--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -20,17 +20,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openebs/node-disk-manager/blockdevice"
 	"os"
 	"sync"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
-	"k8s.io/client-go/rest"
-
+	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/pkg/apis"
-	"github.com/openebs/node-disk-manager/pkg/features"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -116,8 +114,6 @@ type Controller struct {
 	// NodeAttribute is a map of various attributes of the node in which this daemon is running.
 	// The attributes can be hostname, nodename, zone, failure-domain etc
 	NodeAttributes map[string]string
-	// Feature gates for the NDM daemon
-	FeatureGates features.FeatureGate
 	// BDHierarchy stores the hierarchy of devices on this node
 	BDHierarchy blockdevice.Hierarchy
 }
@@ -162,12 +158,7 @@ func NewController() (*Controller, error) {
 func (c *Controller) SetControllerOptions(opts NDMOptions) error {
 	// set the config for running NDM daemon
 	c.SetNDMConfig(opts)
-	// set the feature gates on NDM daemon
-	fg, err := features.ParseFeatureGate(opts.FeatureGate, features.DefaultFeatureGates)
-	if err != nil {
-		return fmt.Errorf("error setting feature gate %v", err)
-	}
-	c.FeatureGates = fg
+
 	c.Filters = make([]*Filter, 0)
 	c.Probes = make([]*Probe, 0)
 	c.NodeAttributes = make(map[string]string, 0)

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -54,7 +54,7 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 		return
 	}
 
-	isGPTBasedUUIDEnabled := pe.Controller.FeatureGates.IsEnabled(features.GPTBasedUUID)
+	isGPTBasedUUIDEnabled := features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID)
 
 	isErrorDuringUpdate := false
 	// iterate through each block device and perform the add/update operation
@@ -106,7 +106,7 @@ func (pe *ProbeEvent) deleteBlockDeviceEvent(msg controller.EventMessage) {
 	}
 
 	isDeactivated := true
-	isGPTBasedUUIDEnabled := pe.Controller.FeatureGates.IsEnabled(features.GPTBasedUUID)
+	isGPTBasedUUIDEnabled := features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID)
 
 	for _, device := range msg.Devices {
 		// create the new UUID for removing the device

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -54,7 +54,7 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 		return
 	}
 
-	isGPTBasedUUIDEnabled := features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID)
+	isGPTBasedUUIDEnabled := features.FeatureGates.IsEnabled(features.GPTBasedUUID)
 
 	isErrorDuringUpdate := false
 	// iterate through each block device and perform the add/update operation
@@ -106,7 +106,7 @@ func (pe *ProbeEvent) deleteBlockDeviceEvent(msg controller.EventMessage) {
 	}
 
 	isDeactivated := true
-	isGPTBasedUUIDEnabled := features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID)
+	isGPTBasedUUIDEnabled := features.FeatureGates.IsEnabled(features.GPTBasedUUID)
 
 	for _, device := range msg.Devices {
 		// create the new UUID for removing the device

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -148,7 +148,7 @@ func (up *udevProbe) scan() error {
 		}
 		if newUdevice.IsDisk() || newUdevice.IsParitition() {
 			deviceDetails := &blockdevice.BlockDevice{}
-			if up.controller.FeatureGates.IsEnabled(features.GPTBasedUUID) {
+			if features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID) {
 				// WWN, Serial, PartitionTableUUID/GPTLabel, PartitionUUID, FileSystemUUID and DeviceType
 				// are the fields we use to generate the UUID. These fields will be fetched
 				// from the udev event itself. This is to guarantee that we do not need to rely

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -148,7 +148,7 @@ func (up *udevProbe) scan() error {
 		}
 		if newUdevice.IsDisk() || newUdevice.IsParitition() {
 			deviceDetails := &blockdevice.BlockDevice{}
-			if features.DefaultFeatureGates.IsEnabled(features.GPTBasedUUID) {
+			if features.FeatureGates.IsEnabled(features.GPTBasedUUID) {
 				// WWN, Serial, PartitionTableUUID/GPTLabel, PartitionUUID, FileSystemUUID and DeviceType
 				// are the fields we use to generate the UUID. These fields will be fetched
 				// from the udev event itself. This is to guarantee that we do not need to rely

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -44,7 +44,7 @@ const (
 )
 
 // supportedFeatures is the list of supported features. This is used while parsing the
-// feature flag
+// feature flag given via command line
 var supportedFeatures = []Feature{
 	GPTBasedUUID,
 }
@@ -54,15 +54,16 @@ var defaultFeatureGates = map[Feature]bool{
 	GPTBasedUUID: false,
 }
 
-// featureGate is a type that implements the FeatureGate interface
-type FeatureGate map[Feature]bool
+// featureFlag is a map representing the flag and its state
+type featureFlag map[Feature]bool
 
-// DefaultFeatureGate is the global feature gate that can be used to check if a feature is enabled
+// FeatureGate is the global feature gate that can be used to check if a feature flag is enabled
 // or disabled
-var DefaultFeatureGates = NewFeatureGate()
+var FeatureGates = NewFeatureGate()
 
-func NewFeatureGate() FeatureGate {
-	fg := make(FeatureGate)
+// NewFeatureGate gets a new map with the default feature gates for the application
+func NewFeatureGate() featureFlag {
+	fg := make(featureFlag)
 
 	// set the default feature gates
 	for k, v := range defaultFeatureGates {
@@ -73,17 +74,17 @@ func NewFeatureGate() FeatureGate {
 }
 
 // IsEnabled returns true if the feature is enabled
-func (fg FeatureGate) IsEnabled(f Feature) bool {
+func (fg featureFlag) IsEnabled(f Feature) bool {
 	return fg[f]
 }
 
-// SetFeatureGate parses a slice of string and sets the feature gate.
-func (fg FeatureGate) SetFeatureGate(features []string) error {
+// SetFeatureFlag parses a slice of string and sets the feature flag.
+func (fg featureFlag) SetFeatureFlag(features []string) error {
 	if len(features) == 0 {
 		klog.V(4).Info("No feature gates are set")
 		return nil
 	}
-	// iterate through each feature and set its state onto the FeatureGate map
+	// iterate through each feature and set its state onto the featureFlag map
 	for _, feature := range features {
 		var f Feature
 		// by default if a feature gate is provided, it is enabled

--- a/pkg/features/features_test.go
+++ b/pkg/features/features_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 func TestFeatureGateIsEnabled(t *testing.T) {
-	testFG := make(FeatureGate)
+	testFG := make(featureFlag)
 	testFG["feature1"] = false
 	testFG["feature2"] = true
 	tests := map[string]struct {
-		fg      FeatureGate
+		fg      featureFlag
 		feature Feature
 		want    bool
 	}{
@@ -60,7 +60,7 @@ func TestFeatureGateIsEnabled(t *testing.T) {
 	}
 }
 
-func TestSetFeatureGate(t *testing.T) {
+func TestSetFeatureFlag(t *testing.T) {
 	F1 := Feature("FeatureGate1")
 	F2 := Feature("FeatureGate2")
 	F3 := Feature("FeatureGate3")
@@ -72,14 +72,14 @@ func TestSetFeatureGate(t *testing.T) {
 	}
 	tests := map[string]struct {
 		args    args
-		want    FeatureGate
+		want    featureFlag
 		wantErr bool
 	}{
 		"empty feature gate slice": {
 			args: args{
 				features: nil,
 			},
-			want:    make(FeatureGate),
+			want:    make(featureFlag),
 			wantErr: false,
 		},
 		"a single feature is added": {
@@ -104,14 +104,14 @@ func TestSetFeatureGate(t *testing.T) {
 			args: args{
 				features: []string{"WrongFeatureGate"},
 			},
-			want:    make(FeatureGate),
+			want:    make(featureFlag),
 			wantErr: true,
 		},
 		"multiple non-default features in enabled and disabled state": {
 			args: args{
 				features: []string{"FeatureGate1", "FeatureGate2=false", "FeatureGate3=true"},
 			},
-			want: FeatureGate{
+			want: featureFlag{
 				F1: true,
 				F2: false,
 				F3: true,
@@ -122,7 +122,7 @@ func TestSetFeatureGate(t *testing.T) {
 			args: args{
 				features: []string{"FeatureGate1", "FeatureGate2=true=true"},
 			},
-			want: FeatureGate{
+			want: featureFlag{
 				F1: true,
 			},
 			wantErr: true,
@@ -130,14 +130,14 @@ func TestSetFeatureGate(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			fg := make(FeatureGate)
-			err := fg.SetFeatureGate(tt.args.features)
+			fg := make(featureFlag)
+			err := fg.SetFeatureFlag(tt.args.features)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SetFeatureGate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("SetFeatureFlag() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(fg, tt.want) && err == nil {
-				t.Errorf("SetFeatureGate() got = %v, want %v", fg, tt.want)
+				t.Errorf("SetFeatureFlag() got = %v, want %v", fg, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The feature gate used to be a part of the daemon controller. This restricted its use to only code paths which had access to the controller pointer. This PR removes the dependency of feature gates on the daemon controller and can be used globally across the code base.

**What this PR does?**:
- adds a new exporter variable `FeatureGates` in features package which holds the state of all features.
- remove feature gate from daemon controller

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- tested by providing a set of correct and incorrect feature gates.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 