### PR TITLE
fix(ndm-exporters): changed exporter service common label

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: openebs-ndm
 description: Helm chart for OpenEBS Node Disk Manager - a Kubernetes native storage device management solution. For instructions on how to install, refer to https://openebs.github.io/node-disk-manager/.
-version: 1.7.1
+version: 1.7.2
 appVersion: 1.7.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -193,7 +193,7 @@ Create labels for ndm operator component
 Create match labels for ndm cluster exporter deployment
 */}}
 {{- define "openebs-ndm.cluster-exporter.matchLabels" -}}
-app: {{ template "openebs-ndm.cluster-exporter.name" . }}
+app: {{ template "openebs-ndm.exporter.name" . }}
 release: {{ .Release.Name }}
 component: {{ default (include "openebs-ndm.cluster-exporter.name" .) .Values.ndmExporter.clusterExporter.componentName }}
 {{- end -}}
@@ -202,7 +202,6 @@ component: {{ default (include "openebs-ndm.cluster-exporter.name" .) .Values.nd
 Create component labels for ndm cluster exporter component
 */}}
 {{- define "openebs-ndm.cluster-exporter.componentLabels" -}}
-name: {{ template "openebs-ndm.exporter.name" . }}
 openebs.io/component-name: {{ default (include "openebs-ndm.cluster-exporter.name" .) .Values.ndmExporter.clusterExporter.componentName }}
 {{- end -}}
 
@@ -220,7 +219,7 @@ Create labels for ndm cluster exporter component
 Create match labels for ndm node exporter deployment
 */}}
 {{- define "openebs-ndm.node-exporter.matchLabels" -}}
-app: {{ template "openebs-ndm.node-exporter.name" . }}
+app: {{ template "openebs-ndm.exporter.name" . }}
 release: {{ .Release.Name }}
 component: {{ default (include "openebs-ndm.node-exporter.name" .) .Values.ndmExporter.nodeExporter.componentName }}
 {{- end -}}
@@ -229,7 +228,6 @@ component: {{ default (include "openebs-ndm.node-exporter.name" .) .Values.ndmEx
 Create component labels for ndm node exporter component
 */}}
 {{- define "openebs-ndm.node-exporter.componentLabels" -}}
-name: {{ template "openebs-ndm.exporter.name" . }}
 openebs.io/component-name: {{ default (include "openebs-ndm.node-exporter.name" .) .Values.ndmExporter.nodeExporter.componentName }}
 {{- end -}}
 

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -85,7 +85,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{- define "openebs-ndm.exporter.name" -}}
-{{- $ndmName := default .Chart.Name .Values.ndmExporter.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $ndmName := .Chart.Name | trunc 63 | trimSuffix "-" }}
 {{- $componentName := "exporter" | trunc 63 | trimSuffix "-" }}
 {{- printf "%s-%s" $ndmName $componentName | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/deploy/helm/charts/templates/cluster-exporter-service.yaml
+++ b/deploy/helm/charts/templates/cluster-exporter-service.yaml
@@ -13,6 +13,6 @@ spec:
       targetPort: {{ .Values.ndmExporter.clusterExporter.metricsPort }}
   selector:
     {{- with .Values.ndmExporter.clusterExporter.podLabels }}
-      {{ toYaml . }}
-      {{- end }}
+    {{ toYaml . }}
+    {{- end }}
   {{- end }}

--- a/deploy/helm/charts/templates/cluster-exporter.yaml
+++ b/deploy/helm/charts/templates/cluster-exporter.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         {{- include "openebs-ndm.cluster-exporter.labels" . | nindent 8 }}
         {{- with .Values.ndmExporter.clusterExporter.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{ toYaml . }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}

--- a/deploy/helm/charts/templates/cluster-exporter.yaml
+++ b/deploy/helm/charts/templates/cluster-exporter.yaml
@@ -16,9 +16,9 @@ spec:
     metadata:
       labels:
         {{- include "openebs-ndm.cluster-exporter.labels" . | nindent 8 }}
-          {{- with .Values.ndmExporter.clusterExporter.podLabels }}
-          {{ toYaml . | nindent 8 }}
-          {{- end }}
+        {{- with .Values.ndmExporter.clusterExporter.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}
       containers:

--- a/deploy/helm/charts/templates/daemonset.yaml
+++ b/deploy/helm/charts/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         {{- include "openebs-ndm.labels" . | nindent 8 }}
         {{- with .Values.ndm.podLabels}}
-        {{ toYaml . | nindent 8 }}
+        {{ toYaml . }}
         {{- end}}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}

--- a/deploy/helm/charts/templates/deployment.yaml
+++ b/deploy/helm/charts/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       labels:
         {{- include "openebs-ndm.operator.labels" . | nindent 8 }}
         {{- with .Values.ndmOperator.podLabels}}
-        {{ toYaml . | nindent 8 }}
+        {{ toYaml . }}
         {{- end}}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}

--- a/deploy/helm/charts/templates/node-exporter-service.yaml
+++ b/deploy/helm/charts/templates/node-exporter-service.yaml
@@ -13,6 +13,6 @@ spec:
       targetPort: {{ .Values.ndmExporter.nodeExporter.metricsPort }}
   selector:
     {{- with .Values.ndmExporter.nodeExporter.podLabels }}
-      {{ toYaml . }}
-      {{- end }}
+    {{ toYaml . }}
+    {{- end }}
   {{- end }}

--- a/deploy/helm/charts/templates/node-exporter.yaml
+++ b/deploy/helm/charts/templates/node-exporter.yaml
@@ -15,9 +15,9 @@ spec:
     metadata:
       labels:
         {{- include "openebs-ndm.node-exporter.labels" . | nindent 8 }}
-          {{- with .Values.ndmExporter.nodeExporter.podLabels }}
-          {{ toYaml . | nindent 8 }}
-          {{- end }}
+        {{- with .Values.ndmExporter.nodeExporter.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}
       containers:

--- a/deploy/helm/charts/templates/node-exporter.yaml
+++ b/deploy/helm/charts/templates/node-exporter.yaml
@@ -16,7 +16,7 @@ spec:
       labels:
         {{- include "openebs-ndm.node-exporter.labels" . | nindent 8 }}
         {{- with .Values.ndmExporter.nodeExporter.podLabels }}
-        {{ toYaml . | nindent 8 }}
+        {{ toYaml . }}
         {{- end }}
     spec:
       serviceAccountName: {{ template "openebs-ndm.serviceAccountName" . }}

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -711,8 +711,7 @@ metadata:
   name: ndm-cluster-exporter-service
   namespace: openebs
   labels:
-    name: openebs-ndm-exporter
-    component: openebs-ndm-cluster-exporter
+    app: openebs-ndm-exporter
 spec:
   clusterIP: None
   ports:
@@ -776,8 +775,7 @@ metadata:
   name: ndm-node-exporter-service
   namespace: openebs
   labels:
-    name: openebs-ndm-exporter
-    component: openebs-ndm-node-exporter
+    app: openebs-ndm-exporter
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-cluster-exporter.yaml
+++ b/deploy/yamls/ndm-cluster-exporter.yaml
@@ -51,8 +51,7 @@ metadata:
   name: ndm-cluster-exporter-service
   namespace: openebs
   labels:
-    name: openebs-ndm-exporter
-    component: openebs-ndm-cluster-exporter
+    app: openebs-ndm-exporter
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/ndm-node-exporter.yaml
+++ b/deploy/yamls/ndm-node-exporter.yaml
@@ -52,8 +52,7 @@ metadata:
   name: ndm-node-exporter-service
   namespace: openebs
   labels:
-    name: openebs-ndm-exporter
-    component: openebs-ndm-node-exporter
+    app: openebs-ndm-exporter
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
https://github.com/openebs/monitoring/issues/79

**What this PR does?**:
This PR removes:
1. Removes the `name` and `component` label from the ndm operator's exporter service yamls.
2. Add a new label(common for both the cluster as well as node exporters) in the ndm exporter services that will be used for monitoring. Label to added be added is- `app: openebs-ndm-exporter` in both the operator as well as helm deployment.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes https://github.com/openebs/monitoring/issues/79
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 