### PR TITLE
test(unit-tests, coverage): add unit tests to github actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,28 @@ jobs:
           pattern: '*.sh'
           exclude: './.git/*,./vendor/*'
 
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: make install-dep
+
+      - name: Unit test
+        # Here sudo permissions are required for running tests, since we are making use
+        # of scsi device mockdata in smartprobe_test.
+        # To access a particular scsi device to fetch this information, sudo or root
+        # permissions are required.
+        run: sudo -E env "PATH=$PATH" make test
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+
   ndm-daemonset:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -47,6 +66,8 @@ jobs:
           fi
           echo "::set-env name=TAG::${CI_TAG}"
           echo "::set-env name=BRANCH::{BRANCH}"
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${CI_TAG}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -67,7 +88,7 @@ jobs:
 
   ndm-exporter:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -81,6 +102,8 @@ jobs:
           fi
           echo "::set-env name=TAG::${CI_TAG}"
           echo "::set-env name=BRANCH::{BRANCH}"
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${CI_TAG}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -101,7 +124,7 @@ jobs:
 
   ndm-operator:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -115,6 +138,8 @@ jobs:
           fi
           echo "::set-env name=TAG::${CI_TAG}"
           echo "::set-env name=BRANCH::{BRANCH}"
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${CI_TAG}"
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,9 +37,28 @@ jobs:
           pattern: '*.sh'
           exclude: './vendor/*'
 
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        run: make install-dep
+
+      - name: Unit test
+        # Here sudo permissions are required for running tests, since we are making use
+        # of scsi device mockdata in smartprobe_test.
+        # To access a particular scsi device to fetch this information, sudo or root
+        # permissions are required.
+        run: sudo -E env "PATH=$PATH" make test
+
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v1
+
   ndm-daemonset:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +76,7 @@ jobs:
 
   ndm-exporter:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -75,7 +94,7 @@ jobs:
 
   ndm-operator:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: ['lint', 'unit-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
+          echo "RELEASE_TAG ${TAG}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -57,6 +58,7 @@ jobs:
         run: |
           echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
+          echo "RELEASE_TAG ${TAG}"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -85,6 +87,7 @@ jobs:
         run: |
           echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
+          echo "RELEASE_TAG ${TAG}"
 
       - name: Set up Docker Buildx
         id: buildx

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,11 @@ before_script:
 
 script:
   - make
+  # Here sudo -E env "PATH=$PATH" make test is required for running tests with
+  # sudo permissions since we are making use of scsi device mockdata in smartprobe_test
+  # which could be fetched for a SCSI device with sudo permissions only since to access
+  # a particular scsi device, sudo or root permissions are required.
+  - sudo -E env "PATH=$PATH" make test
   - sudo -E env "PATH=$PATH" make integration-test
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   global:
     - ARCH=$(go env GOARCH)
     - TAG="ci"
-    - CODECOV_TOKEN="d1e39bea-f800-45de-8266-3e9b85e2594a"
 
 sudo: required
 
@@ -45,16 +44,10 @@ before_script:
 
 script:
   - make
-  # Here sudo -E env "PATH=$PATH" make test is required for running tests with
-  # sudo permissions since we are making use of scsi device mockdata in smartprobe_test
-  # which could be fetched for a SCSI device with sudo permissions only since to access
-  # a particular scsi device, sudo or root permissions are required.
-  - sudo -E env "PATH=$PATH" make test
   - sudo -E env "PATH=$PATH" make integration-test
 
 after_success:
   - make push
-  - bash <(curl -s https://codecov.io/bash)
 
 notifications:
   email:


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
As part of migrating from travis to github actions, unit tests need to be added in github actions workflow.

**What this PR does?**:
- add unit tests to github actions along with support to upload coverage report
to codecov. unit-tests are added to build and pull request workflows.
- remove uploading coverage report from travis
- print BRANCH and TAG envs in build and release workflow

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes. Checked in local fork with tests and coverage result upload

**Any additional information for your reviewer?** : 
unit-tests are not added to release workflow. This is because along with release, build will also be triggered and tests will be run in that workflow

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 