### PR TITLE
chore(build) Updating dockerfile(s) with buildx built-in ARGs

### DIFF
--- a/build/ndm-daemonset/Dockerfile
+++ b/build/ndm-daemonset/Dockerfile
@@ -16,10 +16,15 @@
 #
 FROM golang:1.14.7 as build
 
-ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
 
 ENV GO111MODULE=on \
   CGO_ENABLED=1 \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
   PATH="/root/go/bin:${PATH}"
 
@@ -29,10 +34,7 @@ RUN apt-get update && apt-get install -y make git
 
 COPY . .
 
-RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
-  export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
-  GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.ndm
+RUN make buildx.ndm
 
 FROM ubuntu
 

--- a/build/ndm-exporter/Dockerfile
+++ b/build/ndm-exporter/Dockerfile
@@ -16,10 +16,15 @@
 #
 FROM golang:1.14.7 as build
 
-ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
 
 ENV GO111MODULE=on \
   CGO_ENABLED=1 \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
   PATH="/root/go/bin:${PATH}"
 
@@ -29,10 +34,7 @@ RUN apt-get update && apt-get install -y make git
 
 COPY . .
 
-RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
-  export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
-  GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.exporter
+RUN make buildx.exporter
 
 FROM ubuntu
 

--- a/build/ndm-operator/Dockerfile
+++ b/build/ndm-operator/Dockerfile
@@ -16,10 +16,15 @@
 #
 FROM golang:1.14.7 as build
 
-ARG TARGETPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
 
 ENV GO111MODULE=on \
   CGO_ENABLED=1 \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
   PATH="/root/go/bin:${PATH}"
 
@@ -29,10 +34,7 @@ RUN apt-get update && apt-get install -y make git
 
 COPY . .
 
-RUN export GOOS=$(echo ${TARGETPLATFORM} | cut -d / -f1) && \
-  export GOARCH=$(echo ${TARGETPLATFORM} | cut -d / -f2) && \
-  GOARM=$(echo ${TARGETPLATFORM} | cut -d / -f3 | cut -c2-) && \
-  make buildx.ndo
+RUN make buildx.ndo
 
 FROM ubuntu
 

--- a/changelogs/unreleased/503-xunholy
+++ b/changelogs/unreleased/503-xunholy
@@ -1,0 +1,1 @@
+chore(build) Updating dockerfile(s) with buildx built-in ARGs


### PR DESCRIPTION
Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>

Updating Dockerfiles to use the `buildx` built-in ARGs will provide more flexibility to provide support for additional OS/ARCHS/ARM variants in the future. This also will create a cleaner and more maintainable Dockerfile moving forward.

https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them