### PR TITLE
chore(build): setup muse config

### DIFF
--- a/.muse/config.toml
+++ b/.muse/config.toml
@@ -1,0 +1,7 @@
+ignoreRules = [ "G101",
+                "ST1005"
+              ]
+
+ignoreFiles = """
+vendor/**
+"""


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:

OpenEBS is participating in the KubeCon Bugbash event. As a pre-requisite, muse is set up to identify the issues via static analysis checks that can be fixed by participants. https://www.eventbrite.com/e/cncf-bug-bash-2021-tickets-152369917525

Using this config, the static analysis is skipped on the vendor directory and also ignores the constraint of error messages starting with caps.


**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
