### PR TITLE
refactor(mount): pass file path as parameter in DeviceBasicMountInfo()

### DIFF
--- a/changelogs/unreleased/539-z0marlin
+++ b/changelogs/unreleased/539-z0marlin
@@ -1,0 +1,1 @@
+pass mounts file path as a parameter when fetching mount attributes using DeviceBasicMountInfo()

--- a/cmd/ndm_daemonset/probe/mountprobe.go
+++ b/cmd/ndm_daemonset/probe/mountprobe.go
@@ -95,7 +95,7 @@ func (mp *mountProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 		return
 	}
 	mountProbe := newMountProbe(blockDevice.DevPath)
-	basicMountInfo, err := mountProbe.MountIdentifier.DeviceBasicMountInfo()
+	basicMountInfo, err := mountProbe.MountIdentifier.DeviceBasicMountInfo(mount.HostMountsFilePath)
 	if err != nil {
 		klog.Error(err)
 		return

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -17,7 +17,9 @@ limitations under the License.
 package mount
 
 const (
-	hostMountFilePath = "/host/proc/1/mounts" // hostMountFilePath is the file path mounted inside container
+	// HostMountsFilePath is the default path of
+	// the mounts file mounted inside container
+	HostMountsFilePath = "/host/proc/1/mounts"
 )
 
 // Identifier is an identifier for the mount probe. It will be a devpath like
@@ -39,8 +41,8 @@ type DeviceMountAttr struct {
 // attributes include the filesystem type, mountpoint, device path etc. These mount attributes
 // are fetched by parsing a mounts file (/proc/1/mounts) and getting the relevant data. If the
 // device is not mounted, then the function will return an error.
-func (I *Identifier) DeviceBasicMountInfo() (DeviceMountAttr, error) {
-	mountUtil := NewMountUtil(hostMountFilePath, I.DevPath, "")
+func (I *Identifier) DeviceBasicMountInfo(mountsFilePath string) (DeviceMountAttr, error) {
+	mountUtil := NewMountUtil(mountsFilePath, I.DevPath, "")
 	mountAttr, err := mountUtil.getDeviceMountAttr(mountUtil.getMountName)
 	return mountAttr, err
 }


### PR DESCRIPTION
The `Identifier.DeviceBasicMountInfo()` fetches mount attributes of a
device by reading the mounts file. The path of this file is currently
fixed. Pass the file path as a parameter to the function. This will
provide more flexibility in the code and also ease writing unit tests
for code that uses this function. The default path is exported as a
constant, and can still be used.

**Any additional information for your reviewer?** : 
This PR is a part of the changes required to solve #253, as discussed on slack with @akhilerm 

**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests