### PR TITLE
fix(bd-labels): change jsonpath value addition condition to avoid index out of range

### DIFF
--- a/cmd/ndm_daemonset/controller/blockdevice.go
+++ b/cmd/ndm_daemonset/controller/blockdevice.go
@@ -127,7 +127,7 @@ func addBdLabels(bd *apis.BlockDevice, ctrl *Controller) error {
 			valueStrings := []string{}
 			var jsonPathFieldValue string
 
-			if len(values) > 0 || len(values[0]) > 0 {
+			if len(values) > 0 && len(values[0]) > 0 {
 				for arrIx := range values {
 					for valIx := range values[arrIx] {
 						valueStrings = append(valueStrings, fmt.Sprintf("%v", values[arrIx][valIx].Interface()))


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR fixes the issue which can occur due to `index out of range` when the values array received from jsonpath parsing will be empty.

**What this PR does?**:
This PR requires a small fix of just changing the binary operator from `||` to `&&` so that first it checks for empty array and then for empty first element in the array.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 
