### PR TITLE
chore(build): fix build script and remove deprecated methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,17 +60,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set tag
+      - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -103,17 +106,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set tag
+      - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -146,17 +152,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set tag
+      - name: Set Tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
           CI_TAG=${BRANCH#v}-ci
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
-          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "TAG=${CI_TAG}" >> $GITHUB_ENV
+          echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "TAG: ${TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -65,9 +68,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -102,9 +108,12 @@ jobs:
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+
+      - name: Print Tag info
+        run: |
+          echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,7 @@ ifeq (${DBUILD_SITE_URL}, )
   export DBUILD_SITE_URL
 endif
 
-export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
-
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG}
 
 # Initialize the NDM DaemonSet variables
 # Specify the NDM DaemonSet binary name

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -15,8 +15,6 @@
 # ==============================================================================
 # Build Options
 
-export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
-
 ifeq (${TAG}, )
   export TAG=ci
 endif

--- a/build/ndm-daemonset/Dockerfile
+++ b/build/ndm-daemonset/Dockerfile
@@ -26,7 +26,8 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG}
 
 WORKDIR /go/src/github.com/openebs/node-disk-manager/
 

--- a/build/ndm-exporter/Dockerfile
+++ b/build/ndm-exporter/Dockerfile
@@ -26,7 +26,8 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG}
 
 WORKDIR /go/src/github.com/openebs/node-disk-manager/
 

--- a/build/ndm-operator/Dockerfile
+++ b/build/ndm-operator/Dockerfile
@@ -26,7 +26,8 @@ ENV GO111MODULE=on \
   GOARCH=${TARGETARCH} \
   GOARM=${TARGETVARIANT} \
   DEBIAN_FRONTEND=noninteractive \
-  PATH="/root/go/bin:${PATH}"
+  PATH="/root/go/bin:${PATH}" \
+  RELEASE_TAG=${RELEASE_TAG}
 
 WORKDIR /go/src/github.com/openebs/node-disk-manager/
 


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Github actions [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) the set-env command. Instead of that environment files are the recommended option now.
Additionally, there is an issue with setting RELEASE_TAG inside the buildx container, which needs to be fixed for proper
version to be passed as ldflags.

**What this PR does?**:
- use environment files in github actions instead of deprecated set-env command
- pass RELEASE_TAG as build arguments to buildx container.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
A minor change in how environment variables are set in github actions


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 