### PR TITLE
fix(partition): add filesystem check on disk before creating partitions

### DIFF
--- a/changelogs/unreleased/496-akhilerm
+++ b/changelogs/unreleased/496-akhilerm
@@ -1,0 +1,1 @@
+fix a bug where partition table was written on disk with filesystem, resulting in data loss


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
As per the new UUID generation logic, a GPT partition will be created on
virtual disks. 

The following issue was faced in some scenarios: The iSCSI disk created by
OpenEBS was partitioned. This may have happened because, when NDM tried to
read the disk properties via udev, it was missing, therefore NDM created the
partition, resulting in data loss / corruption. But later those properties came up in the udev cache.


**What this PR does?**:
This fix adds an additional check for filesystem on the disk
before creating partitions.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 