### PR TITLE
cherry-pick(cleanup): support image pull secrets for cleanup pod (#527)

### DIFF
--- a/changelogs/unreleased/493-RealHarshThakur
+++ b/changelogs/unreleased/493-RealHarshThakur
@@ -1,0 +1,1 @@
+upgrade CRDs to v1 and add openAPI validation

--- a/changelogs/unreleased/527-akhilerm
+++ b/changelogs/unreleased/527-akhilerm
@@ -1,0 +1,1 @@
+add image pull secrets to cleanup job pod via environment variable

--- a/pkg/cleaner/config.go
+++ b/pkg/cleaner/config.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package cleaner
 
-import "os"
+import (
+	"os"
+)
 
 const (
 	// EnvCleanUpJobImage is the environment variable for getting the

--- a/pkg/cleaner/jobcontroller.go
+++ b/pkg/cleaner/jobcontroller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openebs/node-disk-manager/blockdevice"
 	"github.com/openebs/node-disk-manager/cmd/ndm_daemonset/controller"
 	"github.com/openebs/node-disk-manager/pkg/apis/openebs/v1alpha1"
+	"github.com/openebs/node-disk-manager/pkg/env"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -136,6 +137,7 @@ func NewCleanupJob(bd *v1alpha1.BlockDevice, volMode VolumeMode, tolerations []v
 	podSpec.ServiceAccountName = getServiceAccount()
 	podSpec.Containers = []v1.Container{jobContainer}
 	podSpec.NodeSelector = map[string]string{controller.KubernetesHostNameLabel: nodeName}
+	podSpec.ImagePullSecrets = env.GetOpenEBSImagePullSecrets()
 	podTemplate := v1.Pod{}
 	podTemplate.Spec = podSpec
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -18,6 +18,9 @@ package env
 
 import (
 	"os"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/openebs/node-disk-manager/pkg/util"
 )
@@ -29,6 +32,9 @@ const (
 
 	// installCRDEnvDefaultValue is the default value for the INSTALL_CRD_ENV
 	installCRDEnvDefaultValue = true
+
+	// IMAGE_PULL_SECRETS_ENV is the environment variable used to pass the image pull secrets
+	IMAGE_PULL_SECRETS_ENV = "OPENEBS_IO_IMAGE_PULL_SECRETS"
 )
 
 // IsInstallCRDEnabled is used to check whether the CRDs need to be installed
@@ -41,4 +47,23 @@ func IsInstallCRDEnabled() bool {
 	}
 
 	return util.CheckTruthy(val)
+}
+
+// GetOpenEBSImagePullSecrets is used to get the image pull secrets from the environment variable
+func GetOpenEBSImagePullSecrets() []v1.LocalObjectReference {
+	secrets := strings.TrimSpace(os.Getenv(IMAGE_PULL_SECRETS_ENV))
+
+	list := make([]v1.LocalObjectReference, 0)
+
+	if len(secrets) == 0 {
+		return list
+	}
+	arr := strings.Split(secrets, ",")
+	for _, item := range arr {
+		if len(item) > 0 {
+			l := v1.LocalObjectReference{Name: strings.TrimSpace(item)}
+			list = append(list, l)
+		}
+	}
+	return list
 }


### PR DESCRIPTION
add image pull secret to cleanup job pod via env

Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

cherry-pick #527 