### PR TITLE
fix(probe): initialize labels before probe start

### DIFF
--- a/cmd/ndm_daemonset/controller/probe.go
+++ b/cmd/ndm_daemonset/controller/probe.go
@@ -112,6 +112,7 @@ func (c *Controller) ListProbe(requestedProbes ...string) []*Probe {
 func (c *Controller) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice,
 	requestedProbes ...string) {
 	blockDevice.NodeAttributes = c.NodeAttributes
+	blockDevice.Labels = make(map[string]string)
 	selectedProbes := c.ListProbe(requestedProbes...)
 	for _, probe := range selectedProbes {
 		probe.FillBlockDeviceDetails(blockDevice)

--- a/cmd/ndm_daemonset/controller/probe_test.go
+++ b/cmd/ndm_daemonset/controller/probe_test.go
@@ -212,6 +212,7 @@ func TestFillDetails(t *testing.T) {
 
 	// create one fake Disk struct
 	expectedDr := &bd.BlockDevice{}
+	expectedDr.Labels = make(map[string]string)
 	expectedDr.DeviceAttributes.Model = fakeModel
 	expectedDr.DeviceAttributes.Serial = fakeSerial
 	expectedDr.DeviceAttributes.Vendor = fakeVendor

--- a/cmd/ndm_daemonset/probe/customtagprobe.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe.go
@@ -96,9 +96,6 @@ func (ctp *customTagProbe) FillBlockDeviceDetails(bd *blockdevice.BlockDevice) {
 		case tagTypePath:
 			fieldToMatch = bd.DevPath
 		}
-		if bd.Labels == nil {
-			bd.Labels = make(map[string]string)
-		}
 		if util.IsMatchRegex(tag.regex, fieldToMatch) {
 			bd.Labels[kubernetes.BlockDeviceTagLabel] = tag.label
 			klog.Infof("Device: %s Label %s:%s added by custom tag probe", bd.DevPath, kubernetes.BlockDeviceTagLabel, tag.label)

--- a/cmd/ndm_daemonset/probe/customtagprobe_test.go
+++ b/cmd/ndm_daemonset/probe/customtagprobe_test.go
@@ -37,6 +37,7 @@ func TestCustomTagProbeFillBlockDeviceDetails(t *testing.T) {
 				Identifier: blockdevice.Identifier{
 					DevPath: "/dev/sda",
 				},
+				Labels: make(map[string]string),
 			},
 			customTags:     nil,
 			wantTagLabel:   "",
@@ -47,6 +48,7 @@ func TestCustomTagProbeFillBlockDeviceDetails(t *testing.T) {
 				Identifier: blockdevice.Identifier{
 					DevPath: "/dev/sda",
 				},
+				Labels: make(map[string]string),
 			},
 			customTags: []tag{
 				{
@@ -63,6 +65,7 @@ func TestCustomTagProbeFillBlockDeviceDetails(t *testing.T) {
 				Identifier: blockdevice.Identifier{
 					DevPath: "/dev/sdb",
 				},
+				Labels: make(map[string]string),
 			},
 			customTags: []tag{
 				{
@@ -79,6 +82,7 @@ func TestCustomTagProbeFillBlockDeviceDetails(t *testing.T) {
 				Identifier: blockdevice.Identifier{
 					DevPath: "/dev/sdb",
 				},
+				Labels: make(map[string]string),
 			},
 			customTags: []tag{
 				{


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@datacore.com>

**Why is this PR required? What issue does it fix?**:
NDM crashes when trying to add zpool labels to the disk from used by probe due to uninitialized map.

**What this PR does?**:
Earlier the blockdevice labels map was initialized in the customtag probe
which causes undeclared map, if the labels are used before using customtag probe.
Now the label initialization happens before the probes are run.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 