### PR TITLE
fix(address): Make api service address configurable

### DIFF
--- a/cmd/ndm_daemonset/app/command/start.go
+++ b/cmd/ndm_daemonset/app/command/start.go
@@ -17,6 +17,7 @@ limitations under the License.
 package command
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/openebs/node-disk-manager/pkg/features"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 //NewCmdStart starts the ndm controller
@@ -65,6 +67,10 @@ func NewCmdStart() *cobra.Command {
 
 		},
 	}
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	getCmd.PersistentFlags().StringVar(&grpc.Address, "api-service-address",
+		grpc.DefaultAddress,
+		"Address(ip:port) for api service")
 
 	return getCmd
 }

--- a/cmd/ndm_daemonset/grpc/api.go
+++ b/cmd/ndm_daemonset/grpc/api.go
@@ -29,10 +29,16 @@ import (
 )
 
 const (
-	ip      = "0.0.0.0"
-	port    = "9090"
-	address = ip + ":" + port
+	// IP represents the IP address of the api service
+	IP = "0.0.0.0"
+	// Port represents the port of the API service
+	Port = "9115"
+	// DefaultAddress represents the DefaultAddress at which api service can be called on which is 0.0.0.0:9115
+	DefaultAddress = IP + ":" + Port
 )
+
+// Address represents the address given by user
+var Address = ""
 
 // Start starts the grpc server
 func Start() {
@@ -49,21 +55,20 @@ func Start() {
 		// This helps clients determine which services are available to call
 		reflection.Register(grpcServer)
 
-		// Similar to registring handlers for http
+		// Similar to registering handlers for http
 		protos.RegisterInfoServer(grpcServer, infoService)
 
 		protos.RegisterNodeServer(grpcServer, nodeService)
 
-		l, err := net.Listen("tcp", address)
+		l, err := net.Listen("tcp", Address)
 		if err != nil {
-			klog.Errorf("Unable to listen %f", err)
+			klog.Errorf("Unable to listen %v", err)
 			os.Exit(1)
 		}
 
 		// Listen for requests
-		klog.Infof("Starting server at : %v ", address)
+		klog.Infof("Starting server at : %v ", Address)
 		grpcServer.Serve(l)
 
 	}
-
 }

--- a/integration_tests/sanity/grpc_tests.go
+++ b/integration_tests/sanity/grpc_tests.go
@@ -19,6 +19,7 @@ package sanity
 import (
 	"context"
 
+	apiservice "github.com/openebs/node-disk-manager/cmd/ndm_daemonset/grpc"
 	"github.com/openebs/node-disk-manager/integration_tests/k8s"
 	"github.com/openebs/node-disk-manager/integration_tests/udev"
 	"github.com/openebs/node-disk-manager/integration_tests/utils"
@@ -29,6 +30,8 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/klog"
 )
+
+var address = apiservice.DefaultAddress
 
 var _ = Describe("gRPC tests", func() {
 
@@ -66,7 +69,7 @@ var _ = Describe("gRPC tests", func() {
 	Context("gRPC services", func() {
 
 		It("iSCSI test", func() {
-			conn, err := grpc.Dial("localhost:9090", grpc.WithInsecure())
+			conn, err := grpc.Dial(address, grpc.WithInsecure())
 			Expect(err).NotTo(HaveOccurred())
 			defer conn.Close()
 
@@ -94,7 +97,7 @@ var _ = Describe("gRPC tests", func() {
 		})
 
 		It("List Block Devices test", func() {
-			conn, err := grpc.Dial("localhost:9090", grpc.WithInsecure())
+			conn, err := grpc.Dial(address, grpc.WithInsecure())
 			Expect(err).NotTo(HaveOccurred())
 			defer conn.Close()
 
@@ -125,7 +128,7 @@ var _ = Describe("gRPC tests", func() {
 		})
 
 		It("Huge pages test", func() {
-			conn, err := grpc.Dial("localhost:9090", grpc.WithInsecure())
+			conn, err := grpc.Dial(address, grpc.WithInsecure())
 			Expect(err).NotTo(HaveOccurred())
 			defer conn.Close()
 
@@ -144,7 +147,7 @@ var _ = Describe("gRPC tests", func() {
 
 		})
 		It("Rescan test", func() {
-			conn, err := grpc.Dial("localhost:9090", grpc.WithInsecure())
+			conn, err := grpc.Dial(address, grpc.WithInsecure())
 			Expect(err).NotTo(HaveOccurred())
 			defer conn.Close()
 

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -130,6 +130,8 @@ spec:
           - -v=4
           - --feature-gates="GPTBasedUUID"
           - --feature-gates="APIService"
+          # Default address is 0.0.0.0:9115, do not use quotes around the address
+          # - --api-service-address=0.0.0.0:9115
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Port of the API service was hardcoded to a common port and as NDM uses host network, it could cause a conflict with other apps running on that port. 

**What this PR does?**:
Makes the ip address and port configurable and changes the default port to 9115.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Checked with passing the new flag and without. 

**Any additional information for your reviewer?** : 
#433 


**Checklist:**
- [x] Fixes #465 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


