### PR TITLE
fix(cleanup): fix cleanup job to run partprobe command only on disk types.

### DIFF
--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -105,9 +105,13 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v
 		args := fmt.Sprintf("(fdisk -o Device -l %[1]s "+
 			"| grep \"^%[1]s\" "+
 			"| xargs -I '{}' wipefs -fa '{}') "+
-			"&& wipefs -fa %[1]s "+
-			"&& if [ -b %[1]s ]; then partprobe %[1]s; fi;",
+			"&& wipefs -fa %[1]s ",
 			bd.Spec.Path)
+
+		// partprobe need to be executed only if the device is of type disk.
+		if bd.Spec.Details.DeviceType == blockdevice.BlockDeviceTypeDisk {
+			args += fmt.Sprintf("&& partprobe %s ", bd.Spec.Path)
+		}
 
 		jobContainer.Args = []string{args}
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
cleanup job fails on partitions, because the partprobe command fails with invalid argument error.

**What this PR does?**:
Fix the cleanup script to run partprobe only on blockdevices having deviceType as disk

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- claimed a sparse blockdevice, unclaimed and wiped it 
- claimed a whole disk for cstor, unclaimed and wiped it
- claimed a single partition for cstor, unclaimed and cleaned it up.
- claimed an LVM device for cstor, unclaimed and wiped it.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Continuation of #463 
Various scenarios tried out before arriving at this conclusion:
- Use ubuntu image instead of alpine base image for linux-utils container. This is because the partprobe implementation is different. But both partprobe implementations failed while running on partitions.
- Tried using the parent device name always for running partprobe. It always works. But getting parent name is difficult in operator
- Run partprobe only when deviceType is disk. (Current solution). The deviceType will be checked and partprobe will be run only if the deviceType is of disk.

Additional Information:
When partprobe was run on partition directly it failed. But when the partition contained a filesystem. it did not error out. The actual reason for this behaviour is not yet known. system calls were traced in both cases, but couldn't makeup any useful information out of it.

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 