### PR TITLE
chore(build): fix envs in github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,15 +68,20 @@ jobs:
             CI_TAG="ci"
           fi
           echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::{BRANCH}"
+          echo "::set-env name=BRANCH::${BRANCH}"
           echo "BRANCH: ${BRANCH}"
           echo "TAG: ${CI_TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
@@ -85,6 +90,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.ndm
           make buildx.push.ndm
@@ -104,15 +111,20 @@ jobs:
             CI_TAG="ci"
           fi
           echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::{BRANCH}"
+          echo "::set-env name=BRANCH::${BRANCH}"
           echo "BRANCH: ${BRANCH}"
           echo "TAG: ${CI_TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
@@ -121,6 +133,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.exporter
           make buildx.push.exporter
@@ -140,15 +154,20 @@ jobs:
             CI_TAG="ci"
           fi
           echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::{BRANCH}"
+          echo "::set-env name=BRANCH::${BRANCH}"
           echo "BRANCH: ${BRANCH}"
           echo "TAG: ${CI_TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Login to GitHub Docker Registry
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
@@ -157,6 +176,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.ndo
           make buildx.push.ndo

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -66,11 +66,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Build Image
         env:
@@ -84,11 +89,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Build Image
         env:
@@ -102,11 +112,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
-          buildx-version: latest
+          version: latest
 
       - name: Build Image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,19 @@ jobs:
 
       - name: Set Tag
         run: |
-          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=TAG::${TAG}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
           echo "RELEASE_TAG ${TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
@@ -44,6 +50,8 @@ jobs:
         run: echo "${DOCKERHUB_PASSWORD}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.ndm
           make buildx.push.ndm
@@ -56,13 +64,19 @@ jobs:
 
       - name: Set Tag
         run: |
-          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=TAG::${TAG}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
           echo "RELEASE_TAG ${TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
@@ -73,6 +87,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.exporter
           make buildx.push.exporter
@@ -85,13 +101,19 @@ jobs:
 
       - name: Set Tag
         run: |
-          echo "::set-env name=TAG::${GITHUB_REF#refs/*/v}"
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=TAG::${TAG}"
           echo "::set-env name=RELEASE_TAG::${TAG}"
           echo "RELEASE_TAG ${TAG}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v1
+        uses: docker/setup-buildx-action@v1
         with:
           version: latest
 
@@ -102,6 +124,8 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
         run: |
           make docker.buildx.ndo
           make buildx.push.ndo

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ before_script:
       sudo chown -R $USER $HOME/.kube;
       make shellcheck;
     fi
+  - export RELEASE_TAG="$TRAVIS_TAG"
+  - export BRANCH="$TRAVIS_BRANCH"
 
 script:
   - make

--- a/build/build.sh
+++ b/build/build.sh
@@ -132,11 +132,11 @@ GIT_COMMIT=$(getGitCommit)
 # Get the version details. By default set as ci.
 VERSION="ci"
 
-if [ -n "${TRAVIS_TAG}" ] ;
+if [ -n "${RELEASE_TAG}" ] ;
 then
     # When github is tagged with a release, then Travis will
-    # set the release tag in env TRAVIS_TAG
-    VERSION="${TRAVIS_TAG}"
+    # set the release tag in env RELEASE_TAG
+    VERSION="${RELEASE_TAG}"
 fi;
 
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR fixes the below issues while building the images in buildx github actions
- In the build workflow the branch env is not set
```
Run make docker.buildx.ndm
  make docker.buildx.ndm
  make buildx.push.ndm
  shell: /bin/bash -e {0}
  env:
    TAG: 0.9.0-RC2-ci
    BRANCH: {BRANCH}
```
- In the release workflow the RELEASE_TAG is not set
```
Run make docker.buildx.ndm
  make docker.buildx.ndm
  make buildx.push.ndm
  shell: /bin/bash -e {0}
  env:
    TAG: 0.9.0-RC2
    RELEASE_TAG: 
```
- Adds an env to pass the IMAGE_ORG to the actions.
- Makes the build script independent of TRAVIS_TAG variable.
- Updates the buildx action to docker/setup-buildx-action@v1

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
