### PR TITLE
chore(build): disable arm and ppc64le builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ jobs:
   include:
     - os: linux
       arch: amd64
-    - os: linux
-      arch: arm64
-    - os: linux
-      arch: ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
since multi-arch images are now built for NDM, travis builds for arm64 and ppc64le will be disabled. 

**What this PR does?**:
remove `arm64` and `ppc64le` from travis builds

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Continuation of https://github.com/openebs/node-disk-manager/pull/428


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 