### PR TITLE
cherry-pick(build): update go version to 1.14.7 (#476)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: go
 
 go:
-  - 1.14.1
+  - 1.14.7
 
 env:
   global:

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -65,7 +65,7 @@ docker.buildx.ndm:
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi
 	@docker buildx build --platform ${PLATFORMS} \
-		-t "$(DOCKERX_IMAGE_NDM)" ${DBUILD_ARGS} -f ndm-daemonset.Dockerfile \
+		-t "$(DOCKERX_IMAGE_NDM)" ${DBUILD_ARGS} -f "build/ndm-daemonset/Dockerfile" \
 		. ${PUSH_ARG}
 	@echo "--> Build docker image: $(DOCKERX_IMAGE_NDM)"
 	@echo
@@ -85,7 +85,7 @@ docker.buildx.ndo:
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi
 	@docker buildx build --platform ${PLATFORMS} \
-		-t "$(DOCKERX_IMAGE_NDO)" ${DBUILD_ARGS} -f ndm-operator.Dockerfile \
+		-t "$(DOCKERX_IMAGE_NDO)" ${DBUILD_ARGS} -f "build/ndm-operator/Dockerfile" \
 		. ${PUSH_ARG}
 	@echo "--> Build docker image: $(DOCKERX_IMAGE_NDO)"
 	@echo
@@ -105,7 +105,7 @@ docker.buildx.exporter:
 		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
 	fi
 	@docker buildx build --platform ${PLATFORMS} \
-		-t "$(DOCKERX_IMAGE_EXPORTER)" ${DBUILD_ARGS} -f ndm-exporter.Dockerfile \
+		-t "$(DOCKERX_IMAGE_EXPORTER)" ${DBUILD_ARGS} -f "build/ndm-exporter/Dockerfile" \
 		. ${PUSH_ARG}
 	@echo "--> Build docker image: $(DOCKERX_IMAGE_EXPORTER)"
 	@echo

--- a/build/ndm-daemonset/Dockerfile
+++ b/build/ndm-daemonset/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This Dockerfile builds node-disk-manager
+# This Dockerfile builds node-disk-manager daemon
 #
-FROM golang:1.14 as build
+FROM golang:1.14.7 as build
 
 ARG TARGETPLATFORM
 
@@ -32,7 +32,7 @@ COPY . .
 RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
   export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
   GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.exporter
+  make buildx.ndm
 
 FROM ubuntu
 
@@ -41,10 +41,13 @@ ARG DBUILD_REPO_URL
 ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.name="node-disk-exporter"
-LABEL org.label-schema.description="OpenEBS NDM Exporter"
+LABEL org.label-schema.name="node-disk-manager"
+LABEL org.label-schema.description="OpenEBS Node Disk Manager"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/exporter /usr/local/bin/exporter
+COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/ndm /usr/sbin/ndm
+COPY --from=build /go/src/github.com/openebs/node-disk-manager/build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/build/ndm-exporter/Dockerfile
+++ b/build/ndm-exporter/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This Dockerfile builds node-disk-manager
+# This Dockerfile builds ndm exporter
 #
-FROM golang:1.14 as build
+FROM golang:1.14.7 as build
 
 ARG TARGETPLATFORM
 
@@ -32,7 +32,7 @@ COPY . .
 RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
   export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
   GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.ndo
+  make buildx.exporter
 
 FROM ubuntu
 
@@ -41,12 +41,10 @@ ARG DBUILD_REPO_URL
 ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.name="node-disk-operator"
-LABEL org.label-schema.description="OpenEBS NDM Operator"
+LABEL org.label-schema.name="node-disk-exporter"
+LABEL org.label-schema.description="OpenEBS NDM Exporter"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/ndo /usr/local/bin/ndo
-
-ENTRYPOINT ["/usr/local/bin/ndo"]
+COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/exporter /usr/local/bin/exporter

--- a/build/ndm-operator/Dockerfile
+++ b/build/ndm-operator/Dockerfile
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# This Dockerfile builds node-disk-manager
+# This Dockerfile builds ndm operator
 #
-FROM golang:1.14 as build
+FROM golang:1.14.7 as build
 
 ARG TARGETPLATFORM
 
@@ -32,7 +32,7 @@ COPY . .
 RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
   export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
   GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.ndm
+  make buildx.ndo
 
 FROM ubuntu
 
@@ -41,13 +41,12 @@ ARG DBUILD_REPO_URL
 ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.name="node-disk-manager"
-LABEL org.label-schema.description="OpenEBS Node Disk Manager"
+LABEL org.label-schema.name="node-disk-operator"
+LABEL org.label-schema.description="OpenEBS NDM Operator"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/ndm /usr/sbin/ndm
-COPY --from=build /go/src/github.com/openebs/node-disk-manager/build/ndm-daemonset/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --from=build /go/src/github.com/openebs/node-disk-manager/bin/ndo /usr/local/bin/ndo
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/ndo"]

--- a/changelogs/unreleased/476-akhilerm
+++ b/changelogs/unreleased/476-akhilerm
@@ -1,0 +1,1 @@
+update go version to 1.14.7


### PR DESCRIPTION
- move build files to separate directory
- update go version to 1.14.7 due to vulnerability in earlier versions (CVE-2020-16845)

cherry-pick #476 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>
