### PR TITLE
fix(event): fix cannot deactive BlockDevice

### DIFF
--- a/changelogs/unreleased/546-cospotato
+++ b/changelogs/unreleased/546-cospotato
@@ -1,0 +1,1 @@
+fixed cannot deactive BlockDevice immediately when "unplugged" device with GPTBasedUUID enabled

--- a/pkg/udevevent/event.go
+++ b/pkg/udevevent/event.go
@@ -52,7 +52,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 
 	// fields used for UUID. These fields will be filled always. But used only if the
 	// GPTBasedUUID feature-gate is enabled.
-	udevDeviceType := device.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
+	deviceDetails.DeviceAttributes.DeviceType = device.GetPropertyValue(libudevwrapper.UDEV_DEVTYPE)
 	deviceDetails.DeviceAttributes.WWN = device.GetPropertyValue(libudevwrapper.UDEV_WWN)
 	deviceDetails.DeviceAttributes.Serial = device.GetPropertyValue(libudevwrapper.UDEV_SERIAL)
 
@@ -83,6 +83,7 @@ func (e *event) process(device *libudevwrapper.UdevDevice) {
 				deviceDetails.DependentDevices = dependents
 				klog.V(4).Infof("Dependents of %s : %+v", deviceDetails.DevPath, dependents)
 			}
+			udevDeviceType := deviceDetails.DeviceAttributes.DeviceType
 			deviceType, err := sysfsDevice.GetDeviceType(udevDeviceType)
 			if err != nil {
 				klog.Errorf("could not get device type for %s, falling back to udev reported type: %s", deviceDetails.DevPath, udevDeviceType)


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:

When I unplugged a disk from node, the BlockDevice was not become Inactive  immediately until I restart (delete daemonset pod) the daemonset on the node.

**What this PR does?**:

fix cannot deactive BlockDevice when GPTBasedUUID is enabled

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
