### PR TITLE
feat(core, uuid): add dm support

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -115,6 +115,9 @@ type BlockDevice struct {
 	// information on the disk
 	DeviceAttributes DeviceAttribute
 
+	// DMInfo is filled if the device is a DM device
+	DMInfo DeviceMapperInformation
+
 	DevUse DeviceUsage
 
 	// PartitionInfo contains details if this blockdevice is a partition
@@ -354,6 +357,15 @@ type PartitionInformation struct {
 
 	// PartitionTableType is the type of the partition (dos/gpt)
 	PartitionTableType string
+}
+
+type DeviceMapperInformation struct {
+	// DMUUID is the UUID of the device as present in <dev-sys-path>/dm/uuid
+	DMUUID string
+
+	// DevMapperPath is the device mapper path. It will be of the format /dev/mapper/<mapper>
+	// This path will be a symlink to the actual dm-X device node
+	DevMapperPath string
 }
 
 // DependentBlockDevices contains path of all devices that are

--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -212,12 +212,18 @@ const (
 	// BlockDeviceTypeLoop represents a loop device
 	BlockDeviceTypeLoop = "loop"
 
+	// BlockDeviceTypeDMDevice is a dm device
 	BlockDeviceTypeDMDevice = "dm"
 
+	// BlockDeviceTypeLVM is an lvm device type
 	BlockDeviceTypeLVM = "lvm"
 
+	// BlockDeviceTypeCrypt is a LUKS volume
 	BlockDeviceTypeCrypt = "crypt"
 )
+
+// DeviceMapperDeviceTypes is the slice of device types that uses a device mapper
+var DeviceMapperDeviceTypes = []string{BlockDeviceTypeDMDevice, BlockDeviceTypeLVM, BlockDeviceTypeCrypt}
 
 const (
 	// DriveTypeHDD represents a rotating hard disk drive

--- a/changelogs/unreleased/495-akhilerm
+++ b/changelogs/unreleased/495-akhilerm
@@ -1,1 +1,1 @@
-add support for dm devices.
+add support for device-mapper(dm) devices.

--- a/changelogs/unreleased/495-akhilerm
+++ b/changelogs/unreleased/495-akhilerm
@@ -1,0 +1,1 @@
+add dm devices support in NDM

--- a/changelogs/unreleased/495-akhilerm
+++ b/changelogs/unreleased/495-akhilerm
@@ -1,1 +1,1 @@
-add dm devices support in NDM
+add support for dm devices.

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -131,17 +131,8 @@ func (odf *oSDiskExcludeFilter) Exclude(blockDevice *blockdevice.BlockDevice) bo
 		}
 		regex := "^" + excludeDevPath + partitionRegex
 
-		// if the device is a dm device, need to check the /dev/mapper instead of /dev/dm-* because the
-		// mounts file will always have entry to the mapper path
-		var deviceMountPath string
-		if util.Contains(blockdevice.DeviceMapperDeviceTypes, blockDevice.DeviceAttributes.DeviceType) {
-			deviceMountPath = blockDevice.DMInfo.DevMapperPath
-		} else {
-			deviceMountPath = blockDevice.DevPath
-		}
-
-		klog.Infof("applying os-filter regex %s on %s", regex, deviceMountPath)
-		if util.IsMatchRegex(regex, deviceMountPath) {
+		klog.Infof("applying os-filter regex %s on %s", regex, blockDevice.DevPath)
+		if util.IsMatchRegex(regex, blockDevice.DevPath) {
 			return false
 		}
 	}

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -130,8 +130,18 @@ func (odf *oSDiskExcludeFilter) Exclude(blockDevice *blockdevice.BlockDevice) bo
 			partitionRegex = "[0-9]*$"
 		}
 		regex := "^" + excludeDevPath + partitionRegex
-		klog.Infof("applying os-filter regex %s on %s", regex, blockDevice.DevPath)
-		if util.IsMatchRegex(regex, blockDevice.DevPath) {
+
+		// if the device is a dm device, need to check the /dev/mapper instead of /dev/dm-* because the
+		// mounts file will always have entry to the mapper path
+		var deviceMountPath string
+		if util.Contains(blockdevice.DeviceMapperDeviceTypes, blockDevice.DeviceAttributes.DeviceType) {
+			deviceMountPath = blockDevice.DMInfo.DevMapperPath
+		} else {
+			deviceMountPath = blockDevice.DevPath
+		}
+
+		klog.Infof("applying os-filter regex %s on %s", regex, deviceMountPath)
+		if util.IsMatchRegex(regex, deviceMountPath) {
 			return false
 		}
 	}

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -130,7 +130,6 @@ func (odf *oSDiskExcludeFilter) Exclude(blockDevice *blockdevice.BlockDevice) bo
 			partitionRegex = "[0-9]*$"
 		}
 		regex := "^" + excludeDevPath + partitionRegex
-
 		klog.Infof("applying os-filter regex %s on %s", regex, blockDevice.DevPath)
 		if util.IsMatchRegex(regex, blockDevice.DevPath) {
 			return false

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -212,8 +212,6 @@ func (up *udevProbe) scan() error {
 					deviceDetails.DevPath, deviceDetails.FSInfo.FileSystemUUID)
 			}
 
-			diskInfo = append(diskInfo, deviceDetails)
-
 			sysfsDevice, err := sysfs.NewSysFsDeviceFromDevPath(deviceDetails.DevPath)
 			// TODO if error occurs a rescan may be required
 			if err != nil {
@@ -239,6 +237,8 @@ func (up *udevProbe) scan() error {
 				deviceDetails.DeviceAttributes.DeviceType = deviceType
 				klog.Infof("Device: %s is of type: %s", deviceDetails.DevPath, deviceDetails.DeviceAttributes.DeviceType)
 			}
+
+			diskInfo = append(diskInfo, deviceDetails)
 		}
 		newUdevice.UdevDeviceUnref()
 	}
@@ -305,7 +305,6 @@ func (up *udevProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice
 			Links: udevDiskDetails.ByPathDevLinks,
 		})
 	}
-	blockDevice.DeviceAttributes.DeviceType = udevDiskDetails.DiskType
 
 	// filesystem info of the attached device. Only filesystem data will be filled in the struct,
 	// as the mountpoint related information will be filled in by the mount probe
@@ -314,7 +313,7 @@ func (up *udevProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice
 	blockDevice.PartitionInfo.PartitionTableType = udevDiskDetails.PartitionTableType
 
 	// if this is a partition, partition number and partition UUID need to be filled
-	if udevDiskDetails.DiskType == libudevwrapper.UDEV_PARTITION {
+	if udevDiskDetails.DiskType == blockdevice.BlockDeviceTypePartition {
 		blockDevice.PartitionInfo.PartitionNumber = udevDiskDetails.PartitionNumber
 	}
 }

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -47,10 +47,9 @@ func mockOsDiskToAPI() (apis.BlockDevice, error) {
 		return apis.BlockDevice{}, err
 	}
 	fakeDetails := apis.DeviceDetails{
-		Model:      mockOsDiskDetails.Model,
-		Serial:     mockOsDiskDetails.Serial,
-		Vendor:     mockOsDiskDetails.Vendor,
-		DeviceType: controller.NDMDefaultDiskType,
+		Model:  mockOsDiskDetails.Model,
+		Serial: mockOsDiskDetails.Serial,
+		Vendor: mockOsDiskDetails.Vendor,
 	}
 	fakeObj := apis.DeviceSpec{
 		Path:        mockOsDiskDetails.DevNode,
@@ -108,7 +107,6 @@ func TestFillDiskDetails(t *testing.T) {
 	expectedDiskInfo := &blockdevice.BlockDevice{}
 	expectedDiskInfo.SysPath = mockOsDiskDetails.SysPath
 	expectedDiskInfo.DevPath = mockOsDiskDetails.DevNode
-	expectedDiskInfo.DeviceAttributes.DeviceType = "disk"
 	expectedDiskInfo.DeviceAttributes.Model = mockOsDiskDetails.Model
 	expectedDiskInfo.DeviceAttributes.Serial = mockOsDiskDetails.Serial
 	expectedDiskInfo.DeviceAttributes.Vendor = mockOsDiskDetails.Vendor

--- a/cmd/ndm_daemonset/probe/uuid.go
+++ b/cmd/ndm_daemonset/probe/uuid.go
@@ -55,6 +55,7 @@ func generateUUID(bd blockdevice.BlockDevice) (string, bool) {
 
 	switch {
 	case bd.DeviceAttributes.DeviceType == blockdevice.BlockDeviceTypeLoop:
+		// hostname and device name, i.e /dev/loopX will be used for generating uuid
 		hostName, _ := os.Hostname()
 		klog.Infof("device(%s) is a loop device, using node name: %s and path: %s", bd.DevPath, hostName, bd.DevPath)
 		uuidField = hostName + bd.DevPath

--- a/cmd/ndm_daemonset/probe/uuid.go
+++ b/cmd/ndm_daemonset/probe/uuid.go
@@ -18,7 +18,6 @@ package probe
 
 import (
 	"os"
-	"strings"
 
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/pkg/util"
@@ -129,13 +128,4 @@ func generateUUIDFromPartitionTable(bd blockdevice.BlockDevice) (string, bool) {
 		return blockdevice.BlockDevicePrefix + util.Hash(uuidField), true
 	}
 	return "", false
-}
-
-// TODO move it to some other pkg
-func isDM(devPath string) bool {
-	devName := strings.Replace(devPath, "/dev/", "", 1)
-	if devName[0:3] == "dm-" {
-		return true
-	}
-	return false
 }

--- a/cmd/ndm_daemonset/probe/uuid.go
+++ b/cmd/ndm_daemonset/probe/uuid.go
@@ -54,12 +54,15 @@ func generateUUID(bd blockdevice.BlockDevice) (string, bool) {
 	// the partition and the unique data will be stored in sectors where consumers do not have access.
 
 	switch {
-	/*case bd.DeviceAttributes.DeviceType == blockdevice.BlockDeviceTypeLoop:
-	klog.Infof("device(%s) is a loop device, using path and node name")*/
+	case bd.DeviceAttributes.DeviceType == blockdevice.BlockDeviceTypeLoop:
+		hostName, _ := os.Hostname()
+		klog.Infof("device(%s) is a loop device, using node name: %s and path: %s", bd.DevPath, hostName, bd.DevPath)
+		uuidField = hostName + bd.DevPath
+		ok = true
 	case isDM(bd.DevPath):
 		// is a DM device, use the DM uuid
 		klog.Infof("device(%s) is a dm device, using DM UUID: %s", bd.DevPath, bd.DMInfo.DMUUID)
-		// TODO add a check if DM uuid is present, else what to do???
+		// TODO add a check if DM uuid is present, else may need to add mitigation steps
 		uuidField = bd.DMInfo.DMUUID
 		ok = true
 	case bd.DeviceAttributes.DeviceType == blockdevice.BlockDeviceTypePartition:
@@ -127,7 +130,7 @@ func generateUUIDFromPartitionTable(bd blockdevice.BlockDevice) (string, bool) {
 	return "", false
 }
 
-// TODO move it to some other place
+// TODO move it to some other pkg
 func isDM(devPath string) bool {
 	devName := strings.Replace(devPath, "/dev/", "", 1)
 	if devName[0:3] == "dm-" {

--- a/cmd/ndm_daemonset/probe/uuid.go
+++ b/cmd/ndm_daemonset/probe/uuid.go
@@ -60,8 +60,8 @@ func generateUUID(bd blockdevice.BlockDevice) (string, bool) {
 		klog.Infof("device(%s) is a loop device, using node name: %s and path: %s", bd.DevPath, hostName, bd.DevPath)
 		uuidField = hostName + bd.DevPath
 		ok = true
-	case isDM(bd.DevPath):
-		// is a DM device, use the DM uuid
+	case util.Contains(blockdevice.DeviceMapperDeviceTypes, bd.DeviceAttributes.DeviceType):
+		// if a DM device, use the DM uuid
 		klog.Infof("device(%s) is a dm device, using DM UUID: %s", bd.DevPath, bd.DMInfo.DMUUID)
 		// TODO add a check if DM uuid is present, else may need to add mitigation steps
 		uuidField = bd.DMInfo.DMUUID

--- a/cmd/ndm_daemonset/probe/uuid_test.go
+++ b/cmd/ndm_daemonset/probe/uuid_test.go
@@ -30,6 +30,10 @@ func TestGenerateUUID(t *testing.T) {
 	fakeSerial := "CT500MX500SSD1"
 	fakeFileSystemUUID := "149108ca-f404-4556-a263-04943e6cb0b3"
 	fakePartitionUUID := "065e2357-05"
+	fakeLVM_DM_UUID := "LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk"
+	fakeCRYPT_DM_UUID := "LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk"
+	loopDevicePath := "/dev/loop98"
+	hostName, _ := os.Hostname()
 	tests := map[string]struct {
 		bd       blockdevice.BlockDevice
 		wantUUID string
@@ -102,6 +106,42 @@ func TestGenerateUUID(t *testing.T) {
 			},
 			wantUUID: "",
 			wantOk:   false,
+		},
+		"deviceType-lvm device": {
+			bd: blockdevice.BlockDevice{
+				DMInfo: blockdevice.DeviceMapperInformation{
+					DMUUID: fakeLVM_DM_UUID,
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypeLVM,
+				},
+			},
+			wantUUID: blockdevice.BlockDevicePrefix + util.Hash(fakeLVM_DM_UUID),
+			wantOk:   true,
+		},
+		"deviceType-crypt device": {
+			bd: blockdevice.BlockDevice{
+				DMInfo: blockdevice.DeviceMapperInformation{
+					DMUUID: fakeCRYPT_DM_UUID,
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypeCrypt,
+				},
+			},
+			wantUUID: blockdevice.BlockDevicePrefix + util.Hash(fakeCRYPT_DM_UUID),
+			wantOk:   true,
+		},
+		"deviceType-loop device": {
+			bd: blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: loopDevicePath,
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypeLoop,
+				},
+			},
+			wantUUID: blockdevice.BlockDevicePrefix + util.Hash(hostName+loopDevicePath),
+			wantOk:   true,
 		},
 	}
 	for name, tt := range tests {

--- a/cmd/ndm_daemonset/probe/uuid_test.go
+++ b/cmd/ndm_daemonset/probe/uuid_test.go
@@ -31,7 +31,7 @@ func TestGenerateUUID(t *testing.T) {
 	fakeFileSystemUUID := "149108ca-f404-4556-a263-04943e6cb0b3"
 	fakePartitionUUID := "065e2357-05"
 	fakeLVM_DM_UUID := "LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk"
-	fakeCRYPT_DM_UUID := "LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk"
+	fakeCRYPT_DM_UUID := "CRYPT-LUKS1-f4608c76343d4b5badaf6651d32f752b-backup"
 	loopDevicePath := "/dev/loop98"
 	hostName, _ := os.Hostname()
 	tests := map[string]struct {

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -125,7 +125,7 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager
-        image: openebs/node-disk-manager-amd64:ci
+        image: openebs/node-disk-manager:ci
         args:
           - -v=4
           - --feature-gates="GPTBasedUUID"
@@ -224,7 +224,7 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
         - name: node-disk-operator
-          image: openebs/node-disk-operator-amd64:ci
+          image: openebs/node-disk-operator:ci
           ports:
           - containerPort: 8080
             name: liveness

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -42,7 +42,7 @@ data:
         name: path filter
         state: true
         include: ""
-        exclude: loop
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/rbd"
 
 ---
 # Create NDM Service Account

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -42,7 +42,7 @@ data:
         name: path filter
         state: true
         include: ""
-        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/dm-,/dev/rbd"
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/dm-,/dev/rbd,/dev/zd"
 
 ---
 # Create NDM Service Account

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -125,11 +125,11 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager
-        image: openebs/node-disk-manager:ci
+        image: akhilerm/node-disk-manager:ci
         args:
           - -v=4
           - --feature-gates="GPTBasedUUID"
-          - --feature-gates="APIService"
+ #         - --feature-gates="APIService"
           # Default address is 0.0.0.0:9115, do not use quotes around the address
           # - --api-service-address=0.0.0.0:9115
         imagePullPolicy: Always

--- a/ndm-operator.yaml
+++ b/ndm-operator.yaml
@@ -42,7 +42,7 @@ data:
         name: path filter
         state: true
         include: ""
-        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/rbd"
+        exclude: "loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/dm-,/dev/rbd"
 
 ---
 # Create NDM Service Account
@@ -125,11 +125,11 @@ spec:
       serviceAccountName: openebs-ndm-operator
       containers:
       - name: node-disk-manager
-        image: akhilerm/node-disk-manager:ci
+        image: openebs/node-disk-manager:ci
         args:
           - -v=4
           - --feature-gates="GPTBasedUUID"
- #         - --feature-gates="APIService"
+          - --feature-gates="APIService"
           # Default address is 0.0.0.0:9115, do not use quotes around the address
           # - --api-service-address=0.0.0.0:9115
         imagePullPolicy: Always

--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -282,6 +282,10 @@ func getCmdlineFile() string {
 	return procCmdLine
 }
 
+// getDeviceName gets the blockdevice special file name.
+// eg: sda, sdb
+// if a mapper device is specified the symlink will be evaluated and the
+// dm-X name will be returned
 func getDeviceName(devPath string) string {
 	var err error
 	var deviceName string

--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -283,7 +283,18 @@ func getCmdlineFile() string {
 }
 
 func getDeviceName(devPath string) string {
-	return strings.Replace(devPath, "/dev/", "", 1)
+	var err error
+	var deviceName string
+
+	deviceName = devPath
+	// if the device is a dm device
+	if strings.HasPrefix(devPath, "/dev/mapper") {
+		deviceName, err = filepath.EvalSymlinks(devPath)
+		if err != nil {
+			return ""
+		}
+	}
+	return strings.Replace(deviceName, "/dev/", "", 1)
 }
 
 func fileExists(file string) bool {

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -67,6 +67,7 @@ const (
 	UDEV_PARTITION_NUMBER     = "ID_PART_ENTRY_NUMBER" // udev attribute to get partition number
 	UDEV_PARTITION_UUID       = "ID_PART_ENTRY_UUID"   // udev attribute to get partition uuid
 	UDEV_PARTITION_TYPE       = "ID_PART_ENTRY_TYPE"   // udev attribute to get partition type
+	UDEV_DM_UUID              = "DM_UUID"              // udev attribute to get the device mapper uuid
 )
 
 // UdevDiskDetails struct contain different attribute of disk.


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Adds DM support to NDM. With the changes in this PR: lvm, crypt, loop, dm devices will be natively supported in NDM.

**What this PR does?**:
- adds DM fields to blockdevice core struct
- add uuid generation algorithm for dm and loop devices
- add dm device support to os disk filter

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
`udevadm info` for dm devices (lvm and crypt)
```
k8s@worker-ak1:~$ udevadm info /dev/dm-0
P: /devices/virtual/block/dm-0
N: dm-0
S: disk/by-id/dm-name-vg0-lv0
S: disk/by-id/dm-uuid-LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk
S: disk/by-uuid/2e5b68d5-134b-44c4-97bd-d857e4cb3fbc
S: mapper/vg0-lv0
S: vg0/lv0
E: DEVLINKS=/dev/disk/by-id/dm-name-vg0-lv0 /dev/disk/by-id/dm-uuid-LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk /dev/mapper/vg0-lv0 /dev/vg0/lv0 /dev/disk/by-uuid/2e5b68d5-134b-44c4-97bd-d857e4cb3fbc
E: DEVNAME=/dev/dm-0
E: DEVPATH=/devices/virtual/block/dm-0
E: DEVTYPE=disk
E: DM_LV_NAME=lv0
E: DM_NAME=vg0-lv0
E: DM_SUSPENDED=0
E: DM_UDEV_DISABLE_LIBRARY_FALLBACK_FLAG=1
E: DM_UDEV_PRIMARY_SOURCE_FLAG=1
E: DM_UDEV_RULES=1
E: DM_UUID=LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk
E: DM_VG_NAME=vg0
E: ID_FS_TYPE=ext4
E: ID_FS_USAGE=filesystem
E: ID_FS_UUID=2e5b68d5-134b-44c4-97bd-d857e4cb3fbc
E: ID_FS_UUID_ENC=2e5b68d5-134b-44c4-97bd-d857e4cb3fbc
E: ID_FS_VERSION=1.0
E: MAJOR=253
E: MINOR=0
E: SUBSYSTEM=block
E: TAGS=:systemd:
E: USEC_INITIALIZED=34095655487
k8s@worker-ak1:~$ udevadm info /dev/dm-2
P: /devices/virtual/block/dm-2
N: dm-2
S: disk/by-id/dm-name-backup
S: disk/by-id/dm-uuid-CRYPT-LUKS1-f4608c76343d4b5badaf6651d32f752b-backup
S: mapper/backup
E: DEVLINKS=/dev/mapper/backup /dev/disk/by-id/dm-name-backup /dev/disk/by-id/dm-uuid-CRYPT-LUKS1-f4608c76343d4b5badaf6651d32f752b-backup
E: DEVNAME=/dev/dm-2
E: DEVPATH=/devices/virtual/block/dm-2
E: DEVTYPE=disk
E: DM_NAME=backup
E: DM_SUSPENDED=0
E: DM_UDEV_PRIMARY_SOURCE_FLAG=1
E: DM_UDEV_RULES=1
E: DM_UUID=CRYPT-LUKS1-f4608c76343d4b5badaf6651d32f752b-backup
E: MAJOR=253
E: MINOR=2
E: SUBSYSTEM=block
E: SYSTEMD_READY=0
E: TAGS=:systemd:
E: USEC_INITIALIZED=662891813216
```
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 