### PR TITLE
chore(github-action): Avoid builds for pushes to helm chart and docs files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,11 @@
 # limitations under the License.
 name: build
 
-on: ['push']
+on:
+  push:
+    paths-ignore:
+    - 'docs/**'
+    - 'deploy/helm/**'
 
 jobs:
   lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ on:
     paths-ignore:
     - 'docs/**'
     - 'deploy/helm/**'
+    - 'changelogs/**'
 
 jobs:
   lint:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,9 @@ name: ci
 on:
   pull_request:
     paths-ignore:
+      - 'docs/**'
       - 'deploy/helm/**'
+      - 'changelogs/**'
     branches:
       # on pull requests to master and release branches
       - master


### PR DESCRIPTION
This condition in the .github/workflows/build.yml file will ignore pushes made to `docs/` and `deploy/helm/` directories and avoid building the images.

Signed-off-by: Niladri Halder <niladri.halder@mayadata.io>