### PR TITLE
feat(cleanup): support image pull secrets for cleanup pod

### DIFF
--- a/changelogs/unreleased/493-RealHarshThakur
+++ b/changelogs/unreleased/493-RealHarshThakur
@@ -1,0 +1,1 @@
+upgrade CRDs to v1 and add openAPI validation

--- a/changelogs/unreleased/527-akhilerm
+++ b/changelogs/unreleased/527-akhilerm
@@ -1,0 +1,1 @@
+add image pull secrets to cleanup job pod via environment variable

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package cleaner
 
-import "os"
+import (
+	"os"
+)
 
 const (
 	// EnvCleanUpJobImage is the environment variable for getting the

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	"github.com/openebs/node-disk-manager/pkg/env"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -136,6 +137,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v
 	podSpec.ServiceAccountName = getServiceAccount()
 	podSpec.Containers = []v1.Container{jobContainer}
 	podSpec.NodeSelector = map[string]string{controller.KubernetesHostNameLabel: nodeName}
+	podSpec.ImagePullSecrets = env.GetOpenEBSImagePullSecrets()
 	podTemplate := v1.Pod{}
 	podTemplate.Spec = podSpec
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -18,6 +18,9 @@ package env
 
 import (
 	"os"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/openebs/node-disk-manager/pkg/util"
 )
@@ -29,6 +32,8 @@ const (
 
 	// installCRDEnvDefaultValue is the default value for the INSTALL_CRD_ENV
 	installCRDEnvDefaultValue = true
+
+	IMAGE_PULL_SECRETS_ENV = "OPENEBS_IO_IMAGE_PULL_SECRETS"
 )
 
 // IsInstallCRDEnabled is used to check whether the CRDs need to be installed
@@ -41,4 +46,22 @@ func IsInstallCRDEnabled() bool {
 	}
 
 	return util.CheckTruthy(val)
+}
+
+func GetOpenEBSImagePullSecrets() []v1.LocalObjectReference {
+	secrets := strings.TrimSpace(os.Getenv(IMAGE_PULL_SECRETS_ENV))
+
+	list := make([]v1.LocalObjectReference, 0)
+
+	if len(secrets) == 0 {
+		return list
+	}
+	arr := strings.Split(secrets, ",")
+	for _, item := range arr {
+		if len(item) > 0 {
+			l := v1.LocalObjectReference{Name: strings.TrimSpace(item)}
+			list = append(list, l)
+		}
+	}
+	return list
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -33,6 +33,7 @@ const (
 	// installCRDEnvDefaultValue is the default value for the INSTALL_CRD_ENV
 	installCRDEnvDefaultValue = true
 
+	// IMAGE_PULL_SECRETS_ENV is the environment variable used to pass the image pull secrets
 	IMAGE_PULL_SECRETS_ENV = "OPENEBS_IO_IMAGE_PULL_SECRETS"
 )
 
@@ -48,6 +49,7 @@ func IsInstallCRDEnabled() bool {
 	return util.CheckTruthy(val)
 }
 
+// GetOpenEBSImagePullSecrets is used to get the image pull secrets from the environment variable
 func GetOpenEBSImagePullSecrets() []v1.LocalObjectReference {
 	secrets := strings.TrimSpace(os.Getenv(IMAGE_PULL_SECRETS_ENV))
 


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does?**:
add image pull secret to cleanup job pod via env

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- provided the env with image pull secrets in the ndm operator deployment spec, claimed a blockdevice and then unclaimed it. 
- claimed-unclaimed device without providing any env variable for image secrets.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3320
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 