### PR TITLE
fix(blkid): add partition entry uuid to blkid probe

### DIFF
--- a/cmd/ndm_daemonset/probe/blkidprobe.go
+++ b/cmd/ndm_daemonset/probe/blkidprobe.go
@@ -69,6 +69,11 @@ func (bp *blkidProbe) FillBlockDeviceDetails(bd *blockdevice.BlockDevice) {
 	// Fortunately, the `libblkid` version in our base container (ubuntu 16.04)
 	// is `2.27.1`, will provide `PTUUID` tag, so we should fetch `PTUUID` from `blkid`.
 	if len(bd.PartitionInfo.PartitionTableUUID) == 0 {
-		bd.PartitionInfo.PartitionTableUUID = di.GetPartitionUUID()
+		bd.PartitionInfo.PartitionTableUUID = di.GetPartitionTableUUID()
+	}
+
+	// PARTUUID also is fetched using blkid, if udev is unable to get the data
+	if len(bd.PartitionInfo.PartitionEntryUUID) == 0 {
+		bd.PartitionInfo.PartitionEntryUUID = di.GetPartitionEntryUUID()
 	}
 }

--- a/pkg/blkid/blkid.go
+++ b/pkg/blkid/blkid.go
@@ -33,7 +33,8 @@ import (
 const (
 	fsTypeIdentifier        = "TYPE"
 	labelIdentifier         = "LABEL"
-	partitionUUIDIdentifier = "PTUUID"
+	partitionTableUUIDIdentifier = "PTUUID"
+	partitionEntryUUIDIdentifier = "PARTUUID"
 )
 
 type DeviceIdentifier struct {
@@ -52,10 +53,15 @@ func (di *DeviceIdentifier) GetOnDiskLabel() string {
 	return di.GetTagValue(labelIdentifier)
 }
 
-// GetPartitionUUID returns the partition UUID present on the disk by reading from the disk
+// GetPartitionTableUUID returns the partition table UUID present on the disk by reading from the disk
 // using libblkid
-func (di *DeviceIdentifier) GetPartitionUUID() string {
-	return di.GetTagValue(partitionUUIDIdentifier)
+func (di *DeviceIdentifier) GetPartitionTableUUID() string {
+	return di.GetTagValue(partitionTableUUIDIdentifier)
+}
+
+// GetPartitionEntryUUID returns the UUID of the partition, by reading from the disk using libblkid
+func (di *DeviceIdentifier) GetPartitionEntryUUID() string {
+	return di.GetTagValue(partitionEntryUUIDIdentifier)
 }
 
 func (di *DeviceIdentifier) GetTagValue(tag string) string {


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
udev is not able to fetch the partition entry uuid in CentOS 7, since PARTUUID is not supported in libblkid 2.23.

**What this PR does?**:
Uses the libblkid from the base container to fetch the partition entry UUID, if it was not filled in by udev

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3490
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 