### PR TITLE
fix(filter): add check for /dev/mapper path along with /dev/dm- in path filter

### DIFF
--- a/changelogs/unreleased/516-akhilerm
+++ b/changelogs/unreleased/516-akhilerm
@@ -1,0 +1,1 @@
+fix a bug in parsing /proc/cmdline where the root partition identifier is not present

--- a/changelogs/unreleased/518-akhilerm
+++ b/changelogs/unreleased/518-akhilerm
@@ -1,0 +1,1 @@
+add check for device mapper path in path filter

--- a/cmd/ndm_daemonset/filter/pathfilter.go
+++ b/cmd/ndm_daemonset/filter/pathfilter.go
@@ -94,6 +94,12 @@ func (pf *pathFilter) Include(blockDevice *blockdevice.BlockDevice) bool {
 	if len(pf.includePaths) == 0 {
 		return true
 	}
+	if util.Contains(blockdevice.DeviceMapperDeviceTypes,
+		blockDevice.DeviceAttributes.DeviceType) {
+		if util.MatchIgnoredCase(pf.includePaths, blockDevice.DMInfo.DevMapperPath) {
+			return true
+		}
+	}
 	return util.MatchIgnoredCase(pf.includePaths, blockDevice.DevPath)
 }
 
@@ -102,6 +108,13 @@ func (pf *pathFilter) Include(blockDevice *blockdevice.BlockDevice) bool {
 func (pf *pathFilter) Exclude(blockDevice *blockdevice.BlockDevice) bool {
 	if len(pf.excludePaths) == 0 {
 		return true
+	}
+	// for DM devices, need to check both the devpath and device mapper path
+	if util.Contains(blockdevice.DeviceMapperDeviceTypes,
+		blockDevice.DeviceAttributes.DeviceType) {
+		if util.MatchIgnoredCase(pf.excludePaths, blockDevice.DMInfo.DevMapperPath) {
+			return false
+		}
 	}
 	return !util.MatchIgnoredCase(pf.excludePaths, blockDevice.DevPath)
 }

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -270,6 +270,8 @@ func (up *udevProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice
 	blockDevice.DeviceAttributes.Vendor = udevDiskDetails.Vendor
 	blockDevice.DeviceAttributes.IDType = udevDiskDetails.IDType
 
+	blockDevice.DMInfo.DevMapperPath = udevDiskDetails.DMPath
+
 	// log only if details are present to prevent log flooding
 	if blockDevice.DeviceAttributes.Model != "" {
 		klog.V(4).Infof("device: %s, Model: %s filled by udev probe",

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -117,8 +117,11 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 		PartitionType:      device.GetPartitionType(),
 		PartitionNumber:    device.GetPartitionNumber(),
 		PartitionTableType: device.GetPropertyValue(UDEV_PARTITION_TABLE_TYPE),
-		// get the devicemapper path from the dm name
-		DMPath: "/dev/mapper" + device.GetPropertyValue(UDEV_DM_NAME),
+	}
+	// get the devicemapper path from the dm name
+	dmName := device.GetPropertyValue(UDEV_DM_NAME)
+	if len(dmName) != 0 {
+		diskDetails.DMPath = "/dev/mapper/" + dmName
 	}
 	return diskDetails
 }

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -68,6 +68,8 @@ const (
 	UDEV_PARTITION_UUID       = "ID_PART_ENTRY_UUID"   // udev attribute to get partition uuid
 	UDEV_PARTITION_TYPE       = "ID_PART_ENTRY_TYPE"   // udev attribute to get partition type
 	UDEV_DM_UUID              = "DM_UUID"              // udev attribute to get the device mapper uuid
+	// UDEV_DM_NAME is udev attribute to get the name of the dm device. This is used to generate the device mapper path
+	UDEV_DM_NAME = "DM_NAME"
 )
 
 // UdevDiskDetails struct contain different attribute of disk.
@@ -89,6 +91,8 @@ type UdevDiskDetails struct {
 	PartitionNumber uint8
 	// PartitionTableType is the type of the partition table (dos/gpt)
 	PartitionTableType string
+	// DMPath is the /dev/mapper path if this is a dm device
+	DMPath string
 }
 
 // freeCharPtr frees c pointer
@@ -113,6 +117,8 @@ func (device *UdevDevice) DiskInfoFromLibudev() UdevDiskDetails {
 		PartitionType:      device.GetPartitionType(),
 		PartitionNumber:    device.GetPartitionNumber(),
 		PartitionTableType: device.GetPropertyValue(UDEV_PARTITION_TABLE_TYPE),
+		// get the devicemapper path from the dm name
+		DMPath: "/dev/mapper" + device.GetPropertyValue(UDEV_DM_NAME),
 	}
 	return diskDetails
 }


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Most systems use a configured `/dev/mapper/<dm-name>` rather than the `/dev/dm-X` to identify dm devices. NDM was only checking for `/dev/dm-X` path in the path filter which caused issues as mentioned [here](https://github.com/openebs/openebs/issues/3310)

**What this PR does?**:
- adds check for /dev/mapper along with device path in path filter

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3310
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 