### PR TITLE
fix(controller, probe): fix sysfs probe and controller options

### DIFF
--- a/changelogs/unreleased/504-akhilerm
+++ b/changelogs/unreleased/504-akhilerm
@@ -1,0 +1,1 @@
+add controller options to device list command, fixed sysfs probe processing empty devices

--- a/cmd/ndm_daemonset/app/command/device-list.go
+++ b/cmd/ndm_daemonset/app/command/device-list.go
@@ -86,6 +86,12 @@ func deviceList() error {
 	if err != nil {
 		return err
 	}
+
+	err = ctrl.SetControllerOptions(options)
+	if err != nil {
+		return err
+	}
+
 	// TODO @akhilerm should pass the filter as args to List, so that all devices will be listed
 	diskList, err := ctrl.ListBlockDeviceResource(false)
 	if err != nil {

--- a/cmd/ndm_daemonset/probe/sysfsprobe.go
+++ b/cmd/ndm_daemonset/probe/sysfsprobe.go
@@ -87,6 +87,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 	sysFsDevice, err := sysfs.NewSysFsDeviceFromDevPath(blockDevice.DevPath)
 	if err != nil {
 		klog.Errorf("unable to get sysfs device for device: %s, err: %v", blockDevice.DevPath, err)
+		return
 	}
 
 	if blockDevice.DeviceAttributes.LogicalBlockSize == 0 {


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
- Controller options were not set in the `devce list` command which caused the command to not list blockdevice resources. 
- The sysfsprobe was missing a return statement which resulted in processing of the device even if an error occurs.

**What this PR does?**:
- set controller options in device list command
- return sysfs probe to prevent null pointer exception

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 