### PR TITLE
cherry-pick(filter): add `block-device-tag` filter during manual claiming (#404)

### DIFF
--- a/changelogs/unreleased/404-akhilerm
+++ b/changelogs/unreleased/404-akhilerm
@@ -1,0 +1,1 @@
+add additional check to exclude blockdevices with tag while manual claiming

--- a/pkg/select/blockdevice/select.go
+++ b/pkg/select/blockdevice/select.go
@@ -47,17 +47,21 @@ func (c *Config) getCandidateDevices(bdList *apis.BlockDeviceList) (*apis.BlockD
 		FilterUnclaimed,
 		// do not consider any devices with legacy annotation for claiming
 		FilterOutLegacyAnnotation,
+		// remove block devices which do not have the blockdevice tag
+		// if selector is present on the BDC, select only those devices
+		// this applies to both manual and auto claiming.
+		FilterBlockDeviceTag,
 	}
 
 	if c.ManualSelection {
-		filterKeys = append(filterKeys, FilterBlockDeviceName)
+		filterKeys = append(filterKeys,
+			FilterBlockDeviceName,
+		)
 	} else {
 		filterKeys = append(filterKeys,
 			// Sparse BDs can be claimed only by manual selection. Therefore, all
 			// sparse BDs will be filtered out in auto mode
 			FilterOutSparseBlockDevices,
-			// remove block devices which do not have the blockdevice tag
-			FilterBlockDeviceTag,
 			FilterDeviceType,
 			FilterVolumeMode,
 			FilterNodeName,


### PR DESCRIPTION
Enforce check on block device tag even for cases where block 
devices are claimed with block device name. 

cherry-pick #404 

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>