### PR TITLE
chore(build): fix build and push script to remove `v` prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH}-ci
+          CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
@@ -96,7 +96,7 @@ jobs:
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH}-ci
+          CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
@@ -132,7 +132,7 @@ jobs:
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
-          CI_TAG=${BRANCH}-ci
+          CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi

--- a/build/push
+++ b/build/push
@@ -79,7 +79,11 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
 
   #Add an option to specify a custom TAG_SUFFIX
   #via environment variable. Default is no tag.
@@ -107,11 +111,7 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    # Example: v0.5.0 maps to 0.5.0
-    # Example: 1.10.0 maps to 1.10.0
-    # Example: v1.10.0-custom maps to 1.10.0-custom
-    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
 else
@@ -132,7 +132,7 @@ then
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
     # Trim the `v` from the TRAVIS_TAG if it exists
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/changelogs/unreleased/467-akhilerm
+++ b/changelogs/unreleased/467-akhilerm
@@ -1,0 +1,1 @@
+remove v prefix from all image tags


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Currently the ci images from release branches are having a prefix `v`, eg: `v0.7.x-ci`. But to make naming consistent across all the images we need to use only `0.7.x-ci`. 

**What this PR does?**:
This PR removes the prefix from both the push script as well as the multiarch image.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
This PR is part of [#137](https://github.com/openebs/charts/pull/137) to remove `v` prefix from all image tags.

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 