### PR TITLE
cherry-pick(probe): close open fd after exclusive open (#450)

### DIFF
--- a/changelogs/unreleased/450-akhilerm
+++ b/changelogs/unreleased/450-akhilerm
@@ -1,0 +1,1 @@
+fix bug of having an open file descriptor in NDM causing applications to receive resource busy error.

--- a/cmd/ndm_daemonset/probe/usedbyprobe.go
+++ b/cmd/ndm_daemonset/probe/usedbyprobe.go
@@ -200,7 +200,7 @@ func getBlockDeviceZFSPartition(bd blockdevice.BlockDevice) (string, bool) {
 // isBlockDeviceInUseByKernel tries to open the device exclusively to check if the device is
 // being held by some process. eg: If kernel zfs uses the disk, the open will fail
 func isBlockDeviceInUseByKernel(path string) (bool, error) {
-	_, err := os.OpenFile(path, os.O_EXCL, 0444)
+	f, err := os.OpenFile(path, os.O_EXCL, 0444)
 
 	if errors.Is(err, syscall.EBUSY) {
 		return true, nil
@@ -208,5 +208,6 @@ func isBlockDeviceInUseByKernel(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer f.Close()
 	return false, nil
 }


### PR DESCRIPTION
NDM was keeping a file descriptor open after an exclusive open, causing other applications to receive a resource busy error.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
cherry-pick #450 

**What this PR does?**:
Closes an open fd after exclusive open

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 