### PR TITLE
fix(pkg, mount): fetch all mount points for a given device

### DIFF
--- a/changelogs/unreleased/590-z0marlin
+++ b/changelogs/unreleased/590-z0marlin
@@ -1,0 +1,2 @@
+update mount utility to fetch all mount points for a given device
+

--- a/cmd/ndm_daemonset/probe/mountprobe.go
+++ b/cmd/ndm_daemonset/probe/mountprobe.go
@@ -101,7 +101,7 @@ func (mp *mountProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevic
 		return
 	}
 
-	blockDevice.FSInfo.MountPoint = append(blockDevice.FSInfo.MountPoint, basicMountInfo.MountPoint)
+	blockDevice.FSInfo.MountPoint = basicMountInfo.MountPoint
 	if blockDevice.FSInfo.FileSystem == "" {
 		blockDevice.FSInfo.FileSystem = basicMountInfo.FileSystem
 	}

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -32,9 +32,9 @@ type Identifier struct {
 // mount point, filesystem type etc.
 // It helps to find mountpoint of a partition/block
 type DeviceMountAttr struct {
-	DevPath    string // DevPath of the device/block
-	MountPoint string // MountPoint of the the device/block
-	FileSystem string // FileSystem in the device that is mounted
+	DevPath    string   // DevPath of the device/block
+	MountPoint []string // MountPoint of the the device/block
+	FileSystem string   // FileSystem in the device that is mounted
 }
 
 // DeviceBasicMountInfo gives the mount attributes of a device that is attached. The mount


### PR DESCRIPTION
Partitions can be mounted at multiple points in a given system.
Return a list of all the mount points of a given device as found in the
mounts file instead of just returning the first entry.

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>

**Checklist:**
- [x] Fixes #558 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests