### PR TITLE
chore(build): refactor buildx script and add ci builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,7 +19,7 @@ on:
     branches:
       # on pull requests to master and release branches
       - master
-      - v*
+      - 'v*'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,84 @@
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI
+
+on: ['pull_request']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: '.'
+          pattern: '*.sh'
+          exclude: './.git/*,./vendor/*'
+
+  ndm-daemonset:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+
+      - name: Build Image
+        run: |
+          make docker.buildx.ndm IMG_RESULT=cache
+
+  ndm-exporter:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+
+      - name: Build Image
+        run: |
+          make docker.buildx.exporter IMG_RESULT=cache
+
+  ndm-operator:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          buildx-version: latest
+
+      - name: Build Image
+        run: |
+          make docker.buildx.ndo IMG_RESULT=cache

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,12 @@
 
 name: ci
 
-on: ['pull_request']
+on:
+  pull_request:
+    branches:
+      # on pull requests to master and release branches
+      - master
+      - v*
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,8 +51,9 @@ jobs:
           buildx-version: latest
 
       - name: Build Image
-        run: |
-          make docker.buildx.ndm IMG_RESULT=cache
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.ndm
 
   ndm-exporter:
     runs-on: ubuntu-latest
@@ -68,8 +69,9 @@ jobs:
           buildx-version: latest
 
       - name: Build Image
-        run: |
-          make docker.buildx.exporter IMG_RESULT=cache
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.exporter
 
   ndm-operator:
     runs-on: ubuntu-latest
@@ -85,5 +87,6 @@ jobs:
           buildx-version: latest
 
       - name: Build Image
-        run: |
-          make docker.buildx.ndo IMG_RESULT=cache
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.ndo

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI
+name: ci
 
 on: ['pull_request']
 

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -30,7 +30,7 @@ endif
 ifeq (${IMG_RESULT}, load)
 	export PUSH_ARG="--load"
     # if load is specified, image will be built only for the build machine architecture.
-    export PLATFORMS=${XC_OS}/${XC_ARCH}
+    export PLATFORMS="local"
 else ifeq (${IMG_RESULT}, cache)
 	# if cache is specified, image will only be available in the build cache, it won't be pushed or loaded
 	# therefore no PUSH_ARG will be specified


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Currently, multiarch images are built only after merging the changes to master. This PR adds a workflow to build the multiarch image for pull requests.

**What this PR does?**:
- Adds option to specify operation for mulitarch image result (push, load, cache)
  1. Push: the mulitarch image will be pushed to the image registry
  2. Load: the image will be loaded to local docker (image will be built only for the platform of build machine)
  3. Cache: Image will be available only in the build cache
- refactor platform names

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes, built and loaded single platform image using buildx

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Continuation of https://github.com/openebs/node-disk-manager/pull/428

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 