### PR TITLE
fix(test): fix unit tests to support /dev/root

### DIFF
--- a/cmd/ndm_daemonset/probe/eventhandler_test.go
+++ b/cmd/ndm_daemonset/probe/eventhandler_test.go
@@ -263,8 +263,23 @@ func TestDeleteDiskEvent(t *testing.T) {
 func compareBlockDevice(t *testing.T, bd1, bd2 apis.BlockDevice) {
 	assert.Equal(t, bd1.Name, bd2.Name)
 	assert.Equal(t, bd1.Labels, bd2.Labels)
+	// devlinks will be compared separately
+	assert.Equal(t, len(bd1.Spec.DevLinks), len(bd2.Spec.DevLinks))
+	if len(bd1.Spec.DevLinks) != len(bd2.Spec.DevLinks) {
+		assert.Fail(t, "Devlinks, expected: %+v \n actual: %+v", bd1.Spec.DevLinks, bd2.Spec.DevLinks)
+		return
+	}
+	// compare each set of devlinks
+	for i := 0; i < len(bd1.Spec.DevLinks); i++ {
+		assert.True(t, unorderedEqual(bd1.Spec.DevLinks[i].Links, bd2.Spec.DevLinks[i].Links))
+	}
+	// links will be made nil since they are already compared
+	bd1.Spec.DevLinks = nil
+	bd2.Spec.DevLinks = nil
+
 	assert.Equal(t, bd1.Spec, bd2.Spec)
 	assert.Equal(t, bd1.Status, bd2.Status)
+
 }
 
 // compareBlockDeviceList is the custom comparison function for blockdevice list

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -121,6 +121,15 @@ func TestFillDiskDetails(t *testing.T) {
 		Kind:  libudevwrapper.BY_PATH_LINK,
 		Links: mockOsDiskDetails.ByPathDevLinks,
 	})
+
+	// The devlinks are compared separately as the ordering of devlinks can be different in some systems
+	// eg: ubuntu 20.04 in github actions
+	assert.True(t, compareDevLinks(expectedDiskInfo.DevLinks, actualDiskInfo.DevLinks))
+
+	// The devlinks are made nil since they are already compared
+	expectedDiskInfo.DevLinks = nil
+	actualDiskInfo.DevLinks = nil
+
 	assert.Equal(t, expectedDiskInfo, actualDiskInfo)
 }
 
@@ -241,4 +250,31 @@ func TestNewUdevProbeForFillDiskDetails(t *testing.T) {
 			assert.Equal(t, test.expectedError, test.actualError)
 		})
 	}
+}
+
+func compareDevLinks(devLink1, devLink2 []blockdevice.DevLink) bool {
+	if len(devLink1) != len(devLink2) {
+		return false
+	}
+	cmp := true
+	for i := 0; i < len(devLink1); i++ {
+		cmp = cmp && unorderedEqual(devLink1[0].Links, devLink2[0].Links)
+	}
+	return cmp
+}
+
+func unorderedEqual(first, second []string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	exists := make(map[string]bool)
+	for _, value := range first {
+		exists[value] = true
+	}
+	for _, value := range second {
+		if !exists[value] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
Github actions has made certain changes in VM configurations which was causing unit tests which make use of OS disk to fail.
The changes in the Github actions VM are:
1. ubuntu-latest now uses ubuntu-20.04 instead of ubuntu-18.04
2. OS disk is now mounted at `/dev/root`
3. Devlinks are appearing in different order in udev 

**What this PR does?**:
1. use `/proc/cmdline` to get mount point if `/proc/self/mounts` fails
2. use separate function to compare devlinks to compare links that are unordered

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 