### PR TITLE
feat(gh-pages): add github page content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# node-bot
+# Node Disk Manager Charts
+
+The contents of this branch (gh-pages) are published via GitHub pages at https://openebs.github.io/node-disk-manager/
+
+This branch contains the following:
+- Node Disk Manager Helm Chart metadata - [index.yaml](./index.yaml). This file is auto-updated by GitHub Action - Helm Chart Releaser. Please do not modify this file.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+name: NDM Helm Charts
+description: Node Disk Manager Helm Repository

--- a/index.md
+++ b/index.md
@@ -30,10 +30,10 @@ kubectl config set-context <current_context_name> --namespace=openebs
 
 - If namespace is not created, run the following command
 ```bash
-helm install <your-relase-name> ndm/openebs-ndm --create-namespace
+helm install <your-release-name> ndm/openebs-ndm --create-namespace
 ```
 - Else, if namespace is already created, run the following command
 ```bash
-helm install <your-relase-name> ndm/openebs-ndm
+helm install <your-release-name> ndm/openebs-ndm
 ```
 

--- a/index.md
+++ b/index.md
@@ -1,0 +1,39 @@
+# Node Disk Manager Helm Repository
+
+<img width="300" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+
+[Helm3](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```bash
+$ helm repo add ndm https://openebs.github.io/node-disk-manager
+```
+
+You can then run `helm search repo ndm` to see the charts.
+
+#### Update OpenEBS Repo
+
+Once OpenEBS repository has been successfully fetched into the local system, it has to be updated to get the latest version. The OpenEBS repo can be updated using the following command.
+
+```bash
+helm repo update
+```
+
+#### Install using Helm 3
+
+- Assign openebs namespace to the current context:
+```bash
+kubectl config set-context <current_context_name> --namespace=openebs
+```
+
+- If namespace is not created, run the following command
+```bash
+helm install <your-relase-name> ndm/openebs-ndm --create-namespace
+```
+- Else, if namespace is already created, run the following command
+```bash
+helm install <your-relase-name> ndm/openebs-ndm
+```
+

--- a/index.md
+++ b/index.md
@@ -13,9 +13,9 @@ $ helm repo add ndm https://openebs.github.io/node-disk-manager
 
 You can then run `helm search repo ndm` to see the charts.
 
-#### Update OpenEBS Repo
+#### Update OpenEBS NDM Repo
 
-Once OpenEBS repository has been successfully fetched into the local system, it has to be updated to get the latest version. The OpenEBS repo can be updated using the following command.
+Once OpenEBS NDM repository has been successfully fetched into the local system, it has to be updated to get the latest version. The OpenEBS NDM repo can be updated using the following command.
 
 ```bash
 helm repo update


### PR DESCRIPTION
This PR adds helm chart install instructions to be displayed at the Github page. 

The page can be viewed at `openebs.github.io/node-disk-manager` after the PRs 
#491 and #488 are merged.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>