### PR TITLE
feat(controller): selectively run probes using allowlist in event msg

### DIFF
--- a/changelogs/unreleased/601-z0marlin
+++ b/changelogs/unreleased/601-z0marlin
@@ -1,0 +1,2 @@
+add probe allowlist in event message to selectively run probes when filling blockdevice details
+

--- a/cmd/ndm_daemonset/controller/probe_test.go
+++ b/cmd/ndm_daemonset/controller/probe_test.go
@@ -80,7 +80,6 @@ func TestAddNewProbe(t *testing.T) {
 //Add some new probes and get the list of the probes and match them
 func TestListProbe(t *testing.T) {
 	probes := make([]*Probe, 0)
-	expectedProbeList := make([]*Probe, 0)
 	mutex := &sync.Mutex{}
 	fakeController := &Controller{
 		Probes: probes,
@@ -88,26 +87,51 @@ func TestListProbe(t *testing.T) {
 	}
 	testProbe := &fakeProbe{}
 	probe1 := &Probe{
-		Priority:  2,
+		Priority:  3,
 		Name:      "probe1",
 		State:     true,
 		Interface: testProbe,
 	}
 	probe2 := &Probe{
-		Priority:  1,
+		Priority:  2,
 		Name:      "probe2",
 		State:     true,
 		Interface: testProbe,
 	}
+	probe3 := &Probe{
+		Priority:  4,
+		Name:      "probe3",
+		State:     false,
+		Interface: testProbe,
+	}
+	probe4 := &Probe{
+		Priority:  1,
+		Name:      "probe4",
+		State:     true,
+		Interface: testProbe,
+	}
+
 	fakeController.AddNewProbe(probe1)
 	fakeController.AddNewProbe(probe2)
-	expectedProbeList = append(expectedProbeList, probe2)
-	expectedProbeList = append(expectedProbeList, probe1)
+	fakeController.AddNewProbe(probe3)
+	fakeController.AddNewProbe(probe4)
+
 	tests := map[string]struct {
 		actualProbeList   []*Probe
 		expectedProbeList []*Probe
 	}{
-		"add some probes and check if they are present or not": {actualProbeList: fakeController.ListProbe(), expectedProbeList: expectedProbeList},
+		"list all enabled probes": {
+			actualProbeList:   fakeController.ListProbe(),
+			expectedProbeList: []*Probe{probe4, probe2, probe1},
+		},
+		"list selective probes, all required probes enabled": {
+			actualProbeList:   fakeController.ListProbe("probe1", "probe2"),
+			expectedProbeList: []*Probe{probe2, probe1},
+		},
+		"list selective probes, some disabled": {
+			actualProbeList:   fakeController.ListProbe("probe2", "probe4", "probe3"),
+			expectedProbeList: []*Probe{probe4, probe2},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -58,7 +58,7 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 	// iterate through each block device and perform the add/update operation
 	for _, device := range msg.Devices {
 		klog.Infof("Processing details for %s", device.DevPath)
-		pe.Controller.FillBlockDeviceDetails(device, msg.AllowedProbes...)
+		pe.Controller.FillBlockDeviceDetails(device, msg.RequestedProbes...)
 
 		// add all devices to the hierarchy cache, irrespective of whether they will be
 		// filtered at a later stage. This is done so that a complete disk hierarchy is available

--- a/cmd/ndm_daemonset/probe/eventhandler.go
+++ b/cmd/ndm_daemonset/probe/eventhandler.go
@@ -58,7 +58,7 @@ func (pe *ProbeEvent) addBlockDeviceEvent(msg controller.EventMessage) {
 	// iterate through each block device and perform the add/update operation
 	for _, device := range msg.Devices {
 		klog.Infof("Processing details for %s", device.DevPath)
-		pe.Controller.FillBlockDeviceDetails(device)
+		pe.Controller.FillBlockDeviceDetails(device, msg.AllowedProbes...)
 
 		// add all devices to the hierarchy cache, irrespective of whether they will be
 		// filtered at a later stage. This is done so that a complete disk hierarchy is available


### PR DESCRIPTION
event messages passed in the `UdevEventMessageChannel` channel are used
to trigger actions in the controller to add/update/delete blockdevices.
In case of addition, the controller runs all the registered probes to
fill certain details of the blockdevice. While all probes need to be run
when adding a new blockdevice, in case of updates, the list of probes to
be run can be narrowed down based on the type of update. For example,
when the mount points of a partition change, mount probe alone is enough
to fetch the new information.
add an allowlist for probes in the event message to inform the
controller what probes are to be run. the controller then runs only the
probes that are enabled and available in the allowlist. leaving the
allowlist empty causes default behaviour which is to run all the enabled
probes.

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>

**Any additional information for your reviewer?** : 
This PR is a continuation of #595 and works towards fixing openebs/openebs#3135.


**Checklist:**
- [x] Fixes  openebs/openebs#3135 (partially)
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
