### PR TITLE
fix(ci): update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,7 @@ jobs:
             openebs/node-disk-operator:ci
 
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.7.1
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.26.1'
           kubernetes version: 'v1.25.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-daemonset/Dockerfile
@@ -237,7 +237,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-exporter/Dockerfile
@@ -327,7 +327,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-operator/Dockerfile
@@ -354,12 +354,12 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.5.1
 
       - name: Build Node Disk Manager
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-daemonset/Dockerfile
@@ -370,7 +370,7 @@ jobs:
             openebs/node-disk-manager:ci
 
       - name: Build Node Disk Operator
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-operator/Dockerfile

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -194,7 +194,7 @@ jobs:
             openebs/node-disk-operator:ci
 
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.7.1
+        uses: manusa/actions-setup-minikube@v2.7.2
         with:
           minikube version: 'v1.26.1'
           kubernetes version: 'v1.25.0'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,7 +88,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-daemonset/Dockerfile
@@ -116,7 +116,7 @@ jobs:
           version: v0.5.1
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-exporter/Dockerfile
@@ -144,7 +144,7 @@ jobs:
           version: v0.5.1
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-operator/Dockerfile
@@ -167,12 +167,12 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           version: v0.5.1
 
       - name: Build Node Disk Manager
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-daemonset/Dockerfile
@@ -183,7 +183,7 @@ jobs:
             openebs/node-disk-manager:ci
 
       - name: Build Node Disk Operator
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-operator/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-daemonset/Dockerfile
@@ -179,7 +179,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-exporter/Dockerfile
@@ -266,7 +266,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ./build/ndm-operator/Dockerfile


### PR DESCRIPTION
- Update all Github Actions minikube setup workflow steps with v2.7.2 of manusa/actions-setup-minikube. This fixes an issue where the version of crictl is incompatible with kubernetes >=v1.24.

- Update the version of docker/build-push-action to v4 and the version of docker/setup-buildx-action
to v2 to avoid using the deprecated save-state and the save-output GitHub Actions commands.

Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>