### PR TITLE
tests(integration): print ndm logs if an integration test fails

### DIFF
--- a/integration_tests/sanity/ndm_integration_test.go
+++ b/integration_tests/sanity/ndm_integration_test.go
@@ -17,15 +17,40 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openebs/node-disk-manager/integration_tests/k8s"
+	"github.com/openebs/node-disk-manager/integration_tests/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
+var k8sGoClient *kubernetes.Clientset
+
 func TestNDM(t *testing.T) {
-	RegisterFailHandler(Fail)
+	// Setup go client for fetching pod logs on failure
+	kubeConfigPath, err := utils.GetConfigPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goClient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k8sGoClient = goClient
+
+	// Custom fail handler to print pod logs on failure
+	RegisterFailHandler(NdmFail)
 	RunSpecs(t, "Integration Test Suite")
 }
 
@@ -89,3 +114,44 @@ var _ = AfterSuite(func() {
 	err = c.DeleteOpenEBSNamespace()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func NdmFail(message string, callerSkip ...int) {
+	printNDMPodLogs()
+	Fail(message, callerSkip...)
+}
+
+func printNDMPodLogs() {
+	podInterface := k8sGoClient.CoreV1().Pods(k8s.Namespace)
+	podList, err := podInterface.List(context.TODO(),
+		metav1.ListOptions{LabelSelector: "name=" + DaemonSetPodPrefix})
+	if err != nil {
+		GinkgoWriter.Write([]byte("could not fetch pod logs: " + err.Error()))
+		return
+	}
+
+	if len(podList.Items) == 0 {
+		GinkgoWriter.Write([]byte("could not find ndm pod"))
+		return
+	}
+
+	if len(podList.Items) > 1 {
+		GinkgoWriter.Write(
+			[]byte("found more than one ndm pods. will pick the first pod in the list"))
+	}
+
+	podName := podList.Items[0].Name
+	podLogs, err := podInterface.GetLogs(podName,
+		&corev1.PodLogOptions{}).Stream(context.TODO())
+	if err != nil {
+		GinkgoWriter.Write([]byte("could not fetch pod logs: " + err.Error()))
+		return
+	}
+	defer podLogs.Close()
+	GinkgoWriter.Write([]byte("------------------ NDM Logs ------------------\n"))
+	_, err = io.Copy(GinkgoWriter, podLogs)
+	if err != nil {
+		GinkgoWriter.Write([]byte("could not write pod logs: " + err.Error()))
+		return
+	}
+	GinkgoWriter.Write([]byte("-------------------- END --------------------\n"))
+}


### PR DESCRIPTION
ndm logs are necessary to debug issues with integration tests. print the
ndm pod logs if a test fails

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>

**Why is this PR required? What issue does it fix?**:
there have been multiple flaky integration test runs in the ndm ci pipeline. There's an open issue to fix these tests (#625). However, it is difficult to debug the test runs on github ci since the ndm logs aren't available. This PR aims to solve the problem.

**Checklist:**
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? (NA)
- [ ] Commit has unit tests (NA)
- [ ] Commit has integration tests (NA)
