### PR TITLE
fix(workflow): add load option and fix image tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,8 +248,8 @@ jobs:
         with:
           # add each registry to which the image needs to be pushed here
           images: |
-            ${{ env.IMAGE_ORG }}/node-disk-manager
-            quay.io/${{ env.IMAGE_ORG }}/node-disk-manager
+            ${{ env.IMAGE_ORG }}/node-disk-operator
+            quay.io/${{ env.IMAGE_ORG }}/node-disk-operator
           tag-latest: false
           tag-custom-only: true
           tag-custom: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -171,6 +171,7 @@ jobs:
         with:
           file: ./build/ndm-daemonset/Dockerfile
           push: false
+          load: true
           platforms: linux/amd64
           tags: |
             openebs/node-disk-manager:ci
@@ -180,6 +181,7 @@ jobs:
         with:
           file: ./build/ndm-operator/Dockerfile
           push: false
+          load: true
           platforms: linux/amd64
           tags: |
             openebs/node-disk-operator:ci

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A detailed usage documentation is maintained in the [wiki](https://github.com/op
 Before building the image locally, you need to setup your development environment. The detailed instructions for setting up development environment, building and testing are available [here](./BUILD.md).
 
 #### Push Image
-By default travis pushes the docker image to `openebs/node-disk-manager-amd64`, with *ci* as well as commit tags. 
+By default Github Action pushes the docker image to `openebs/node-disk-manager`, with *ci* tags. 
 You can push to your custom registry and modify the ndm-operator.yaml file for your testing. 
 
 # License

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,21 +26,21 @@ Once the release branch is created, changelog from `changelogs/unreleased` needs
 
 The format of the release tag is either "Release-Name-RC1" or "Release-Name" depending on whether the tag is a release candidate or a release. (Example: v0.5.0-RC1 is a GitHub release tag for node-disk-manager release candidate build. v0.5.0 is the release tag that is created after the release criteria are satisfied by the node-disk-manager RC builds.)
 
-Once the release is triggered, Travis build process has to be monitored. Once Travis build passes, images are pushed to docker hub and quay.io. Images can be verified by going through docker hub and quay.io. Also, the images shouldn't have any high level vulnerabilities.
+Once the release is triggered, Github Action release workflow has to be monitored. Once the workflow passes, images are pushed to docker hub and quay.io. Images can be verified by going through docker hub and quay.io. Also, the images shouldn't have any high level vulnerabilities.
 
-Images for the different components are published at the following location depending on the architecture (amd64, arm64, ppc64le):
+Images for the different components are published at the following location:
 
 - Node Disk Manager Daemon
-    https://quay.io/repository/openebs/node-disk-manager-{ARCH}?tab=tags
-    https://hub.docker.com/r/openebs/node-disk-manager-{ARCH}/tags
+    https://quay.io/repository/openebs/node-disk-manager?tab=tags
+    https://hub.docker.com/r/openebs/node-disk-manager/tags
 
 - Node Disk Operator
-    https://quay.io/repository/openebs/node-disk-operator-{ARCH}?tab=tags
-    https://hub.docker.com/r/openebs/node-disk-operator-{ARCH}/tags
+    https://quay.io/repository/openebs/node-disk-operator?tab=tags
+    https://hub.docker.com/r/openebs/node-disk-operator/tags
 
 - Node Disk Exporter
-    https://quay.io/repository/openebs/node-disk-exporter-{ARCH}?tab=tags
-    https://hub.docker.com/r/openebs/node-disk-exporter-{ARCH}/tags
+    https://quay.io/repository/openebs/node-disk-exporter?tab=tags
+    https://hub.docker.com/r/openebs/node-disk-exporter/tags
 
 
 Once a release is created, update the release description with the change log mentioned in `changelog/v0.5.x`. Once the change logs are updated in release, repo owner needs to create a PR to `master` with the following details:

--- a/build/build.sh
+++ b/build/build.sh
@@ -134,8 +134,8 @@ VERSION="ci"
 
 if [ -n "${RELEASE_TAG}" ] ;
 then
-    # When github is tagged with a release, then Travis will
-    # set the release tag in env RELEASE_TAG
+    # When github is tagged with a release, then github action release workflow
+    # will set the release tag in env RELEASE_TAG
     VERSION="${RELEASE_TAG}"
 fi;
 

--- a/build/push
+++ b/build/push
@@ -59,11 +59,11 @@ BUILD_ID=$(git describe --tags --always)
 
 # Determine the current branch
 CURRENT_BRANCH=""
-if [ -z ${TRAVIS_BRANCH} ];
+if [ -z ${BRANCH} ];
 then
   CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 else
-  CURRENT_BRANCH=${TRAVIS_BRANCH}
+  CURRENT_BRANCH=${BRANCH}
 fi
 
 #Depending on the branch where builds are generated,
@@ -106,12 +106,12 @@ then
   # This unique/build image will be pushed to corresponding ci repo.
   TagAndPushImage "${DIMAGE}-ci" "${BUILD_TAG}"
 
-  if [ ! -z "${TRAVIS_TAG}" ] ;
+  if [ ! -z "${RELEASE_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will
-    # set the release tag in env TRAVIS_TAG
-    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
+    # When github is tagged with a release, then github action release workflow
+    # will set the release tag in env RELEASE_TAG
+    TagAndPushImage "${DIMAGE}" "${RELEASE_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
 else
@@ -126,13 +126,13 @@ then
   # Push CI tagged image - :ci or :branch-ci
   TagAndPushImage "quay.io/${DIMAGE}" "${CI_TAG}"
 
-  if [ ! -z "${TRAVIS_TAG}" ] ;
+  if [ ! -z "${RELEASE_TAG}" ] ;
   then
     # Push with different tags if tagged as a release
-    # When github is tagged with a release, then Travis will
-    # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
+    # When github is tagged with a release, then github action reelase workflow
+    # will set the release tag in env RELEASE_TAG
+    # Trim the `v` from the RELEASE_TAG if it exists
+    TagAndPushImage "quay.io/${DIMAGE}" "${RELEASE_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does?**:
- add load option to pull request workflow so images that are built during integration-tests are loaded into the local docker daemon before running the tests
- fix image name in build workflow for node-disk-operator
- fix docs and scripts that uses travis variables.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
Continuation of https://github.com/openebs/node-disk-manager/pull/548

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 