### PR TITLE
chore(workflow): use RELEASE_TAG from env in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
             DBUILD_REPO_URL=https://github.com/openebs/node-disk-manager
             DBUILD_SITE_URL=https://openebs.io
-            RELEASE_TAG=${RELEASE_TAG}
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   ndm-exporter:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
             DBUILD_REPO_URL=https://github.com/openebs/node-disk-manager
             DBUILD_SITE_URL=https://openebs.io
-            RELEASE_TAG=${RELEASE_TAG}
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   ndm-operator:
     runs-on: ubuntu-latest
@@ -251,4 +251,4 @@ jobs:
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
             DBUILD_REPO_URL=https://github.com/openebs/node-disk-manager
             DBUILD_SITE_URL=https://openebs.io
-            RELEASE_TAG=${RELEASE_TAG}
+            RELEASE_TAG=${{ env.RELEASE_TAG }}

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ ifeq (${DBUILD_SITE_URL}, )
   export DBUILD_SITE_URL
 endif
 
-export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
+export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG}
 
 # Initialize the NDM DaemonSet variables
 # Specify the NDM DaemonSet binary name


### PR DESCRIPTION
**What this PR does?**:
- use ${{ env.RELEASE_TAG }} instead of ${RELEASE_TAG} as they are expanded only in a shell

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_
continuation of #553 

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 