### PR TITLE
fix(client): fix client Get call done in BD update

### DIFF
--- a/changelogs/unreleased/648-akhilerm
+++ b/changelogs/unreleased/648-akhilerm
@@ -1,0 +1,1 @@
+update get call to use empty object instead of deepcopy object while updating the resources

--- a/cmd/ndm_daemonset/controller/blockdevicestore.go
+++ b/cmd/ndm_daemonset/controller/blockdevicestore.go
@@ -88,15 +88,15 @@ func (c *Controller) UpdateBlockDevice(blockDevice apis.BlockDevice, oldBlockDev
 
 	blockDeviceCopy := blockDevice.DeepCopy()
 	if oldBlockDevice == nil {
-		oldBlockDevice = blockDevice.DeepCopy()
+		oldBlockDevice = &apis.BlockDevice{}
 		err = c.Clientset.Get(context.TODO(), client.ObjectKey{
-			Namespace: oldBlockDevice.Namespace,
-			Name:      oldBlockDevice.Name}, oldBlockDevice)
+			Namespace: blockDeviceCopy.Namespace,
+			Name:      blockDeviceCopy.Name}, oldBlockDevice)
 		if err != nil {
 			klog.Errorf("eventcode=%s msg=%s : %v, err:%v rname=%v",
 				"ndm.blockdevice.update.failure",
 				"Failed to update block device : unable to get blockdevice object",
-				oldBlockDevice.ObjectMeta.Name, err, blockDeviceCopy.ObjectMeta.Name)
+				blockDeviceCopy.ObjectMeta.Name, err, blockDeviceCopy.ObjectMeta.Name)
 			return err
 		}
 	}
@@ -327,6 +327,9 @@ func mergeMetadata(newMetadata, oldMetadata metav1.ObjectMeta) metav1.ObjectMeta
 
 	// Patch older label with new label. If there is a new key then it will be added
 	// if it is an existing key then value will be overwritten with value from new label
+	if oldMetadata.Labels == nil {
+		oldMetadata.Labels = make(map[string]string)
+	}
 	for key, value := range newMetadata.Labels {
 		oldMetadata.Labels[key] = value
 	}

--- a/pkg/epoll/epoll.go
+++ b/pkg/epoll/epoll.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"os"
 	"syscall"
+
+	"k8s.io/klog"
 )
 
 const (
@@ -189,6 +191,7 @@ func (e *Epoll) dispatchEvent(ev *syscall.EpollEvent) {
 	if !ok {
 		return
 	}
+	klog.V(4).Infof("epoll event for file %s dispatched", w.FileName)
 
 	e.eventChan <- Event{
 		fileName: w.FileName,
@@ -200,7 +203,9 @@ func (e *Epoll) listen() {
 	events := make([]syscall.EpollEvent, 2)
 	for e.active {
 		// TODO: Handle errors here
+		klog.Info("waiting for epoll events...")
 		count, _ := syscall.EpollWait(e.epfd, events, timeout)
+		klog.Infof("received %d events from epoll. dispatching...", count)
 		for i := 0; e.active && i < count; i++ {
 			e.dispatchEvent(&events[i])
 		}

--- a/pkg/epoll/epoll.go
+++ b/pkg/epoll/epoll.go
@@ -203,9 +203,9 @@ func (e *Epoll) listen() {
 	events := make([]syscall.EpollEvent, 2)
 	for e.active {
 		// TODO: Handle errors here
-		klog.Info("waiting for epoll events...")
+		klog.V(4).Info("waiting for epoll events...")
 		count, _ := syscall.EpollWait(e.epfd, events, timeout)
-		klog.Infof("received %d events from epoll. dispatching...", count)
+		klog..V(4).Infof("received %d events from epoll. dispatching...", count)
 		for i := 0; e.active && i < count; i++ {
 			e.dispatchEvent(&events[i])
 		}

--- a/pkg/epoll/epoll.go
+++ b/pkg/epoll/epoll.go
@@ -205,7 +205,7 @@ func (e *Epoll) listen() {
 		// TODO: Handle errors here
 		klog.V(4).Info("waiting for epoll events...")
 		count, _ := syscall.EpollWait(e.epfd, events, timeout)
-		klog..V(4).Infof("received %d events from epoll. dispatching...", count)
+		klog.V(4).Infof("received %d events from epoll. dispatching...", count)
 		for i := 0; e.active && i < count; i++ {
 			e.dispatchEvent(&events[i])
 		}


### PR DESCRIPTION


Signed-off-by: Akhil Mohan <akhil.mohan@mayadata.io>

**What this PR does?**:
use empty object instead of deepcopy object in Get() call. This
is done so that empty fields returned from API server are not filled
in from the deepcopy object

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 