### PR TITLE
fix(sysfs): trim newline while parsing sysfs files

### DIFF
--- a/changelogs/unreleased/666-akhilerm
+++ b/changelogs/unreleased/666-akhilerm
@@ -1,0 +1,1 @@
+fix sysfs parsing by trimming newline suffix when reading from sysfs files

--- a/pkg/sysfs/syspath.go
+++ b/pkg/sysfs/syspath.go
@@ -18,11 +18,12 @@ package sysfs
 
 import (
 	"fmt"
-	"github.com/openebs/node-disk-manager/blockdevice"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/openebs/node-disk-manager/blockdevice"
 )
 
 const (

--- a/pkg/sysfs/syspath_test.go
+++ b/pkg/sysfs/syspath_test.go
@@ -742,6 +742,20 @@ func TestSysFsDeviceGetDeviceType(t *testing.T) {
 			want:             "raid0",
 			wantErr:          false,
 		},
+		"device is a dm device with empty uuid": {
+			sysfsDevice: &Device{
+				deviceName: "dm-16",
+				path:       "/dev/dm-16",
+				sysPath: filepath.Join(tmpDir,
+					"sys/devices/virtual/block/dm-16") + "/",
+			},
+			devType:          blockdevice.BlockDeviceTypeDisk,
+			subDirectoryName: "dm",
+			subFileName:      "uuid",
+			subFileContent:   "\n",
+			want:             blockdevice.BlockDeviceTypeDMDevice,
+			wantErr:          false,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/sysfs/util.go
+++ b/pkg/sysfs/util.go
@@ -30,6 +30,7 @@ func readSysFSFileAsInt64(sysFilePath string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	// Remove tailing newline (usual in sysfs) before parsing
 	return strconv.ParseInt(strings.TrimSuffix(string(b), "\n"), 10, 64)
 }
 
@@ -38,7 +39,8 @@ func readSysFSFileAsString(sysFilePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(b), nil
+	// Remove tailing newline (usual in sysfs)
+	return strings.TrimSuffix(string(b), "\n"), nil
 }
 
 // addDevPrefix adds the /dev prefix to all the device names

--- a/pkg/sysfs/util_test.go
+++ b/pkg/sysfs/util_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package sysfs
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAddDevPrefix(t *testing.T) {
@@ -52,6 +53,13 @@ func TestReadSysFSFileAsString(t *testing.T) {
 			path:        "/tmp/dm-0/dm/",
 			fileName:    "uuid",
 			fileContent: "LVM-OSlVs5gIXuqSKVPukc2aGPh0AeJw31TJqYIRuRHoodYg9Jwkmyvvk0QNYK4YulHt",
+			want:        "LVM-OSlVs5gIXuqSKVPukc2aGPh0AeJw31TJqYIRuRHoodYg9Jwkmyvvk0QNYK4YulHt",
+			wantErr:     false,
+		},
+		"valid sysfs path with tailing new line": {
+			path:        "/tmp/dm-0/dm/",
+			fileName:    "uuid",
+			fileContent: "LVM-OSlVs5gIXuqSKVPukc2aGPh0AeJw31TJqYIRuRHoodYg9Jwkmyvvk0QNYK4YulHt\n",
 			want:        "LVM-OSlVs5gIXuqSKVPukc2aGPh0AeJw31TJqYIRuRHoodYg9Jwkmyvvk0QNYK4YulHt",
 			wantErr:     false,
 		},


### PR DESCRIPTION
Signed-off-by: Akhil Mohan <akhil.mohan@datacore.com>

**Why is this PR required? What issue does it fix?**:
sysfs files like `dm/uuid` etc are sometimes suffixed by a newline
character which need to be trimmed off for correct parsing, else
it will result in incorrect device type being detected

**What this PR does?**:
trim the newline suffix while reading from sysfs

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes openebs/openebs#3499
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [x] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 