### PR TITLE
fix(tests): fix unit test that uses devlinks

### DIFF
--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -207,6 +207,9 @@ func TestGetDevLinks(t *testing.T) {
 	}
 }
 
+// unorderedEqual compares 2 arrays, if all elements in one array are present
+// in the second array.
+// eg: [1,2,3] and [3,1,2] are equal in unorderedEqual.
 func unorderedEqual(first, second []string) bool {
 	if len(first) != len(second) {
 		return false

--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -96,6 +96,13 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			assert.True(t, unorderedEqual(test.expectedDetails.ByIdDevLinks, test.actualDetails.ByIdDevLinks))
+			assert.True(t, unorderedEqual(test.expectedDetails.ByPathDevLinks, test.actualDetails.ByPathDevLinks))
+			// need to make this nil as devlinks already compared.
+			test.expectedDetails.ByIdDevLinks = nil
+			test.expectedDetails.ByPathDevLinks = nil
+			test.actualDetails.ByIdDevLinks = nil
+			test.actualDetails.ByPathDevLinks = nil
 			assert.Equal(t, test.expectedDetails, test.actualDetails)
 		})
 	}
@@ -198,4 +205,20 @@ func TestGetDevLinks(t *testing.T) {
 			})
 		}
 	}
+}
+
+func unorderedEqual(first, second []string) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	exists := make(map[string]bool)
+	for _, value := range first {
+		exists[value] = true
+	}
+	for _, value := range second {
+		if !exists[value] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does?**:
use unordered comparison for comparing string array of devlinks as devlinks order can change

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
Continuation of https://github.com/openebs/node-disk-manager/pull/547


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 