### PR TITLE
feat(filter): add support to use unused partitions in os-disk

### DIFF
--- a/changelogs/unreleased/524-akhilerm
+++ b/changelogs/unreleased/524-akhilerm
@@ -1,0 +1,1 @@
+add support for creating blockdevices for unused os-disk partitions

--- a/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
+++ b/cmd/ndm_daemonset/filter/osdiskexcludefilter.go
@@ -90,7 +90,6 @@ func (odf *oSDiskExcludeFilter) Start() {
 		mountPointUtil := mount.NewMountUtil(hostMountFilePath, "", mountPoint)
 		if devPath, err := mountPointUtil.GetDiskPath(); err != nil {
 			klog.Errorf("unable to configure os disk filter for mountpoint: %s, error: %v", mountPoint, err)
-			klog.Error(err)
 		} else {
 			odf.excludeDevPaths = append(odf.excludeDevPaths, devPath)
 		}
@@ -103,7 +102,6 @@ func (odf *oSDiskExcludeFilter) Start() {
 		mountPointUtil := mount.NewMountUtil(defaultMountFilePath, "", mountPoint)
 		if devPath, err := mountPointUtil.GetDiskPath(); err != nil {
 			klog.Errorf("unable to configure os disk filter for mountpoint: %s, error: %v", mountPoint, err)
-			klog.Error(err)
 		} else {
 			odf.excludeDevPaths = append(odf.excludeDevPaths, devPath)
 		}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -41,8 +41,11 @@ const (
 	// blockdevice UUID algorithm mentioned in
 	// https://github.com/openebs/openebs/pull/2666
 	GPTBasedUUID Feature = "GPTBasedUUID"
+
 	// APIService feature flag starts the GRPC server which provides functionality to manage block devices
 	APIService Feature = "APIService"
+
+	UseOSDisk Feature = "UseOSDisk"
 )
 
 // supportedFeatures is the list of supported features. This is used while parsing the
@@ -50,12 +53,14 @@ const (
 var supportedFeatures = []Feature{
 	GPTBasedUUID,
 	APIService,
+	UseOSDisk,
 }
 
 // defaultFeatureGates is the default features that will be applied to the application
 var defaultFeatureGates = map[Feature]bool{
 	GPTBasedUUID: false,
 	APIService:   false,
+	UseOSDisk:    false,
 }
 
 // featureFlag is a map representing the flag and its state

--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -59,7 +59,7 @@ func (m DiskMountUtil) GetDiskPath() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	devPath, err := getDiskDevPath(mountAttr.DevPath)
+	devPath, err := getPartitionDevPath(mountAttr.DevPath)
 	if err != nil {
 		return "", err
 	}
@@ -104,9 +104,14 @@ func (m DiskMountUtil) getDeviceMountAttr(fn getMountData) (DeviceMountAttr, err
 	return mountAttr, fmt.Errorf("could not get device mount attributes, Path/MountPoint not present in mounts file")
 }
 
-//	getDiskSysPath takes disk/partition name as input (sda, sda1, sdb, sdb2 ...) and
-//	returns syspath of that disk from which we can generate ndm given uuid of that disk.
-func getDiskDevPath(partition string) (string, error) {
+//	getPartitionDevPath takes disk/partition name as input (sda, sda1, sdb, sdb2 ...) and
+//	returns dev path of that disk/partition (/dev/sda1,/dev/sda)
+//
+// NOTE: if the feature gate to use OS disk is enabled, the dev path of disk /partition is returned,
+// eg: sda1, sda2, root on sda5 returns /dev/sda1, /dev/sda2, /dev/sda5 respectively
+// else, the devpath of the parent disk will be returned
+// eg: sda1, root on sda5 returns /dev/sda, /dev/sda respectively
+func getPartitionDevPath(partition string) (string, error) {
 	softlink, err := getSoftLinkForPartition(partition)
 	if err != nil {
 		return "", err

--- a/pkg/mount/mountutil.go
+++ b/pkg/mount/mountutil.go
@@ -121,6 +121,8 @@ func getDiskDevPath(partition string) (string, error) {
 	var ok bool
 	if features.FeatureGates.IsEnabled(features.UseOSDisk) {
 		// the last part will be used instead of the parent disk
+		// eg: /sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda4 is the link
+		// and sda4 will be the device.
 		split := strings.Split(link, "/")
 		disk = split[len(split)-1]
 	} else {

--- a/pkg/mount/mountutil_test.go
+++ b/pkg/mount/mountutil_test.go
@@ -310,7 +310,7 @@ func TestGetSoftLinkForPartition(t *testing.T) {
 }
 
 func TestGetDiskDevPath_WithRoot(t *testing.T) {
-	path, err := getDiskDevPath("root")
+	path, err := getPartitionDevPath("root")
 
 	assert.NoError(t, err)
 	assert.True(t, strings.HasPrefix(path, "/dev/"))


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Sometimes the nodes may have only one large disk with many partitions. NDM currently ignores the complete disk if it contains a system partition. This PR adds support to create blockdevice resources from the unused partitions on the OS disk.

**What this PR does?**:
- adds a new feature gate to enable / disable using OS disk for blockdevices
- modify the os disk filter to exclude only the partition that contains the system mountpoints and not the entire disk

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3133
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 