### PR TITLE
cherry-pick(controller): fix nil pointer dereference in BDC controller due to non existent BD

### DIFF
--- a/changelogs/unreleased/479-akhilerm
+++ b/changelogs/unreleased/479-akhilerm
@@ -1,0 +1,1 @@
+fix a bug where NDM operator crashes if a claimed BD is manually deleted


### PR DESCRIPTION
when a Claimed BD is manually deleted by removing the finalizer, and later when the user
tries to delete BDC, NDM operator will continuously crash. This because NDM operator
tries to release a non existent BD. This change throws an error and add an event to BDC
when a corresponding BD cannot be found.

cherry-pick #479 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>