### PR TITLE
chore(build): add license check as part of lint job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
           pattern: '*.sh'
           exclude: './.git/*,./vendor/*'
 
+      - name: License Check
+        run: make license-check-go
+
   unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,6 +37,9 @@ jobs:
           pattern: '*.sh'
           exclude: './vendor/*'
 
+      - name: License Check
+        run: make license-check-go
+
   unit-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Currently license check is done as part of the build process, after installing dependencies. Adding this check to lint job saves time by failing the build earlier if the licenses are not up-to-date

**What this PR does?**:
- add license check as part of lint job so that the build can fail fast, if license fails. 

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 