### PR TITLE
fix(probe): fetch block size and drive type for partitions

### DIFF
--- a/changelogs/unreleased/537-z0marlin
+++ b/changelogs/unreleased/537-z0marlin
@@ -1,0 +1,2 @@
+fix sysfsprobe to fetch block/sector size and drive type for partitions
+


### PR DESCRIPTION
sysfsprobe fetches logical/physical blocksize, hw sector size,
and drive type from sysfs using `<syspath>/queue` directory.
This directory is available only for parent disks and not partitions.
These details for partitions are same as their parent disks. Use
their parent disks to fetch the details.

## Testing

Manually tested by running in a minikube cluster
![Screenshot from 2021-01-20 17-15-00](https://user-images.githubusercontent.com/31250892/105172507-befc2a00-5b45-11eb-9bb9-609c0fa4a2de.png)


**Checklist:**
- [x] Fixes openebs/openebs#3134
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
