### PR TITLE
fix(probe): add unknown drive type

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -231,6 +231,9 @@ const (
 
 	// DriveTypeSSD represents a solid state drive
 	DriveTypeSSD = "SSD"
+
+	// DriveTypeUnknown is used when the drive type of the disk could not be determined.
+	DriveTypeUnknown = "Unknown"
 )
 
 // FileSystemInformation contains the filesystem and mount information of blockdevice, if present

--- a/changelogs/unreleased/523-akhilerm
+++ b/changelogs/unreleased/523-akhilerm
@@ -1,0 +1,1 @@
+add `Unknown` drive type into blockdevice resource instead of using an empty string

--- a/cmd/ndm_daemonset/probe/seachestprobe.go
+++ b/cmd/ndm_daemonset/probe/seachestprobe.go
@@ -117,7 +117,8 @@ func (scp *seachestProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockD
 		klog.V(4).Infof("Disk: %s PhysicalBlockSize:%d filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.PhysicalBlockSize)
 	}
 
-	if blockDevice.DeviceAttributes.DriveType == "" {
+	if blockDevice.DeviceAttributes.DriveType == "" ||
+		blockDevice.DeviceAttributes.DriveType == blockdevice.DriveTypeUnknown {
 		blockDevice.DeviceAttributes.DriveType = seachestProbe.SeachestIdentifier.DriveType(driveInfo)
 		klog.V(4).Infof("Disk: %s DriveType:%s filled by seachest.", blockDevice.DevPath, blockDevice.DeviceAttributes.DriveType)
 	}

--- a/cmd/ndm_daemonset/probe/sysfsprobe.go
+++ b/cmd/ndm_daemonset/probe/sysfsprobe.go
@@ -126,7 +126,8 @@ func (cp *sysfsProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 			blockDevice.DevPath, blockDevice.DeviceAttributes.HardwareSectorSize)
 	}
 
-	if blockDevice.DeviceAttributes.DriveType == "" {
+	if blockDevice.DeviceAttributes.DriveType == "" ||
+		blockDevice.DeviceAttributes.DriveType == blockdevice.DriveTypeUnknown {
 		driveType, err := sysFsDevice.GetDriveType()
 		if err != nil {
 			klog.Warningf("unable to get drive type for device: %s, err: %v", blockDevice.DevPath, err)

--- a/pkg/seachest/seachest.go
+++ b/pkg/seachest/seachest.go
@@ -34,6 +34,7 @@ package seachest
 import "C"
 import (
 	"fmt"
+	"github.com/openebs/node-disk-manager/blockdevice"
 	"unsafe"
 
 	"k8s.io/klog"
@@ -181,13 +182,13 @@ func (I *Identifier) GetRotationalLatency(driveInfo *C.driveInformationSAS_SATA)
 func (I *Identifier) DriveType(driveInfo *C.driveInformationSAS_SATA) string {
 
 	if driveInfo.rotationRate == 0x0000 {
-		return "Not Available"
+		return blockdevice.DriveTypeUnknown
 	}
 
 	if driveInfo.rotationRate == 0x0001 {
-		return "SSD"
+		return blockdevice.DriveTypeSSD
 	}
-	return "HDD"
+	return blockdevice.DriveTypeHDD
 }
 
 func (I *Identifier) GetTotalBytesRead(driveInfo *C.driveInformationSAS_SATA) uint64 {

--- a/pkg/sysfs/syspath.go
+++ b/pkg/sysfs/syspath.go
@@ -234,7 +234,7 @@ func (s Device) GetHardwareSectorSize() (int64, error) {
 func (s Device) GetDriveType() (string, error) {
 	rotational, err := readSysFSFileAsInt64(s.sysPath + "queue/rotational")
 	if err != nil {
-		return "", err
+		return blockdevice.DriveTypeUnknown, err
 	}
 
 	if rotational == 1 {
@@ -242,7 +242,7 @@ func (s Device) GetDriveType() (string, error) {
 	} else if rotational == 0 {
 		return blockdevice.DriveTypeSSD, nil
 	}
-	return "", fmt.Errorf("undefined rotational value %d", rotational)
+	return blockdevice.DriveTypeUnknown, fmt.Errorf("undefined rotational value %d", rotational)
 }
 
 // GetCapacityInBytes gets the capacity of the device in bytes

--- a/pkg/sysfs/syspath_test.go
+++ b/pkg/sysfs/syspath_test.go
@@ -472,7 +472,7 @@ func TestSysFsDeviceGetDriveType(t *testing.T) {
 			},
 			createQueueDir: false,
 			rotational:     "0",
-			want:           "",
+			want:           blockdevice.DriveTypeUnknown,
 			wantErr:        true,
 		},
 		"valid rotational value (1) present in syspath": {


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does?**:
- add unknown drive type to blockdevices. This will be used instead of the empty string. While adding the crd validation we came across this case which failed validation due to code setting to blank. Instead of blank, if we provide Unknown it will be better in terms of readability and validation.

**Does this PR require any upgrade changes?**:
No, upgrades are automatically handled

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 