### PR TITLE
Enhance the details storage on BD when the device has zpool

### DIFF
--- a/cmd/ndm_daemonset/controller/controller.go
+++ b/cmd/ndm_daemonset/controller/controller.go
@@ -73,6 +73,8 @@ const (
 	NDMDeviceTypeKey = "ndm.io/blockdevice-type"
 	// NDMManagedKey specifies blockdevice cr should be managed by ndm or not.
 	NDMManagedKey = "ndm.io/managed"
+	// NDMZpoolName specifies the zpool name
+	NDMZpoolName = "ndm.io/zpool-name"
 )
 
 const (

--- a/cmd/ndm_daemonset/probe/usedbyprobe.go
+++ b/cmd/ndm_daemonset/probe/usedbyprobe.go
@@ -129,10 +129,11 @@ func (sp *usedbyProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevi
 
 		// check for ZFS file system
 		fstype := usedByProbe.BlkidIdentifier.GetOnDiskFileSystem()
-
+		zpool := usedByProbe.BlkidIdentifier.GetOnDiskLabel()
 		if fstype == zfsFileSystemLabel {
 			blockDevice.DevUse.InUse = true
-
+			blockDevice.FSInfo.FileSystem = zfsFileSystemLabel
+			blockDevice.Labels[controller.NDMZpoolName] = zpool
 			// the disk can either be in use by cstor or zfs local PV
 			ok, err := isBlockDeviceInUseByKernel(blockDevice.DevPath)
 

--- a/pkg/blkid/blkid.go
+++ b/pkg/blkid/blkid.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	fsTypeIdentifier = "TYPE"
+	labelIdentifier  = "LABEL"
 )
 
 type DeviceIdentifier struct {
@@ -40,17 +41,27 @@ type DeviceIdentifier struct {
 // GetOnDiskFileSystem returns the filesystem present on the disk by reading from the disk
 // using libblkid
 func (di *DeviceIdentifier) GetOnDiskFileSystem() string {
+	return di.GetTagValue(fsTypeIdentifier)
+}
+
+// GetOnDiskLabel returns the label present on the disk by reading from the disk
+// using libblkid
+func (di *DeviceIdentifier) GetOnDiskLabel() string {
+	return di.GetTagValue(labelIdentifier)
+}
+
+func (di *DeviceIdentifier) GetTagValue(tag string) string {
 	var blkidType *C.char
-	blkidType = C.CString(fsTypeIdentifier)
+	blkidType = C.CString(tag)
 	defer C.free(unsafe.Pointer(blkidType))
 
 	var device *C.char
 	device = C.CString(di.DevPath)
 	defer C.free(unsafe.Pointer(device))
 
-	var fstype *C.char
-	fstype = C.blkid_get_tag_value(nil, blkidType, device)
-	defer C.free(unsafe.Pointer(fstype))
+	var tagValue *C.char
+	tagValue = C.blkid_get_tag_value(nil, blkidType, device)
+	defer C.free(unsafe.Pointer(tagValue))
 
-	return C.GoString(fstype)
+	return C.GoString(tagValue)
 }


### PR DESCRIPTION
Signed-off-by: liuminjian <liuminjian@chinatelecom.cn>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
#638 Enhance the details storage on BD when the device has zpool
**What this PR does?**:
1. add file type field for zfs block device
2. add zpool name label for zfs block device
![image](https://user-images.githubusercontent.com/7840869/132805285-e37e15a5-67d4-4d1c-a2e8-f17671cf83cb.png)

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


**PLEASE REMOVE BELOW INFORMATION BEFORE SUBMITTING**

The PR title message must follow convention:
   `<type>(<scope>): <subject>`.

Where:
    Most common types are:
    * `feat`        - for new features, not a new feature for build script
    * `fix`         - for bug fixes or improvements, not a fix for build script
    * `chore`       - changes not related to production code
    * `docs`        - changes related to documentation
    * `style`       - formatting, missing semi colons, linting fix etc; no significant production code changes
    * `test`        - adding missing tests, refactoring tests; no production code change
    * `refactor`    - refactoring production code, eg. renaming a variable or function name, there should not be any significant production code changes
    * `cherry-pick` - if PR is merged in master branch and raised to release branch(like v0.4.x)
    
IMPORTANT: Please review the [CONTRIBUTING.md](../CONTRIBUTING.md) file for detailed contributing guidelines.
