### PR TITLE
feat(blockdevicefilter): add filter for empty block device tag label value

### DIFF
--- a/changelogs/unreleased/500-ajeetrai707
+++ b/changelogs/unreleased/500-ajeetrai707
@@ -1,0 +1,1 @@
+restrict claiming of blockdevices with empty block-device-tag value

--- a/pkg/select/blockdevice/filters.go
+++ b/pkg/select/blockdevice/filters.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog"
+	"strings"
 )
 
 const (
@@ -296,6 +297,12 @@ func filterBlockDeviceTag(originalBD *apis.BlockDeviceList, spec *apis.DeviceCla
 	}
 
 	for _, bd := range originalBD.Items {
+		// if the tag label value is empty then the BD should not be selected
+		if val,ok:=bd.Labels[kubernetes.BlockDeviceTagLabel];ok{
+			if strings.TrimSpace(val)==""{
+				continue
+			}
+		}
 		// if the tag label is not present, the BD will be included in the list
 		if blockDeviceTagDoesNotExistSelector.Matches(labels.Set(bd.Labels)) {
 			filteredBDList.Items = append(filteredBDList.Items, bd)

--- a/pkg/select/blockdevice/filters.go
+++ b/pkg/select/blockdevice/filters.go
@@ -17,6 +17,8 @@ limitations under the License.
 package blockdevice
 
 import (
+	"strings"
+
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/db/kubernetes"
@@ -26,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog"
-	"strings"
 )
 
 const (


### PR DESCRIPTION
This PR adds a filter that does not select
BD that has empty block device tag value.
Ref: https://github.com/openebs/openebs/discussions/3139

Signed-off-by: ajeetrai707 <ajeetrai707@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 