### PR TITLE
fix(controller): fix nil pointer dereference in BDC controller due to non existent BD

### DIFF
--- a/changelogs/unreleased/479-akhilerm
+++ b/changelogs/unreleased/479-akhilerm
@@ -1,0 +1,1 @@
+fix a bug where NDM operator crashes if a claimed BD is manually deleted


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
When a Claimed BD is manually deleted by removing the finalizer, and later when the user
tries to delete BDC, NDM operator will continuously crash. This because NDM operator
tries to release a non existent BD.

**What this PR does?**:
adds a check to throw an error when the claimed BD is not found. This PR also adds an event to BDC when BlockDevice is not found.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #439 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 