### PR TITLE
style(crd): add FSType into kubectl output (#435)

### DIFF
--- a/changelogs/unreleased/435-harshthakur9030
+++ b/changelogs/unreleased/435-harshthakur9030
@@ -1,0 +1,1 @@
+Adding filesystem info column in output of kubectl get bd -o wide

--- a/pkg/crds/build.go
+++ b/pkg/crds/build.go
@@ -19,6 +19,7 @@ package crds
 import (
 	"errors"
 	"fmt"
+
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 

--- a/pkg/setup/build_crd.go
+++ b/pkg/setup/build_crd.go
@@ -35,6 +35,7 @@ func buildBlockDeviceCRD() (*apiext.CustomResourceDefinition, error) {
 		WithShortNames([]string{apis.BlockDeviceResourceShort}).
 		WithPrinterColumns("NodeName", "string", ".spec.nodeAttributes.nodeName").
 		WithPriorityPrinterColumns("Path", "string", ".spec.path", 1).
+		WithPriorityPrinterColumns("FSType", "string", ".spec.filesystem.fsType", 1).
 		WithPrinterColumns("Size", "string", ".spec.capacity.storage").
 		WithPrinterColumns("ClaimState", "string", ".status.claimState").
 		WithPrinterColumns("Status", "string", ".status.state").


### PR DESCRIPTION
Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>

**Why is this PR required? What issue does it fix?**:
https://github.com/openebs/openebs/issues/3057


**What this PR does?**:
Adding the coloum for filesystem type. 

`$k get bd -o wide
`

`NAME                                           NODENAME                                   PATH        FSTYPE   SIZE          CLAIMSTATE   STATUS   AGE`

`blockdevice  gke-node   /dev/sdb1   ext4     10736352768   Unclaimed    Active   89m`

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
kubectl get bd 

**Any additional information for your reviewer?** : 
It does make the output a bit congested. 


**Checklist:**
- [x] Fixes #[3057](https://github.com/openebs/openebs/issues/3057)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


