### PR TITLE
fix(controller, probe): fix sysfs probe and controller options

### DIFF
--- a/changelogs/unreleased/504-akhilerm
+++ b/changelogs/unreleased/504-akhilerm
@@ -1,0 +1,1 @@
+add controller options to device list command, fixed sysfs probe processing empty devices

--- a/cmd/ndm_daemonset/app/command/device-list.go
+++ b/cmd/ndm_daemonset/app/command/device-list.go
@@ -86,6 +86,12 @@ func deviceList() error {
 	if err != nil {
 		return err
 	}
+
+	err = ctrl.SetControllerOptions(options)
+	if err != nil {
+		return err
+	}
+
 	// TODO @akhilerm should pass the filter as args to List, so that all devices will be listed
 	diskList, err := ctrl.ListBlockDeviceResource(false)
 	if err != nil {

--- a/cmd/ndm_daemonset/probe/sysfsprobe.go
+++ b/cmd/ndm_daemonset/probe/sysfsprobe.go
@@ -87,6 +87,7 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 	sysFsDevice, err := sysfs.NewSysFsDeviceFromDevPath(blockDevice.DevPath)
 	if err != nil {
 		klog.Errorf("unable to get sysfs device for device: %s, err: %v", blockDevice.DevPath, err)
+		return
 	}
 
 	if blockDevice.DeviceAttributes.LogicalBlockSize == 0 {


### PR DESCRIPTION
- set controller options in device list command
- return sysfs probe to prevent null pointer exception

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

cherry-pick #504 