### PR TITLE
fix(probe): update bd cache after generating uuid

### DIFF
--- a/changelogs/unreleased/602-z0marlin
+++ b/changelogs/unreleased/602-z0marlin
@@ -1,0 +1,2 @@
+fix add-handler to update controller blockdevice cache after generating uuid
+

--- a/cmd/ndm_daemonset/probe/addhandler.go
+++ b/cmd/ndm_daemonset/probe/addhandler.go
@@ -126,6 +126,8 @@ func (pe *ProbeEvent) addBlockDevice(bd blockdevice.BlockDevice, bdAPIList *apis
 	} else {
 		bd.UUID = uuid
 		klog.V(4).Infof("uuid: %s has been generated for device: %s", uuid, bd.DevPath)
+		// update cache after generating uuid
+		pe.addBlockDeviceToHierarchyCache(bd)
 		bdAPI, err := pe.Controller.GetBlockDevice(uuid)
 
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
when adding a blockdevice, the information stroed in the controller
cache does not contain the the up to date uuid of the bd generated while
adding the bd. Update the bd cache with the new uuid after generation.

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them
