### PR TITLE
fix(cleanup): run partprobe commands only on block files

### DIFF
--- a/changelogs/unreleased/463-akhilerm
+++ b/changelogs/unreleased/463-akhilerm
@@ -1,0 +1,1 @@
+fix running cleanup job for sparse blockdevices.


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
After cleaning up the device, partprobe was run on the device to reload the changes into the kernel. But running partprobe on sparse blockdevices can error out. 

**What this PR does?**:
-  Added an additional check to run `partprobe` only if the device is a block file.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes. The following 2 cases were tested.
1. Run the cleanup job on a sparse file
2. Run the cleanup job on a regular disk

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Fix bug introduced in  #445 

**Checklist:**
- [x] Fixes [#3084](https://github.com/openebs/openebs/issues/3084)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 