### PR TITLE
cherry-pick(partition): check if filesystem exists on disk before creating partitions

### DIFF
--- a/changelogs/unreleased/496-akhilerm
+++ b/changelogs/unreleased/496-akhilerm
@@ -1,0 +1,1 @@
+fix a bug where partition table was written on disk with filesystem, resulting in data loss


### PR DESCRIPTION
as per the new UUID generation logic, a GPT partition will be created on
virtual disks. This fix adds an additional check for filesystem on the disk
before creating partitions.

The following issue was faced in some scenarios: The iSCSI disk created by
OpenEBS was partitioned. This may have happened because, when NDM tried to
read the disk properties via udev, it was missing, therefore NDM created the
partition. But later those properties came up in the udev cache.

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

cherry-pick #496 