### PR TITLE
fix(eventhandler): add all devices to hierarchy before filtering

### DIFF
--- a/changelogs/unreleased/538-akhilerm
+++ b/changelogs/unreleased/538-akhilerm
@@ -1,0 +1,1 @@
+add all devices to hierarchy cache irrespective of whether the blockdevice will be filtered or not.

--- a/cmd/ndm_daemonset/probe/addhandler.go
+++ b/cmd/ndm_daemonset/probe/addhandler.go
@@ -61,8 +61,6 @@ func (pe *ProbeEvent) addBlockDeviceToHierarchyCache(bd blockdevice.BlockDevice)
 // addBlockDevice processed when an add event is received for a device
 func (pe *ProbeEvent) addBlockDevice(bd blockdevice.BlockDevice, bdAPIList *apis.BlockDeviceList) error {
 
-	pe.addBlockDeviceToHierarchyCache(bd)
-
 	// handle devices that are not managed by NDM
 	// eg:devices in use by mayastor, zfs PV and jiva
 	// TODO jiva handling is still to be added.

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -59,6 +59,13 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 	for _, device := range msg.Devices {
 		klog.Infof("Processing details for %s", device.DevPath)
 		pe.Controller.FillBlockDeviceDetails(device)
+
+		// add all devices to the hierarchy cache, irrespective of whether they will be
+		// filtered at a later stage. This is done so that a complete disk hierarchy is available
+		// at all times by NDM. It also helps in device processing when complex filter configurations
+		// are provided. Ref: https://github.com/openebs/openebs/issues/3321
+		pe.addBlockDeviceToHierarchyCache(*device)
+
 		// if ApplyFilter returns true then we process the event further
 		if !pe.Controller.ApplyFilter(device) {
 			continue


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
When a filter excludes the parent disk and includes the partition, it caused to NDM error out, because the parent disk was not added in the hierarchy cache. This PR adds the device into the hierachy cache irrespective of whether it is filtered or not. This removes issues while such filter configurations are provided.

**What this PR does?**:
- add device to hierarchy cache before filtering

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
- tested with the scenario mentioned in openebs/openebs#3321

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3321
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 