### PR TITLE
fix(api, controller): deprecate invalid capacity request

### DIFF
--- a/changelogs/unreleased/443-akhilerm
+++ b/changelogs/unreleased/443-akhilerm
@@ -1,0 +1,1 @@
+deprecate invalid capacity request phase from block device claim

--- a/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
+++ b/pkg/apis/openebs/v1alpha1/blockdeviceclaim_types.go
@@ -139,6 +139,7 @@ const (
 	BlockDeviceClaimStatusPending DeviceClaimPhase = "Pending"
 
 	// BlockDeviceClaimStatusInvalidCapacity represents BlockDeviceClaim has invalid capacity request i.e. 0/-1
+	// Deprecated
 	BlockDeviceClaimStatusInvalidCapacity DeviceClaimPhase = "Invalid Capacity Request"
 
 	// BlockDeviceClaimStatusDone represents BlockDeviceClaim has been assigned backing blockdevice and ready for use.

--- a/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
+++ b/pkg/controller/blockdeviceclaim/blockdeviceclaim_controller_test.go
@@ -252,7 +252,7 @@ func (r *ReconcileBlockDeviceClaim) InvalidCapacityTest(t *testing.T,
 	if err != nil {
 		t.Errorf("Get devRequestInst: (%v)", err)
 	}
-	r.CheckBlockDeviceClaimStatus(t, req, openebsv1alpha1.BlockDeviceClaimStatusInvalidCapacity)
+	r.CheckBlockDeviceClaimStatus(t, req, openebsv1alpha1.BlockDeviceClaimStatusPending)
 }
 
 func TestBlockDeviceClaimsLabelSelector(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The `InvalidCapacityRequest` phase was a wrong addititon into `status.phase` of BlockDeviceClaim. But invalid capacity can only be a reason for the BDC to remain in Pending state. This also guarantees that, even if invalid capacity is given after editing the capacity to a correct value, the BDC can get Bound.

**What this PR does?**:
Deprecate the `InvalidCapacityRequest` phase from block device claim. The phase will be moved to Pending and invalid capacity can only be a reason for BDC remaining in Pending state. Exisiting BDCs with the phase will be changed to Pending.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- Create NDM Operator with `0.6.0` image. Create a BDC with invalid capacity request. The BDC will be in `InvalidCapacity` phase. Update the image with changes in this PR. The BDC phase will change to `Pending`. Editing the capacity to a correct value, gets the BDC to a `Bound` state.

**Any additional information for your reviewer?** : 
This is actually part of cleanup of BDC api.


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [x] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 