### PR TITLE
fix(cleaner); fix cleaning partitions before wiping main disk

### DIFF
--- a/changelogs/unreleased/445-akhilerm
+++ b/changelogs/unreleased/445-akhilerm
@@ -1,0 +1,1 @@
+fix wiping released blockdevices with partitions

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -22,6 +22,7 @@ package cleaner
 
 import (
 	"context"
+	"fmt"
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
@@ -39,8 +40,6 @@ const (
 	JobNamePrefix = "cleanup-"
 	// BDLabel is the label set on the job for identification of the BD
 	BDLabel = "blockdevice"
-	// BlockCleanerCommand is the command used to clean raw block
-	BlockCleanerCommand = "wipefs"
 )
 
 // JobController defines the interface for the job controller.
@@ -75,10 +74,19 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v
 	mountName := "vol-mount"
 
 	if volMode == VolumeModeBlock {
+		jobContainer.Command = []string{"/bin/sh", "-c"}
+
+		// fdisk is used to get all the partitions of the device.
+		// first all the partitions are cleared off any filesystem signatures, then the actual partition table
+		// header is removed. partprobe is called so as to re-read partition table, and update system with
+		// the changes/
 		// wipefs erases the filesystem signature from the block
 		// -a    wipe all magic strings
 		// -f    force erasure
-		jobContainer.Command = getCommand(BlockCleanerCommand, "-af", bd.Spec.Path)
+		args := fmt.Sprintf("(fdisk -o Device -l %s | grep \"^%s\" | sort -r | xargs -I '{}' wipefs -fa '{}') && wipefs -fa %s && partprobe %s",
+			bd.Spec.Path, bd.Spec.Path, bd.Spec.Path, bd.Spec.Path)
+
+		jobContainer.Args = []string{args}
 
 		// in case of sparse disk, need to mount the sparse file directory
 		// and clear the sparse file
@@ -197,15 +205,6 @@ func (c *jobController) CancelJob(bdName string) error {
 
 func generateCleaningJobName(bdName string) string {
 	return JobNamePrefix + bdName
-}
-
-func getCommand(cmd string, args ...string) []string {
-	var command []string
-	command = append(command, cmd)
-	for _, arg := range args {
-		command = append(command, arg)
-	}
-	return command
 }
 
 // GetNodeName gets the Node name from BlockDevice

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -83,7 +83,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v
 		// wipefs erases the filesystem signature from the block
 		// -a    wipe all magic strings
 		// -f    force erasure
-		args := fmt.Sprintf("(fdisk -o Device -l %s | grep \"^%s\" | sort -r | xargs -I '{}' wipefs -fa '{}') && wipefs -fa %s && partprobe %s",
+		args := fmt.Sprintf("(fdisk -o Device -l %s | grep \"^%s\" | xargs -I '{}' wipefs -fa '{}') && wipefs -fa %s && partprobe %s",
 			bd.Spec.Path, bd.Spec.Path, bd.Spec.Path, bd.Spec.Path)
 
 		jobContainer.Args = []string{args}


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
When an application creates partitions on a claimed disk, currently only the partition table is wiped as part of
cleanup. There are chances that filesystem can exist on the partitions.  In such a scenario, creating another partition
starting at the same sector as the earlier one, causes system picking up the filesystem signature from the
previous partition and using it.

**What this PR does?**:
To fix the above issue, first the filesystem signature in the partitions need to be wiped and then the partition table. 
This PR modifies the `wipefs` command to list all the partitions of the claimed disk and wipe each one of them, starting with the FS signature in the partitions. Also `partprobe` command is invoked so as to re-read the partition table on the disk after wiping.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes. Created a cstor pool on a raw disk. Then deleted the pool. After that partition was manually created. System is not reporting
any known filesystems, earlier `zfs_member` filesystem was reported.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 