### PR TITLE
feat(metrics): exporting seachest data to prometheus

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -119,11 +119,35 @@ type BlockDevice struct {
 	// DependentDevices stores the dependent devices
 	DependentDevices DependentBlockDevices
 
-	// TemperatureInfo stores the temperature information of the drive
-	TemperatureInfo TemperatureInformation
+	SMARTInfo SMARTStats
 
 	// Status contains the state of the blockdevice
 	Status Status
+}
+
+// SMARTStats represents stats from SMART spec and data fetched/calculated by data from seachest
+type SMARTStats struct {
+
+	// RotationRate stores the rotation rate of a block device, only applicable for HDD
+	RotationRate uint16
+
+	// RotationalLatency stores the latency of the drive, only applicable for HDD
+	RotationalLatency float64
+
+	// TemperatureInfo stores the temperature information of the drive
+	TemperatureInfo TemperatureInformation
+
+	// TotalBytesRead stores the total amount of bytes read by a block device
+	TotalBytesRead uint64
+
+	// TotalBytesWritten stores the total amount of bytes written by a block device
+	TotalBytesWritten uint64
+
+	// UtilizationRate stores the rate of utilization of a block device
+	UtilizationRate float64
+
+	// PercentEnduranceUsed stores the endurance used in percent
+	PercentEnduranceUsed float64
 }
 
 // Identifier represents the various identifiers that can be used to
@@ -276,12 +300,26 @@ type DevLink struct {
 
 // TemperatureInformation stores the temperature information of the blockdevice
 type TemperatureInformation struct {
-	// TemperatureDataValid specifies whether the current temperature
+	// CurrentTemperatureDataValid specifies whether the current temperature
 	// data reported is valid or not
-	TemperatureDataValid bool
+	CurrentTemperatureDataValid bool
+
+	// LowestTemperatureDataValid specifies whether the lowest temperature
+	// data reported is valid or not
+	LowestTemperatureDataValid bool
+
+	// HighestTemperatureDataValid specifies whether the highest temperature
+	// data reported is valid or not
+	HighestTemperatureDataValid bool
 
 	// CurrentTemperature is the temperature of the drive in celsius
 	CurrentTemperature int16
+
+	// LowestTemperature is the lowest temperature of the drive recorded in celsius
+	LowestTemperature int16
+
+	// HighestTemperature is the highest temperature of the drive recorded in celsius
+	HighestTemperature int16
 }
 
 // PartitionInformation contains information related to the partition, if this

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -151,6 +151,7 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 
 	blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperatureDataValid = seachestProbe.
 		SeachestIdentifier.GetTemperatureDataValidStatus(driveInfo)
+
 	klog.V(4).Infof("Disk: %s TemperatureDataValid:%t filled by seachest.",
 		blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperatureDataValid)
 
@@ -161,24 +162,29 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 		klog.V(4).Infof("Disk: %s CurrentTemperature:%d filled by seachest.",
 			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperature)
 
-		blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid = seachestProbe.
-			SeachestIdentifier.GetHighestValid(driveInfo)
+	}
 
-		klog.V(4).Infof("Disk: %s HighestTemperatureDataValid:%t filled by seachest.",
-			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid)
+	blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid = seachestProbe.
+		SeachestIdentifier.GetHighestValid(driveInfo)
+
+	klog.V(4).Infof("Disk: %s HighestTemperatureDataValid:%t filled by seachest.",
+		blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid)
+
+	if blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid == true {
 
 		blockDevice.SMARTInfo.TemperatureInfo.HighestTemperature = seachestProbe.
 			SeachestIdentifier.GetHighestTemperature(driveInfo)
 
 		klog.V(4).Infof("Disk: %s HighestTemperature:%d filled by seachest.",
 			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.HighestTemperature)
+	}
+	blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid = seachestProbe.
+		SeachestIdentifier.GetLowestValid(driveInfo)
 
-		blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid = seachestProbe.
-			SeachestIdentifier.GetLowestValid(driveInfo)
+	klog.V(4).Infof("Disk: %s LowestValid:%t filled by seachest.",
+		blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid)
 
-		klog.V(4).Infof("Disk: %s LowestValid:%t filled by seachest.",
-			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid)
-
+	if blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid == true {
 		blockDevice.SMARTInfo.TemperatureInfo.LowestTemperature = seachestProbe.
 			SeachestIdentifier.GetLowestTemperature(driveInfo)
 

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -124,65 +124,65 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 
 	// All the below mentioned fields will be filled in only after BlockDevice struct
 	// starts supporting them.
-	/*if d.RotationRate == 0 {
-		d.RotationRate = seachestProbe.SeachestIdentifier.GetRotationRate(driveInfo)
-		klog.V(4).Infof("Disk: %s RotationRate:%d filled by seachest.", d.Path, d.RotationRate)
-	}*/
-
-	/*if d.TotalBytesRead == 0 {
-		d.TotalBytesRead = seachestProbe.SeachestIdentifier.GetTotalBytesRead(driveInfo)
-		klog.V(4).Infof("Disk: %s TotalBytesRead:%d filled by seachest.", d.Path, d.TotalBytesRead)
+	if blockDevice.SMARTInfo.RotationRate == 0 {
+		blockDevice.SMARTInfo.RotationRate = seachestProbe.SeachestIdentifier.GetRotationRate(driveInfo)
+		klog.V(4).Infof("Disk: %s RotationRate:%d filled by seachest.", blockDevice.DevPath, blockDevice.SMARTInfo.RotationRate)
 	}
 
-	if d.TotalBytesWritten == 0 {
-		d.TotalBytesWritten = seachestProbe.SeachestIdentifier.GetTotalBytesWritten(driveInfo)
-		klog.V(4).Infof("Disk: %s TotalBytesWritten:%d filled by seachest.", d.Path, d.TotalBytesWritten)
+	if blockDevice.SMARTInfo.TotalBytesRead == 0 {
+		blockDevice.SMARTInfo.TotalBytesRead = seachestProbe.SeachestIdentifier.GetTotalBytesRead(driveInfo)
+		klog.V(4).Infof("Disk: %s TotalBytesRead:%d filled by seachest.", blockDevice.DevPath, blockDevice.SMARTInfo.TotalBytesRead)
 	}
 
-	if d.DeviceUtilizationRate == 0 {
-		d.DeviceUtilizationRate = seachestProbe.SeachestIdentifier.GetDeviceUtilizationRate(driveInfo)
-		klog.V(4).Infof("Disk: %s DeviceUtilizationRate:%f filled by seachest.", d.Path, d.DeviceUtilizationRate)
+	if blockDevice.SMARTInfo.TotalBytesWritten == 0 {
+		blockDevice.SMARTInfo.TotalBytesWritten = seachestProbe.SeachestIdentifier.GetTotalBytesWritten(driveInfo)
+		klog.V(4).Infof("Disk: %s TotalBytesWritten:%d filled by seachest.", blockDevice.DevPath, blockDevice.SMARTInfo.TotalBytesWritten)
 	}
 
-	if d.PercentEnduranceUsed == 0 {
-		d.PercentEnduranceUsed = seachestProbe.SeachestIdentifier.GetPercentEnduranceUsed(driveInfo)
-		klog.V(4).Infof("Disk: %s PercentEnduranceUsed:%f filled by seachest.", d.Path, d.PercentEnduranceUsed)
-	}*/
+	if blockDevice.SMARTInfo.UtilizationRate == 0 {
+		blockDevice.SMARTInfo.UtilizationRate = seachestProbe.SeachestIdentifier.GetDeviceUtilizationRate(driveInfo)
+		klog.V(4).Infof("Disk: %s UtilizationRate:%f filled by seachest.", blockDevice.DevPath, blockDevice.SMARTInfo.UtilizationRate)
+	}
 
-	blockDevice.TemperatureInfo.TemperatureDataValid = seachestProbe.
+	if blockDevice.SMARTInfo.PercentEnduranceUsed == 0 {
+		blockDevice.SMARTInfo.PercentEnduranceUsed = seachestProbe.SeachestIdentifier.GetPercentEnduranceUsed(driveInfo)
+		klog.V(4).Infof("Disk: %s PercentEnduranceUsed:%f filled by seachest.", blockDevice.DevPath, blockDevice.SMARTInfo.PercentEnduranceUsed)
+	}
+
+	blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperatureDataValid = seachestProbe.
 		SeachestIdentifier.GetTemperatureDataValidStatus(driveInfo)
 	klog.V(4).Infof("Disk: %s TemperatureDataValid:%t filled by seachest.",
-		blockDevice.DevPath, blockDevice.TemperatureInfo.TemperatureDataValid)
+		blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperatureDataValid)
 
-	if blockDevice.TemperatureInfo.TemperatureDataValid == true {
-		blockDevice.TemperatureInfo.CurrentTemperature = seachestProbe.
+	if blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperatureDataValid == true {
+		blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperature = seachestProbe.
 			SeachestIdentifier.GetCurrentTemperature(driveInfo)
 
 		klog.V(4).Infof("Disk: %s CurrentTemperature:%d filled by seachest.",
-			blockDevice.DevPath, blockDevice.TemperatureInfo.CurrentTemperature)
+			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.CurrentTemperature)
 
-		/*d.TemperatureInfo.HighestValid = seachestProbe.
+		blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid = seachestProbe.
 			SeachestIdentifier.GetHighestValid(driveInfo)
 
-		klog.V(4).Infof("Disk: %s HighestValid:%t filled by seachest.",
-			d.Path, d.TemperatureInfo.HighestValid)
+		klog.V(4).Infof("Disk: %s HighestTemperatureDataValid:%t filled by seachest.",
+			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.HighestTemperatureDataValid)
 
-		d.TemperatureInfo.HighestTemperature = seachestProbe.
+		blockDevice.SMARTInfo.TemperatureInfo.HighestTemperature = seachestProbe.
 			SeachestIdentifier.GetHighestTemperature(driveInfo)
 
 		klog.V(4).Infof("Disk: %s HighestTemperature:%d filled by seachest.",
-			d.Path, d.TemperatureInfo.HighestTemperature)
+			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.HighestTemperature)
 
-		d.TemperatureInfo.LowestValid = seachestProbe.
+		blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid = seachestProbe.
 			SeachestIdentifier.GetLowestValid(driveInfo)
 
 		klog.V(4).Infof("Disk: %s LowestValid:%t filled by seachest.",
-			d.Path, d.TemperatureInfo.LowestValid)
+			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.LowestTemperatureDataValid)
 
-		d.TemperatureInfo.LowestTemperature = seachestProbe.
+		blockDevice.SMARTInfo.TemperatureInfo.LowestTemperature = seachestProbe.
 			SeachestIdentifier.GetLowestTemperature(driveInfo)
 
 		klog.V(4).Infof("Disk: %s LowestTemperature:%d filled by seachest.",
-			d.Path, d.TemperatureInfo.LowestTemperature)*/
+			blockDevice.DevPath, blockDevice.SMARTInfo.TemperatureInfo.LowestTemperature)
 	}
 }

--- a/pkg/metrics/smart/metrics.go
+++ b/pkg/metrics/smart/metrics.go
@@ -31,6 +31,33 @@ type MetricsData struct {
 	// blockDeviceTemperature is the temperature of the the blockdevice if it is reported
 	blockDeviceCurrentTemperature *prometheus.GaugeVec
 
+	// blockDevicehighestTemperature is the highest temperature of the the blockdevice if it is reported
+	blockDeviceHighestTemperature *prometheus.GaugeVec
+
+	// blockDeviceHighestTemperatureValid tells whether the highest temperature data is valid
+	blockDeviceHighestTemperatureValid *prometheus.GaugeVec
+
+	// blockDevicelowestTemperature is the lowest temperature of the the blockdevice if it is reported
+	blockDeviceLowestTemperature *prometheus.GaugeVec
+
+	// blockDeviceLowestTemperatureValid tells whether the lowest temperature data is valid
+	blockDeviceLowestTemperatureValid *prometheus.GaugeVec
+
+	// blockDeviceCapacity is capacity of block device
+	blockDeviceCapacity *prometheus.GaugeVec
+
+	// blockDeviceTotalReadBytes is the total number of bytes read from the block device
+	blockDeviceTotalReadBytes *prometheus.CounterVec
+
+	// blockDeviceTotalWrittenBytes is the total number of bytes written from the block device
+	blockDeviceTotalWrittenBytes *prometheus.CounterVec
+
+	// blockDeviceUtilizationRate is utilization rate of the block device
+	blockDeviceUtilizationRate *prometheus.GaugeVec
+
+	// blockDevicePercentEnduranceUsed  is percentage of endurance used by a block device
+	blockDevicePercentEnduranceUsed *prometheus.GaugeVec
+
 	// errors and rejected requests
 	rejectRequestCount prometheus.Counter
 	errorRequestCount  prometheus.Counter
@@ -63,11 +90,21 @@ func NewMetrics(collector string) *Metrics {
 func (m *Metrics) Collectors() []prometheus.Collector {
 	return []prometheus.Collector{
 		m.blockDeviceCurrentTemperatureValid,
+		m.blockDeviceHighestTemperatureValid,
+		m.blockDeviceLowestTemperatureValid,
 		m.blockDeviceCurrentTemperature,
+		m.blockDeviceHighestTemperature,
+		m.blockDeviceLowestTemperature,
+		m.blockDeviceTotalReadBytes,
+		m.blockDeviceTotalWrittenBytes,
+		m.blockDeviceUtilizationRate,
+		m.blockDevicePercentEnduranceUsed,
 		m.rejectRequestCount,
 		m.errorRequestCount,
 	}
 }
+
+var labels []string = []string{"blockdevicename", "path", "hostname", "nodename"}
 
 // ErrorCollectors lists out all collectors for metrics related to error
 func (m *Metrics) ErrorCollectors() []prometheus.Collector {
@@ -96,7 +133,35 @@ func (m *Metrics) WithBlockDeviceCurrentTemperature() *Metrics {
 			Name:      "block_device_current_temperature_celsius",
 			Help:      `Current reported temperature of the blockdevice. -1 if not reported`,
 		},
-		[]string{"blockdevicename", "path", "hostname", "nodename"},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceHighestTemperature declares the metric highest temperature
+// as a prometheus metric
+func (m *Metrics) WithBlockDeviceHighestTemperature() *Metrics {
+	m.blockDeviceHighestTemperature = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_highest_temperature_celsius",
+			Help:      `Highest reported temperature of the blockdevice. -1 if not reported`,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceLowestTemperature declares the metric lowest temperature
+// as a prometheus metric
+func (m *Metrics) WithBlockDeviceLowestTemperature() *Metrics {
+	m.blockDeviceLowestTemperature = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_lowest_temperature_celsius",
+			Help:      `Lowest reported temperature of the blockdevice. -1 if not reported`,
+		},
+		labels,
 	)
 	return m
 }
@@ -110,7 +175,100 @@ func (m *Metrics) WithBlockDeviceCurrentTemperatureValid() *Metrics {
 			Name:      "block_device_current_temperature_valid",
 			Help:      `Validity of the current temperature data reported. 0 means not valid, 1 means valid`,
 		},
-		[]string{"blockdevicename", "path", "hostname", "nodename"},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceHighestTemperatureValid declares the metric highest temperature valid
+// as a prometheus metric
+func (m *Metrics) WithBlockDeviceHighestTemperatureValid() *Metrics {
+	m.blockDeviceHighestTemperatureValid = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_highest_temperature_valid",
+			Help:      `Validity of the highest temperature data reported. 0 means not valid, 1 means valid`,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceLowestTemperatureValid declares the metric lowest temperature valid
+// as a prometheus metric
+func (m *Metrics) WithBlockDeviceLowestTemperatureValid() *Metrics {
+	m.blockDeviceLowestTemperatureValid = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_lowest_temperature_valid",
+			Help:      `Validity of the lowest temperature data reported. 0 means not valid, 1 means valid`,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceCapacity declares the blockdevice capacity
+func (m *Metrics) WithBlockDeviceCapacity() *Metrics {
+	m.blockDeviceCapacity = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_capacity_bytes",
+			Help:      `Capacity of the block device in bytes`,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceTotalBytesRead declares the total number of bytes read by a block device
+func (m *Metrics) WithBlockDeviceTotalBytesRead() *Metrics {
+	m.blockDeviceTotalReadBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_total_read_bytes",
+			Help:      `total number of bytes read by a block device in bytes `,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceTotalBytesWritten declares the total number of bytes written by a block device
+func (m *Metrics) WithBlockDeviceTotalBytesWritten() *Metrics {
+	m.blockDeviceTotalWrittenBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_total_written_bytes",
+			Help:      `total number of bytes written by a block device in bytes `,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDeviceUtilizationRate declares the utilization rate of a block device
+func (m *Metrics) WithBlockDeviceUtilizationRate() *Metrics {
+	m.blockDeviceUtilizationRate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_utilization_rate_percent",
+			Help:      `Ratio of actual workload to manufacturer's designed workload for the device `,
+		},
+		labels,
+	)
+	return m
+}
+
+// WithBlockDevicePercentEnduranceUsed declares the percentage of endurance used by a block device
+func (m *Metrics) WithBlockDevicePercentEnduranceUsed() *Metrics {
+	m.blockDevicePercentEnduranceUsed = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: m.CollectorType,
+			Name:      "block_device_endurance_used_percent",
+			Help:      `Estimate of the percentage of the device life that has been used `,
+		},
+		labels,
 	)
 	return m
 }
@@ -169,8 +327,31 @@ func (m *Metrics) SetBlockDeviceCurrentTemperature(currentTemp int16) *Metrics {
 	m.blockDeviceCurrentTemperature.WithLabelValues(m.UUID,
 		m.Path,
 		m.HostName,
-		m.NodeName).
+		m.NodeName,
+	).
 		Set(float64(currentTemp))
+	return m
+}
+
+// SetBlockDeviceHighestTemperature sets the highest temperature value to the metric
+func (m *Metrics) SetBlockDeviceHighestTemperature(highTemp int16) *Metrics {
+	m.blockDeviceHighestTemperature.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(float64(highTemp))
+	return m
+}
+
+// SetBlockDeviceLowestTemperature sets the lowest temperature value to the metric
+func (m *Metrics) SetBlockDeviceLowestTemperature(lowTemp int16) *Metrics {
+	m.blockDeviceLowestTemperature.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(float64(lowTemp))
 	return m
 }
 
@@ -180,7 +361,32 @@ func (m *Metrics) SetBlockDeviceCurrentTemperatureValid(valid bool) *Metrics {
 	m.blockDeviceCurrentTemperatureValid.WithLabelValues(m.UUID,
 		m.Path,
 		m.HostName,
-		m.NodeName).
+		m.NodeName,
+	).
+		Set(getTemperatureValidity(valid))
+	return m
+}
+
+// SetBlockDeviceHighestTemperatureValid sets the validity of the exposed highest
+// temperature metrics
+func (m *Metrics) SetBlockDeviceHighestTemperatureValid(valid bool) *Metrics {
+	m.blockDeviceCurrentTemperatureValid.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(getTemperatureValidity(valid))
+	return m
+}
+
+// SetBlockDeviceLowestTemperatureValid sets the validity of the exposed lowest
+// temperature metrics
+func (m *Metrics) SetBlockDeviceLowestTemperatureValid(valid bool) *Metrics {
+	m.blockDeviceCurrentTemperatureValid.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
 		Set(getTemperatureValidity(valid))
 	return m
 }
@@ -192,4 +398,57 @@ func getTemperatureValidity(isValid bool) float64 {
 		return 1
 	}
 	return 0
+}
+
+// SetBlockDeviceCapacity sets the current block device capacity value to the metric
+func (m *Metrics) SetBlockDeviceCapacity(capacity uint64) *Metrics {
+	m.blockDeviceCapacity.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(float64(capacity))
+	return m
+}
+
+// SetBlockDeviceTotalBytesRead sets the total bytes read value to the metric
+func (m *Metrics) SetBlockDeviceTotalBytesRead(size uint64) *Metrics {
+	m.blockDeviceTotalReadBytes.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	)
+	return m
+}
+
+// SetBlockDeviceTotalBytesWritten sets the total bytes written value to the metric
+func (m *Metrics) SetBlockDeviceTotalBytesWritten(size uint64) *Metrics {
+	m.blockDeviceTotalWrittenBytes.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	)
+	return m
+}
+
+// SetBlockDeviceUtilizationRate sets the utilization rate value to the metric
+func (m *Metrics) SetBlockDeviceUtilizationRate(size float64) *Metrics {
+	m.blockDeviceUtilizationRate.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(float64(size))
+	return m
+}
+
+// SetBlockDevicePercentEnduranceUsed sets the percentage of endurance used by a block device to the metric
+func (m *Metrics) SetBlockDevicePercentEnduranceUsed(size float64) *Metrics {
+	m.blockDevicePercentEnduranceUsed.WithLabelValues(m.UUID,
+		m.Path,
+		m.HostName,
+		m.NodeName,
+	).
+		Set(float64(size))
+	return m
 }

--- a/pkg/seachest/seachest.go
+++ b/pkg/seachest/seachest.go
@@ -34,8 +34,9 @@ package seachest
 import "C"
 import (
 	"fmt"
-	"k8s.io/klog"
 	"unsafe"
+
+	"k8s.io/klog"
 )
 
 // Seachest errors are converted to string using this function
@@ -161,6 +162,18 @@ func (I *Identifier) GetPhysicalSectorSize(driveInfo *C.driveInformationSAS_SATA
 func (I *Identifier) GetRotationRate(driveInfo *C.driveInformationSAS_SATA) uint16 {
 	if driveInfo.rotationRate > 1 {
 		return ((uint16)(driveInfo.rotationRate))
+	}
+	return 0
+}
+
+func (I *Identifier) GetRotationalLatency(driveInfo *C.driveInformationSAS_SATA) float64 {
+	if driveInfo.rotationRate > 1 {
+		// latency = 1/rpm/60
+		// Formula reference: https://sciencing.com/calculate-rotational-latency-8559684.html
+		rpm := (uint16)(driveInfo.rotationRate)
+		rps := float64(rpm / 60)
+		latency := float64(1 / rps)
+		return latency
 	}
 	return 0
 }


### PR DESCRIPTION
Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Exports seachest data which is already fetched

**What this PR does?**:
Exports seachest data to prometheus

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
The following data is exported :
    HighestTemperature
    LowestTempearature
    RotationalLatency
    Capacity
    LogicalSectorSize
    PhysicalSectorSize
    RotationRate
    DriveType
    TotalBytesRead
    TotalBytesWritten
    DeviceUtilization
Other than the above, Rotational Latency is calculated and exported

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_



**Checklist:**
- [x] Fixes #451 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


