### PR TITLE
fix(endpoints-discovery): Fixed ndm exporter's service endpoints discovery

### DIFF
--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -713,6 +713,7 @@ metadata:
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-cluster-exporter
+  namespace: openebs
 spec:
   clusterIP: None
   ports:
@@ -777,6 +778,7 @@ metadata:
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-node-exporter
+  namespace: openebs
 spec:
   clusterIP: None
   ports:

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -710,10 +710,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ndm-cluster-exporter-service
+  namespace: openebs
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-cluster-exporter
-  namespace: openebs
 spec:
   clusterIP: None
   ports:
@@ -775,10 +775,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ndm-node-exporter-service
+  namespace: openebs
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-node-exporter
-  namespace: openebs
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-cluster-exporter.yaml
+++ b/deploy/yamls/ndm-cluster-exporter.yaml
@@ -52,6 +52,7 @@ metadata:
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-cluster-exporter
+  namespace: openebs
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-cluster-exporter.yaml
+++ b/deploy/yamls/ndm-cluster-exporter.yaml
@@ -49,10 +49,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ndm-cluster-exporter-service
+  namespace: openebs
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-cluster-exporter
-  namespace: openebs
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-node-exporter.yaml
+++ b/deploy/yamls/ndm-node-exporter.yaml
@@ -53,6 +53,7 @@ metadata:
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-node-exporter
+  namespace: openebs
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-node-exporter.yaml
+++ b/deploy/yamls/ndm-node-exporter.yaml
@@ -50,10 +50,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ndm-node-exporter-service
+  namespace: openebs
   labels:
     name: openebs-ndm-exporter
     component: openebs-ndm-node-exporter
-  namespace: openebs
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
The ndm cluster exporter and ndm node exporter service were not be to discover/identify the endpoints because of being installed in different ns then the ndm-manager daemonset and ndm-operator deployment through operator.

**What this PR does?**:
This PR adds namespace field in the metadata section to the service same as the namespace in which the ndm-manager daemonset and ndm-operator deployment  is installed to that the service is able to successfully identify its endpoints.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 