### PR TITLE
fix(filter): add partition and device mapper check to validity filter

### DIFF
--- a/changelogs/unreleased/519-akhilerm
+++ b/changelogs/unreleased/519-akhilerm
@@ -1,0 +1,1 @@
+add checks for validity of partition and dm device resources created

--- a/cmd/ndm_daemonset/filter/devicevalidityfilter_test.go
+++ b/cmd/ndm_daemonset/filter/devicevalidityfilter_test.go
@@ -138,3 +138,81 @@ func Test_isValidCapacity(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidPartition(t *testing.T) {
+	tests := map[string]struct {
+		bd   *blockdevice.BlockDevice
+		want bool
+	}{
+		"valid blockdevice of type partition": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda1",
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypePartition,
+				},
+				PartitionInfo: blockdevice.PartitionInformation{
+					PartitionEntryUUID: "065e2357-05",
+				},
+			},
+			want: true,
+		},
+		"invalid blockdevice of type partition": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/sda1",
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypePartition,
+				},
+			},
+			want: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isValidPartition(tt.bd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsValidDMDevice(t *testing.T) {
+	tests := map[string]struct {
+		bd   *blockdevice.BlockDevice
+		want bool
+	}{
+		"valid blockdevice of type device mapper": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/dm-0",
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypeLVM,
+				},
+				DMInfo: blockdevice.DeviceMapperInformation{
+					DMUUID: "LVM-j2xmqvbcVWBQK9Jdttte3CyeVTGgxtVV5VcCi3nxdwihZDxSquMOBaGL5eymBNvk",
+				},
+			},
+			want: true,
+		},
+		"invalid blockdevice of type device mapper": {
+			bd: &blockdevice.BlockDevice{
+				Identifier: blockdevice.Identifier{
+					DevPath: "/dev/dm-1",
+				},
+				DeviceAttributes: blockdevice.DeviceAttribute{
+					DeviceType: blockdevice.BlockDeviceTypeLVM,
+				},
+			},
+			want: false,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := isValidDMDevice(tt.bd)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Repeated udev scan sometimes misses certain fields for devices like partition uuid, dm uuid etc. Since these fields are mandatory for generating the blockdevices unique ID, not having these fields may have issues with wrong blockdevices being created.

**What this PR does?**:
- adds a new check in the device validity filter to make sure that only devices with a valid partition UUID or dm UUID are used for creating blockdevice resources.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 