### PR TITLE
feat(path-filter): Filter blockdevice using custom udev rules

### DIFF
--- a/cmd/ndm_daemonset/filter/pathfilter.go
+++ b/cmd/ndm_daemonset/filter/pathfilter.go
@@ -130,7 +130,7 @@ func (pf *pathFilter) Exclude(blockDevice *blockdevice.BlockDevice) bool {
 			return false
 		}
 	}
-	if util.MatchIgnoredCase(pf.excludePaths, blockDevice.DevPath){
+	if util.MatchIgnoredCase(pf.excludePaths, blockDevice.DevPath) {
 		return false
 	}
 	for _, link := range blockDevice.DevLinks {

--- a/cmd/ndm_daemonset/probe/udevprobe.go
+++ b/cmd/ndm_daemonset/probe/udevprobe.go
@@ -325,6 +325,13 @@ func (up *udevProbe) FillBlockDeviceDetails(blockDevice *blockdevice.BlockDevice
 		})
 	}
 
+	if len(udevDiskDetails.SymLinks) != 0 {
+		blockDevice.DevLinks = append(blockDevice.DevLinks, blockdevice.DevLink{
+			Kind:  libudevwrapper.SYMLINK,
+			Links: udevDiskDetails.SymLinks,
+		})
+	}
+
 	// filesystem info of the attached device. Only filesystem data will be filled in the struct,
 	// as the mountpoint related information will be filled in by the mount probe
 	blockDevice.FSInfo.FileSystem = udevDiskDetails.FileSystem

--- a/cmd/ndm_daemonset/probe/udevprobe_test.go
+++ b/cmd/ndm_daemonset/probe/udevprobe_test.go
@@ -125,6 +125,12 @@ func TestFillDiskDetails(t *testing.T) {
 			Links: mockOsDiskDetails.ByPathDevLinks,
 		})
 	}
+	if len(mockOsDiskDetails.SymLinks) > 0 {
+		expectedDiskInfo.DevLinks = append(expectedDiskInfo.DevLinks, blockdevice.DevLink{
+			Kind:  libudevwrapper.SYMLINK,
+			Links: mockOsDiskDetails.SymLinks,
+		})
+	}
 
 	// The devlinks are compared separately as the ordering of devlinks can be different in some systems
 	// eg: ubuntu 20.04 in github actions

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -632,7 +632,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
-        image: openebs/node-disk-manager:ci
+        image: openebs/node-disk-operator:ci
         ports:
         - containerPort: 8080
           name: liveness

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -525,7 +525,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-manager
-        image: openebs/node-disk-manager:ci
+        image: abhishek09dh/node-disk-manager:nd-labelV2
         args:
         - -v=4
         - --feature-gates="GPTBasedUUID"
@@ -632,7 +632,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
-        image: openebs/node-disk-operator:ci
+        image: abhishek09dh/node-disk-manager:nd-labelV2
         ports:
         - containerPort: 8080
           name: liveness

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -525,7 +525,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-manager
-        image: abhishek09dh/node-disk-manager:nd-labelV2
+        image: openebs/node-disk-manager:ci
         args:
         - -v=4
         - --feature-gates="GPTBasedUUID"
@@ -632,7 +632,7 @@ spec:
       serviceAccountName: openebs-maya-operator
       containers:
       - name: node-disk-operator
-        image: abhishek09dh/node-disk-manager:nd-labelV2
+        image: openebs/node-disk-manager:ci
         ports:
         - containerPort: 8080
           name: liveness

--- a/pkg/blkid/blkid.go
+++ b/pkg/blkid/blkid.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	fsTypeIdentifier        = "TYPE"
-	labelIdentifier         = "LABEL"
+	fsTypeIdentifier             = "TYPE"
+	labelIdentifier              = "LABEL"
 	partitionTableUUIDIdentifier = "PTUUID"
 	partitionEntryUUIDIdentifier = "PARTUUID"
 )

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -235,11 +235,9 @@ func (device *UdevDevice) GetDevLinks() map[string][]string {
 			} else {
 				byIdLink = append(byIdLink, link)
 			}
-		}
-		if util.Contains(parts, BY_PATH_LINK) {
+		} else if util.Contains(parts, BY_PATH_LINK) {
 			byPathLink = append(byPathLink, link)
-		}
-		if !util.Contains(parts, BY_UUID_LINK) && !util.Contains(parts, BY_PARTUUID_LINK) {
+		} else if !util.Contains(parts, BY_UUID_LINK) && !util.Contains(parts, BY_PARTUUID_LINK) {
 			symLink = append(symLink, link)
 		}
 	}

--- a/pkg/udev/common.go
+++ b/pkg/udev/common.go
@@ -237,9 +237,9 @@ func (device *UdevDevice) GetDevLinks() map[string][]string {
 			}
 		} else if util.Contains(parts, BY_PATH_LINK) {
 			byPathLink = append(byPathLink, link)
-		} else if !util.Contains(parts, BY_UUID_LINK) && !util.Contains(parts, BY_PARTUUID_LINK) {
-			symLink = append(symLink, link)
 		}
+		// we can add very dev link in symlink map as there is a 1:1 mapping between the two links
+		symLink = append(symLink, link)
 	}
 	devLinkMap[BY_ID_LINK] = byIdLink
 	devLinkMap[BY_PATH_LINK] = byPathLink

--- a/pkg/udev/common_test.go
+++ b/pkg/udev/common_test.go
@@ -85,6 +85,7 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 		Path:               diskDetails.DevNode,
 		ByIdDevLinks:       diskDetails.ByIdDevLinks,
 		ByPathDevLinks:     diskDetails.ByPathDevLinks,
+		SymLinks:           diskDetails.SymLinks,
 		PartitionTableType: diskDetails.PartTableType,
 		IDType:             diskDetails.IdType,
 	}
@@ -101,8 +102,10 @@ func TestDiskInfoFromLibudev(t *testing.T) {
 			// need to make this nil as devlinks already compared.
 			test.expectedDetails.ByIdDevLinks = nil
 			test.expectedDetails.ByPathDevLinks = nil
+			test.expectedDetails.SymLinks = nil
 			test.actualDetails.ByIdDevLinks = nil
 			test.actualDetails.ByPathDevLinks = nil
+			test.actualDetails.SymLinks = nil
 			assert.Equal(t, test.expectedDetails, test.actualDetails)
 		})
 	}

--- a/pkg/udev/mockdata.go
+++ b/pkg/udev/mockdata.go
@@ -55,6 +55,7 @@ type MockOsDiskDetails struct {
 	IdType         string
 	ByIdDevLinks   []string
 	ByPathDevLinks []string
+	SymLinks       []string
 	Dependents     bd.DependentBlockDevices
 }
 
@@ -108,6 +109,7 @@ func MockDiskDetails() (MockOsDiskDetails, error) {
 	devLinks := device.GetDevLinks()
 	diskDetails.ByIdDevLinks = devLinks[BY_ID_LINK]
 	diskDetails.ByPathDevLinks = devLinks[BY_PATH_LINK]
+	diskDetails.SymLinks = devLinks[SYMLINK]
 	return diskDetails, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR fixes the issue - https://github.com/openebs/openebs/issues/3491

**What this PR does?**:
This PR adds extra dev links(apart from `by-id` and by-path`) info which we get from the `udev` probe. This are useful to filter out bds when a disk is configured with some custom udev rules and uses those rules inside the path filter config of ndm.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
1. Added custom udev rules for a disk: `KERNEL=="sdb1",SYMLINK+="openebs_storage_02"`
2. Relead the udev db using the command: `udevadm control --reload`
3. The new symlink is available in the udev output now:
```console
P: /devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb1
N: sdb1
L: 0
S: disk/by-uuid/E48D-9C94
S: disk/by-path/pci-0000:00:14.0-usb-0:4:1.0-scsi-0:0:0:0-part1
S: disk/by-label/ABHISHEK
S: disk/by-id/usb-JetFlash_Transcend_8GB_OWXSZQ7L-0:0-part1
S: openebs_storage_02
S: disk/by-partuuid/02a28704-01
E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-4/1-4:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb1
E: DEVNAME=/dev/sdb1
E: DEVTYPE=partition
E: DEVLINKS=/dev/disk/by-uuid/E48D-9C94 /dev/disk/by-path/pci-0000:00:14.0-usb-0:4:1.0-scsi-0:0:0:0-part1 /dev/disk/by-label/ABHISHEK /dev/disk/by-id/usb-JetFlash_Transcend_8GB_OWXSZQ7L-0:0-part1 /dev/openebs_storage_02 /dev/disk/by-partuuid/02a28704-01
E: TAGS=:systemd:
```
4. Install ndm operator
5. Update the ndm config:
    a. Exclude the disk with symlink: `/dev/openebs_storage_02` using exclude path filter:
    ```console
    - key: path-filter
      name: path filter
      state: true
      include: ""
      exclude: "/dev/loop,/dev/openebs_storage_02,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/dm-,/dev/rbd,/dev/zd"
    ```
    `OUTPUT`: Listing bds with `kubectl get bd -n openebs` doesn't list the above disk.
    b. Include the disk with symlink: `/dev/openebs_storage_02` using include path filter:
    ```console
    - key: path-filter
      name: path filter
      state: true
      include: "/dev/openebs_storage_02"
      exclude: "/dev/loop,/dev/fd0,/dev/sr0,/dev/ram,/dev/md,/dev/dm-,/dev/rbd,/dev/zd"
    ```
    `OUTPUT`: Listing bds with `kubectl get bd -n openebs` does list the above disk.
6. The bds are listed is it should have been:
     ```console
     abhishek@abhishek-Mayadata:~$ kubectl get bd -n openebs
     NAME                                           NODENAME            SIZE         CLAIMSTATE   STATUS   AGE
     blockdevice-0db0a0b21ddbc52266b551d2d1c53791   abhishek-mayadata   7812939776   Unclaimed    Active   4s
     blockdevice-14065e0e32469367655092a3333cfe99   abhishek-mayadata   1024         Unclaimed    Active   102s
     blockdevice-2345c8576f192616c18b8f9f19f2497e   abhishek-mayadata   536870912    Unclaimed    Active   102s
     ```
   `blockdevice-0db0a0b21ddbc52266b551d2d1c53791   abhishek-mayadata   7812939776   Unclaimed    Active   4s` is the one having the custom udev rule

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes - https://github.com/openebs/openebs/issues/3491
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 