### PR TITLE
feat(blockdevice, core): add mpath to supported DM device types

### DIFF
--- a/blockdevice/blockdevice.go
+++ b/blockdevice/blockdevice.go
@@ -220,10 +220,18 @@ const (
 
 	// BlockDeviceTypeCrypt is a LUKS volume
 	BlockDeviceTypeCrypt = "crypt"
+
+	// BlockDeviceTypeMultiPath is a multipath device
+	BlockDeviceTypeMultiPath = "mpath"
 )
 
 // DeviceMapperDeviceTypes is the slice of device types that uses a device mapper
-var DeviceMapperDeviceTypes = []string{BlockDeviceTypeDMDevice, BlockDeviceTypeLVM, BlockDeviceTypeCrypt}
+var DeviceMapperDeviceTypes = []string{
+	BlockDeviceTypeDMDevice,
+	BlockDeviceTypeLVM,
+	BlockDeviceTypeCrypt,
+	BlockDeviceTypeMultiPath,
+}
 
 const (
 	// DriveTypeHDD represents a rotating hard disk drive

--- a/changelogs/unreleased/530-akhilerm
+++ b/changelogs/unreleased/530-akhilerm
@@ -1,0 +1,1 @@
+add support for multipath devices


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
If `mpath` is not added to supported type, NDM will not use the `DM_UUID` to create a blockdevice UUID, resulting in device identification erroring out.

**What this PR does?**:
- add multipath device type to supported DM device types

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 