### PR TITLE
fix(sysfs): add check for empty devpath

### DIFF
--- a/changelogs/unreleased/560-akhilerm
+++ b/changelogs/unreleased/560-akhilerm
@@ -1,0 +1,1 @@
+add check for empty devpath while creating sysfs device

--- a/pkg/sysfs/device.go
+++ b/pkg/sysfs/device.go
@@ -37,8 +37,11 @@ type Device struct {
 // The sysfs device struct contains the device name along with the syspath
 func NewSysFsDeviceFromDevPath(devPath string) (*Device, error) {
 	devName := strings.Replace(devPath, "/dev/", "", 1)
-	sysPath, err := getDeviceSysPath(devPath)
+	if len(devName) == 0 {
+		return nil, fmt.Errorf("unable to create sysfs device from devPath for device: %s, error: device name empty")
+	}
 
+	sysPath, err := getDeviceSysPath(devPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create sysfs device from devpath for device: %s, error: %v", devPath, err)
 	}

--- a/pkg/sysfs/device.go
+++ b/pkg/sysfs/device.go
@@ -38,7 +38,7 @@ type Device struct {
 func NewSysFsDeviceFromDevPath(devPath string) (*Device, error) {
 	devName := strings.Replace(devPath, "/dev/", "", 1)
 	if len(devName) == 0 {
-		return nil, fmt.Errorf("unable to create sysfs device from devPath for device: %s, error: device name empty")
+		return nil, fmt.Errorf("unable to create sysfs device from devPath for device: %s, error: device name empty", devPath)
 	}
 
 	sysPath, err := getDeviceSysPath(devPath)

--- a/pkg/sysfs/device_test.go
+++ b/pkg/sysfs/device_test.go
@@ -22,20 +22,20 @@ import (
 )
 
 func TestNewSysFsDeviceFromDevPath(t *testing.T) {
-	type args struct {
+	tests := map[string]struct {
 		devPath string
-	}
-	tests := []struct {
-		name    string
-		args    args
 		want    *Device
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+		"empty device path is used": {
+			devPath: "",
+			want:    nil,
+			wantErr: true,
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewSysFsDeviceFromDevPath(tt.args.devPath)
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := NewSysFsDeviceFromDevPath(tt.devPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewSysFsDeviceFromDevPath() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
If the devpath received due to some error is empty, then sysfs device creation caused a crash. This PR adds a check for empty path before creating a sysfs device.

**What this PR does?**:
- adds check for empty device path

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3362
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 