### PR TITLE
fix(mount): fix parsing /proc/cmdline

### DIFF
--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -125,7 +125,7 @@ spec:
       # to detect disk attach and detach events using fd.
       hostNetwork: true
       hostPID: true
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager:ci
@@ -226,7 +226,7 @@ spec:
       labels:
         name: node-disk-operator
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
         image: openebs/node-disk-operator:ci
@@ -281,7 +281,7 @@ spec:
       labels:
         name: ndm-cluster-exporter
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: ndm-cluster-exporter
         image: openebs/node-disk-exporter:ci
@@ -322,7 +322,7 @@ spec:
       labels:
         name: ndm-node-exporter
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-exporter
         image: openebs/node-disk-exporter:ci

--- a/deploy/yamls/ndm-cluster-exporter.yaml
+++ b/deploy/yamls/ndm-cluster-exporter.yaml
@@ -18,7 +18,7 @@ spec:
       labels:
         name: ndm-cluster-exporter
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: ndm-cluster-exporter
         image: openebs/node-disk-exporter:ci

--- a/deploy/yamls/ndm-node-exporter.yaml
+++ b/deploy/yamls/ndm-node-exporter.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         name: ndm-node-exporter
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-exporter
         image: openebs/node-disk-exporter:ci

--- a/deploy/yamls/node-disk-manager.yaml
+++ b/deploy/yamls/node-disk-manager.yaml
@@ -26,7 +26,7 @@ spec:
       # to detect disk attach and detach events using fd.
       hostNetwork: true
       hostPID: true
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-manager
         image: openebs/node-disk-manager:ci

--- a/deploy/yamls/node-disk-operator.yaml
+++ b/deploy/yamls/node-disk-operator.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         name: node-disk-operator
     spec:
-      serviceAccountName: openebs-ndm-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
         image: openebs/node-disk-operator:ci

--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -191,6 +191,14 @@ func parseRootDeviceLink(file io.Reader) (string, error) {
 
 			rootSpec := strings.Split(arg[len(rootPrefix):], "=")
 
+			// if the expected format is not present, then we skip getting the root partition
+			if len(rootSpec) < 2 {
+				if strings.HasPrefix(rootSpec[0], "/dev") {
+					return rootSpec[0], nil
+				}
+				return "", ErrCouldNotFindRootDevice
+			}
+
 			identifierType := strings.ToLower(rootSpec[0])
 			identifier := rootSpec[1]
 

--- a/pkg/mount/mountutil_test.go
+++ b/pkg/mount/mountutil_test.go
@@ -266,6 +266,11 @@ func TestParseRootDeviceLink(t *testing.T) {
 			"/dev/disk/by-partuuid/325c5bfa-08a8-433c-bc62-2dd5255213fd",
 			nil,
 		},
+		"single line with root on dm device, (simulates cmdline in GKE)": {
+			"BOOT_IMAGE=/syslinux/vmlinuz.A root=/dev/dm-0",
+			"/dev/dm-0",
+			nil,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
NDM is crashing on new GKE setups due to a failure in parsing the `/proc/cmdline` file. This issue occurs when the file contains a root partition entry like `root=/dev/dm-0`, where the identifier type is not present

**What this PR does?**:
- adds additional check of no.of items in the `root=` line while parsing
- fix service account in ndm yamls

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #515 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 