### PR TITLE
fix(tests): fix buggy tests in probe and sysfs

### DIFF
--- a/changelogs/unreleased/593-z0marlin
+++ b/changelogs/unreleased/593-z0marlin
@@ -1,0 +1,2 @@
+fix tests in probe and syspath packages
+


### PR DESCRIPTION
changes made:
- fix sysfs tests to cleanup after finishing. tests were failing when
run the second time after passing for the first time.
- skip `TestUdevProbe` in package probe if disk uuid cannot be
generated
- fix `TestFillDiskDetails` in package probe to correctly set
expected dev links

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>

**Checklist:**
- [x] Fixes #589 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests