### PR TITLE
fix(manager): set reconciliation interval for manager

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openebs/node-disk-manager/pkg/env"
 	"os"
 	goruntime "runtime"
+	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -44,6 +45,9 @@ import (
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
+
+	// reconciliation interval for the resources
+	reconInterval = 5 * time.Second
 )
 
 func init() {
@@ -86,6 +90,7 @@ func main() {
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   8787,
+		SyncPeriod:             &reconInterval,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "node-disk-operator.openebs.io",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,7 +47,7 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 
 	// reconciliation interval for the resources
-	reconInterval = 5 * time.Second
+	reconInterval = 30 * time.Second
 )
 
 func init() {


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**Why is this PR required? What issue does it fix?**:
since the default sync period was not set, the resources were not getting reconciled incase of successful reconciliation. 

**What this PR does?**:
- sets the sync period to 30 seconds so that the resources are reconciled frequently

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3413
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 