### PR TITLE
feat(probe, config): add support for config based tag on blockdevices

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -97,6 +97,10 @@ type BlockDevice struct {
 	// the BlockDevice is attached
 	NodeAttributes NodeAttribute
 
+	// Labels for this blockdevice. These labels will be used on the k8s resource that is created
+	// optional
+	Labels map[string]string
+
 	// FSInfo contains the file system related information of this
 	// BlockDevice if it exists
 	FSInfo FileSystemInformation

--- a/changelogs/unreleased/475-akhilerm
+++ b/changelogs/unreleased/475-akhilerm
@@ -1,0 +1,1 @@
+add support to add custom tag to blockdevices based on config

--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -29,7 +29,9 @@ import (
 type DeviceInfo struct {
 	// NodeAttributes is the attributes of the node to which this block device is attached,
 	// like hostname, nodename
-	NodeAttributes     bd.NodeAttribute
+	NodeAttributes bd.NodeAttribute
+	// Optional labels that can be added to the blockdevice resource
+	Labels             map[string]string
 	UUID               string   // UUID of backing disk
 	Capacity           uint64   // Capacity of blockdevice
 	Model              string   // Do blockdevice have model ??
@@ -86,6 +88,10 @@ func (di *DeviceInfo) getObjectMeta() metav1.ObjectMeta {
 	objectMeta.Labels[KubernetesHostNameLabel] = di.NodeAttributes[HostNameKey]
 	objectMeta.Labels[NDMDeviceTypeKey] = NDMDefaultDeviceType
 	objectMeta.Labels[NDMManagedKey] = TrueString
+	// adding custom labels
+	for k, v := range di.Labels {
+		objectMeta.Labels[k] = v
+	}
 	return objectMeta
 }
 

--- a/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
+++ b/cmd/ndm_daemonset/controller/disk_to_device_convertor.go
@@ -35,6 +35,7 @@ func (c *Controller) NewDeviceInfoFromBlockDevice(blockDevice *bd.BlockDevice) *
 	}
 
 	deviceDetails.UUID = blockDevice.UUID
+	deviceDetails.Labels = blockDevice.Labels
 	deviceDetails.Capacity = blockDevice.Capacity.Storage
 	deviceDetails.Model = blockDevice.DeviceAttributes.Model
 	deviceDetails.Serial = blockDevice.DeviceAttributes.Serial

--- a/cmd/ndm_daemonset/controller/ndmconfig.go
+++ b/cmd/ndm_daemonset/controller/ndmconfig.go
@@ -34,6 +34,8 @@ const (
 type NodeDiskManagerConfig struct {
 	ProbeConfigs  []ProbeConfig  `json:"probeconfigs"`  // ProbeConfigs contains configs of Probes
 	FilterConfigs []FilterConfig `json:"filterconfigs"` // FilterConfigs contains configs of Filters
+	// TagConfigs contains configs for tags
+	TagConfigs []TagConfig `json:"tagconfigs"`
 }
 
 // ProbeConfig contains configs of Probe
@@ -50,6 +52,13 @@ type FilterConfig struct {
 	State   string `json:"state"`   // State is state of Filter
 	Include string `json:"include"` // Include contains , separated values which we want to include for filter
 	Exclude string `json:"exclude"` // Exclude contains , separated values which we want to exclude for filter
+}
+
+type TagConfig struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Pattern string `json:"pattern"`
+	TagName string `json:"tag"`
 }
 
 // SetNDMConfig sets config for probes and filters which user provides via configmap. If

--- a/cmd/ndm_daemonset/probe/customtagprobe.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe.go
@@ -1,0 +1,91 @@
+package probe
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
+	"github.com/openebs/node-disk-manager/db/kubernetes"
+	"github.com/openebs/node-disk-manager/pkg/util"
+
+	"k8s.io/klog"
+)
+
+const (
+	customTagProbePriority = 7
+
+	tagTypePath = "path"
+)
+
+var (
+	customTagProbeState = defaultEnabled
+
+	supportedTagTypes = []string{tagTypePath}
+)
+
+type customTagProbe struct {
+	tags []tag
+}
+
+type tag struct {
+	tagType string
+	regex   string
+	label   string
+}
+
+// The label validation regex should be the same as used in
+// https://github.com/kubernetes/apimachinery/blob/master/pkg/util/validation/validation.go
+const labelValidatorRegex = "(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?"
+
+var customTagProbeRegister = func() {
+	// Get a controller object
+	ctrl := <-controller.ControllerBroadcastChannel
+	if ctrl == nil {
+		klog.Error("unable to configure custom tag probe")
+		return
+	}
+	tagProbe := &customTagProbe{}
+
+	if ctrl.NDMConfig != nil {
+		for _, tagConfig := range ctrl.NDMConfig.TagConfigs {
+			if !util.Contains(supportedTagTypes, tagConfig.Type) {
+				klog.Errorf("unsupported tag type: %s", tagConfig.Type)
+			}
+
+			if !util.IsMatchRegex(labelValidatorRegex, tagConfig.TagName) {
+				klog.Errorf("not a valid label \"%s\"", tagConfig.TagName)
+			}
+
+			tagProbe.tags = append(tagProbe.tags, tag{
+				tagType: tagConfig.Type,
+				regex:   tagConfig.Pattern,
+				label:   tagConfig.TagName,
+			})
+		}
+	}
+	newRegisterProbe := &registerProbe{
+		priority:   customTagProbePriority,
+		name:       "Custom Tag Probe",
+		state:      customTagProbeState,
+		pi:         tagProbe,
+		controller: ctrl,
+	}
+	newRegisterProbe.register()
+}
+
+func (ctp *customTagProbe) Start() {}
+
+func (ctp *customTagProbe) FillBlockDeviceDetails(bd *blockdevice.BlockDevice) {
+	for _, tag := range ctp.tags {
+		var fieldToMatch string
+		switch tag.tagType {
+		case tagTypePath:
+			fieldToMatch = bd.DevPath
+		}
+		if bd.Labels == nil {
+			bd.Labels = make(map[string]string)
+		}
+		if util.IsMatchRegex(tag.regex, fieldToMatch) {
+			bd.Labels[kubernetes.BlockDeviceTagLabel] = tag.label
+			klog.Infof("Device: %s Label %s:%s added by custom tag probe", bd.DevPath, kubernetes.BlockDeviceTagLabel, tag.label)
+		}
+	}
+}

--- a/cmd/ndm_daemonset/probe/customtagprobe.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package probe
 
 import (

--- a/cmd/ndm_daemonset/probe/customtagprobe_test.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe_test.go
@@ -1,29 +1,95 @@
 package probe
 
 import (
-	"github.com/openebs/node-disk-manager/blockdevice"
 	"testing"
+
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"github.com/openebs/node-disk-manager/db/kubernetes"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func Test_customTagProbe_FillBlockDeviceDetails(t *testing.T) {
-	type fields struct {
-		tags []tag
-	}
-	type args struct {
-		bd *blockdevice.BlockDevice
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		args   args
+func TestCustomTagProbeFillBlockDeviceDetails(t *testing.T) {
+	tests := map[string]struct {
+		bd             *blockdevice.BlockDevice
+		customTags     []tag
+		wantTagLabel   string
+		wantTagLabelOk bool
 	}{
-		// TODO: Add test cases.
+		"no custom tags are provided": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda",
+				},
+			},
+			customTags:     nil,
+			wantTagLabel:   "",
+			wantTagLabelOk: false,
+		},
+		"single custom tag using path is present with matching device": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda",
+				},
+			},
+			customTags: []tag{
+				{
+					tagType: tagTypePath,
+					regex:   "/dev/sda",
+					label:   "label1",
+				},
+			},
+			wantTagLabel:   "label1",
+			wantTagLabelOk: true,
+		},
+		"single custom tag using path is present without matching device": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sdb",
+				},
+			},
+			customTags: []tag{
+				{
+					tagType: tagTypePath,
+					regex:   "/dev/sda",
+					label:   "label1",
+				},
+			},
+			wantTagLabel:   "",
+			wantTagLabelOk: false,
+		},
+		"single custom tag with regex using path is present with matching device": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sdb",
+				},
+			},
+			customTags: []tag{
+				{
+					tagType: tagTypePath,
+					regex:   "/dev/sd[a|b]",
+					label:   "label1",
+				},
+			},
+			wantTagLabel:   "label1",
+			wantTagLabelOk: true,
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			bd := tt.bd
 			ctp := &customTagProbe{
-				tags: tt.fields.tags,
+				tags: tt.customTags,
 			}
+			ctp.FillBlockDeviceDetails(bd)
+
+			tagValue, ok := bd.Labels[kubernetes.BlockDeviceTagLabel]
+			assert.Equal(t, tt.wantTagLabelOk, ok)
+
+			if tt.wantTagLabelOk {
+				assert.Equal(t, tt.wantTagLabel, tagValue)
+			}
+
 		})
 	}
 }

--- a/cmd/ndm_daemonset/probe/customtagprobe_test.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe_test.go
@@ -1,0 +1,29 @@
+package probe
+
+import (
+	"github.com/openebs/node-disk-manager/blockdevice"
+	"testing"
+)
+
+func Test_customTagProbe_FillBlockDeviceDetails(t *testing.T) {
+	type fields struct {
+		tags []tag
+	}
+	type args struct {
+		bd *blockdevice.BlockDevice
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctp := &customTagProbe{
+				tags: tt.fields.tags,
+			}
+		})
+	}
+}

--- a/cmd/ndm_daemonset/probe/customtagprobe_test.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package probe
 
 import (

--- a/cmd/ndm_daemonset/probe/mountprobe.go
+++ b/cmd/ndm_daemonset/probe/mountprobe.go
@@ -67,7 +67,7 @@ var mountProbeRegister = func() {
 		pi:         &mountProbe{Controller: ctrl},
 		controller: ctrl,
 	}
-	// Here we register the probe (smart probe in this case)
+	// Here we register the probe (mount probe in this case)
 	newRegisterProbe.register()
 }
 

--- a/cmd/ndm_daemonset/probe/probe.go
+++ b/cmd/ndm_daemonset/probe/probe.go
@@ -34,6 +34,7 @@ var RegisteredProbes = []func(){
 	udevProbeRegister,
 	sysfsProbeRegister,
 	usedbyProbeRegister,
+	customTagProbeRegister,
 }
 
 type registerProbe struct {


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
`openebs.io/block-device-tag` label can be used on the blockdevice resources to reserve devices to some application. Earlier this label need to added manually to each blockdevice by the user. In this PR, this step is automated. User can specify a regex pattern and all device path which match this path will be added the user provided label
NOTE: Currently only device path based matching is supported

**What this PR does?**:
Adds a new probe called `customTagProbe` which can be used to add labels to blockdevices based on the user provided configuration. Following is a sample config
```
tagConfigs:
  - name: "Cassandra Device"
    type: path
    pattern: "/dev/sdc"
    tag: "cassandra"
```

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3087
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 